### PR TITLE
rework peer tracking logic to handle multiple connections

### DIFF
--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -874,9 +874,7 @@ func TestPeerDisconnect(t *testing.T) {
 	peers := psubs[0].ListPeers("foo")
 	assertPeerList(t, peers, hosts[1].ID())
 	for _, c := range hosts[1].Network().ConnsToPeer(hosts[0].ID()) {
-		for _, s := range c.GetStreams() {
-			s.Close()
-		}
+		c.Close()
 	}
 
 	time.Sleep(time.Millisecond * 10)

--- a/notify.go
+++ b/notify.go
@@ -25,12 +25,6 @@ func (p *PubSubNotif) Connected(n inet.Network, c inet.Conn) {
 }
 
 func (p *PubSubNotif) Disconnected(n inet.Network, c inet.Conn) {
-	go func() {
-		select {
-		case p.peerDead <- c.RemotePeer():
-		case <-p.ctx.Done():
-		}
-	}()
 }
 
 func (p *PubSubNotif) Listen(n inet.Network, _ ma.Multiaddr) {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,12 @@
       "hash": "QmNiJiXwWE3kRhZrC5ej3kSjWHm337pYfhjLGSCDNKJP2s",
       "name": "go-libp2p-crypto",
       "version": "2.0.4"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmabLh8TrJ3emfAoQk5AbqbLTbMyj7XqumMFmAFxa9epo8",
+      "name": "go-multistream",
+      "version": "0.3.9"
     }
   ],
   "gxVersion": "0.9.0",

--- a/pubsub.go
+++ b/pubsub.go
@@ -318,8 +318,7 @@ func (p *PubSub) processLoop(ctx context.Context) {
 
 			if p.host.Network().Connectedness(pid) == inet.Connected {
 				// still connected, must be a duplicate connection being closed.
-				// we respawn the writer as we need to ensure there is at leat one active
-				// at worst we can end with two writers pushing messages from the same channel.
+				// we respawn the writer as we need to ensure there is a stream active
 				log.Warning("peer declared dead but still connected; respawning writer: ", pid)
 				go p.handleNewPeer(ctx, pid, ch)
 				continue


### PR DESCRIPTION
Multiple connections are simply not handled at all by the current code; see https://github.com/libp2p/go-libp2p-pubsub/issues/130.

This is an attempt to rework the peer tracking logic so that multiple connections are handled gracefully.
