### PR TITLE
godoc documentation is not markdown

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -2,23 +2,25 @@
 // propagation, also known as overlay multicast.
 // The implementation provides topic-based pubsub, with pluggable routing algorithms.
 //
-// The main interface to the library is the `PubSub` object.
-// You can construct this object with the following constructors
-// - `NewFloodSub` creates an instance that uses the floodsub routing algorithm.
-// - `NewGossipSub` creates an instance that uses the gossipsub routing algorithm.
-// - `NewRandomSub` creates an instance that uses the randomsub routing algorithm.
+// The main interface to the library is the PubSub object.
+// You can construct this object with the following constructors:
+// <ul>
+// <li> NewFloodSub creates an instance that uses the floodsub routing algorithm.   </li>
+// <li> NewGossipSub creates an instance that uses the gossipsub routing algorithm. </li>
+// <li> NewRandomSub creates an instance that uses the randomsub routing algorithm. </li>
+// </ul>
 //
 // In addition, there is a generic constructor that creates a pubsub instance with
 // a custom PubSubRouter interface. This procedure is currently reserved for internal
 // use within the package.
 //
-// Once you have constructed a `PubSub` instance, you need to establish some connections
+// Once you have constructed a PubSub instance, you need to establish some connections
 // to your peers; the implementation relies on ambient peer discovery, leaving bootstrap
 // and active peer discovery up to the client.
 //
-// To publish a message to some topic, use `Publish`; you don't need to be subscribed
+// To publish a message to some topic, use Publish; you don't need to be subscribed
 // to the topic in order to publish.
 //
-// To subscribe to a topic, use `Subscribe`; this will give you a subscription interface
+// To subscribe to a topic, use Subscribe; this will give you a subscription interface
 // from which new messages can be pumped.
 package pubsub


### PR DESCRIPTION
This updates the doc.go stub to issue html instead of markdown; doh.