### PR TITLE
fix announce retry logic

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -434,14 +434,9 @@ func (p *PubSub) doAnnounceRetry(pid peer.ID, topic string, sub bool) {
 		return
 	}
 
-	// don't take pointers to the goroutine stack
-	topicP := new(string)
-	subP := new(bool)
-	*topicP = topic
-	*subP = sub
 	subopt := &pb.RPC_SubOpts{
-		Topicid:   topicP,
-		Subscribe: subP,
+		Topicid:   &topic,
+		Subscribe: &sub,
 	}
 
 	out := rpcWithSubs(subopt)

--- a/pubsub.go
+++ b/pubsub.go
@@ -407,24 +407,49 @@ func (p *PubSub) announce(topic string, sub bool) {
 		case peer <- out:
 		default:
 			log.Infof("Can't send announce message to peer %s: queue full; scheduling retry", pid)
-			go p.announceRetry(topic, sub)
+			go p.announceRetry(pid, topic, sub)
 		}
 	}
 }
 
-func (p *PubSub) announceRetry(topic string, sub bool) {
+func (p *PubSub) announceRetry(pid peer.ID, topic string, sub bool) {
 	time.Sleep(time.Duration(1+rand.Intn(1000)) * time.Millisecond)
 
 	retry := func() {
 		_, ok := p.myTopics[topic]
 		if (ok && sub) || (!ok && !sub) {
-			p.announce(topic, sub)
+			p.doAnnounceRetry(pid, topic, sub)
 		}
 	}
 
 	select {
 	case p.eval <- retry:
 	case <-p.ctx.Done():
+	}
+}
+
+func (p *PubSub) doAnnounceRetry(pid peer.ID, topic string, sub bool) {
+	peer, ok := p.peers[pid]
+	if !ok {
+		return
+	}
+
+	// don't take pointers to the goroutine stack
+	topicP := new(string)
+	subP := new(bool)
+	*topicP = topic
+	*subP = sub
+	subopt := &pb.RPC_SubOpts{
+		Topicid:   topicP,
+		Subscribe: subP,
+	}
+
+	out := rpcWithSubs(subopt)
+	select {
+	case peer <- out:
+	default:
+		log.Infof("Can't send announce message to peer %s: queue full; scheduling retry", pid)
+		go p.announceRetry(pid, topic, sub)
 	}
 }
 


### PR DESCRIPTION
The announce retry logic is faulty: if any peer fails, then it schedules a retry for all peers. Furthermore, the loop can spawn multiple retry goroutines per pass, which results in an avalanche of goroutines in heavy traffic.
See https://github.com/ipfs/go-ipfs/issues/5657