### PR TITLE
fix data race in gossipsub piggybacking

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -124,17 +124,20 @@ func rpcWithControl(msgs []*pb.Message,
 }
 
 func copyRPC(rpc *RPC) *RPC {
-	return &RPC{
+	res := &RPC{
 		RPC: pb.RPC{
 			Subscriptions: rpc.Subscriptions,
 			Publish:       rpc.Publish,
-			Control: &pb.ControlMessage{
-				Ihave: rpc.Control.Ihave,
-				Iwant: rpc.Control.Iwant,
-				Graft: rpc.Control.Graft,
-				Prune: rpc.Control.Prune,
-			},
 		},
 		from: rpc.from,
 	}
+	if rpc.Control != nil {
+		res.Control = &pb.ControlMessage{
+			Ihave: rpc.Control.Ihave,
+			Iwant: rpc.Control.Iwant,
+			Graft: rpc.Control.Graft,
+			Prune: rpc.Control.Prune,
+		}
+	}
+	return res
 }

--- a/comm.go
+++ b/comm.go
@@ -124,20 +124,11 @@ func rpcWithControl(msgs []*pb.Message,
 }
 
 func copyRPC(rpc *RPC) *RPC {
-	res := &RPC{
-		RPC: pb.RPC{
-			Subscriptions: rpc.Subscriptions,
-			Publish:       rpc.Publish,
-		},
-		from: rpc.from,
-	}
+	res := new(RPC)
+	*res = *rpc
 	if rpc.Control != nil {
-		res.Control = &pb.ControlMessage{
-			Ihave: rpc.Control.Ihave,
-			Iwant: rpc.Control.Iwant,
-			Graft: rpc.Control.Graft,
-			Prune: rpc.Control.Prune,
-		}
+		res.Control = new(pb.ControlMessage)
+		*res.Control = *rpc.Control
 	}
 	return res
 }

--- a/comm.go
+++ b/comm.go
@@ -122,3 +122,19 @@ func rpcWithControl(msgs []*pb.Message,
 		},
 	}
 }
+
+func copyRPC(rpc *RPC) *RPC {
+	return &RPC{
+		RPC: pb.RPC{
+			Subscriptions: rpc.Subscriptions,
+			Publish:       rpc.Publish,
+			Control: &pb.ControlMessage{
+				Ihave: rpc.Control.Ihave,
+				Iwant: rpc.Control.Iwant,
+				Graft: rpc.Control.Graft,
+				Prune: rpc.Control.Prune,
+			},
+		},
+		from: rpc.from,
+	}
+}

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -308,9 +308,14 @@ func (gs *GossipSubRouter) sendPrune(p peer.ID, topic string) {
 }
 
 func (gs *GossipSubRouter) sendRPC(p peer.ID, out *RPC) {
+	// do we own the RPC?
+	own := false
+
 	// piggyback cotrol message retries
 	ctl, ok := gs.control[p]
 	if ok {
+		out = copyRPC(out)
+		own = true
 		gs.piggybackControl(p, out, ctl)
 		delete(gs.control, p)
 	}
@@ -318,6 +323,10 @@ func (gs *GossipSubRouter) sendRPC(p peer.ID, out *RPC) {
 	// piggyback gossip
 	ihave, ok := gs.gossip[p]
 	if ok {
+		if !own {
+			out = copyRPC(out)
+			own = true
+		}
 		gs.piggybackGossip(p, out, ihave)
 		delete(gs.gossip, p)
 	}


### PR DESCRIPTION
Fixes data race in ownership of RPC when piggybacking control messages.
Closes #98 