### PR TITLE
Update badges for consistency across libp2p repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # go-libp2p-pubsub
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-libp2p-blue.svg?style=flat-square)](http://github.com/libp2p/libp2p)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://github.com/libp2p/libp2p)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 
 > A pubsub system with flooding and gossiping variants.
 


### PR DESCRIPTION
This is one of many PRs to get our README badges all consistently
referring to libp2p in places where they currently refer to IPFS.

The changes are:

- any existing "Made by Protocol Labs" badges that link to `ipn.io` have been
changed to link to `protocol.ai`
- the project badge has been changed to libp2p, with the yellow color
- the IRC badge links to the `#libp2p` channel
- the "Made by PL", project, and IRC badges appear in that order
- the Standard Readme badge has been removed, if present
- badges for Travis CI have been removed if the current state is "unknown" and
this repo lacks a `.travis.yml` file
- badges for Coveralls have been removed if the state is "unknown"


Since this is a cookie-cutter message shared by many PRs to various repos,
some of the changes above may not apply to this specific PR.