### PR TITLE
fix public key extraction for abnormal ExtractPublicKey semantics

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -53,6 +53,9 @@ func messagePubKey(m *pb.Message) (crypto.PubKey, error) {
 		if err != nil {
 			return nil, fmt.Errorf("cannot extract signing key: %s", err.Error())
 		}
+		if pubk == nil {
+			return nil, fmt.Errorf("cannot extract signing key")
+		}
 	} else {
 		pubk, err = crypto.UnmarshalPublicKey(m.Key)
 		if err != nil {


### PR DESCRIPTION
ExtractPublicKey currently returns `nil, nil` when the peer id is not an identity-hash encoded key, which can cause a nil pointer dereference if someone sends a message with a signature but no public key (for RSA).

See also https://github.com/libp2p/go-libp2p-peer/issues/38