### PR TITLE
Test adversarial signing

### DIFF
--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -15,7 +15,6 @@ import (
 	protocol "github.com/libp2p/go-libp2p-protocol"
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
 
-	//bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	bhost "github.com/libp2p/go-libp2p-blankhost"
 )
 

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -954,14 +954,14 @@ func TestImproperlySignedMessageNotRelayed(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 2)
-	adversarialPeer := hosts[0]
+	adversary := hosts[0]
 	honestPeer := hosts[1]
 
 	// The adversary enables signing, but disables verification to let through
 	// an incorrectly signed message.
 	adversaryPubSub := getPubsub(
 		ctx,
-		adversarialPeer,
+		adversary,
 		WithMessageSigning(true),
 		WithStrictSignatureVerification(false),
 	)
@@ -984,7 +984,7 @@ func TestImproperlySignedMessageNotRelayed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	adversarialPeerSubscription, err := adversaryPubSub.Subscribe(topic)
+	adversaryPeerSubscription, err := adversaryPubSub.Subscribe(topic)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1016,7 +1016,7 @@ func TestImproperlySignedMessageNotRelayed(t *testing.T) {
 			case <-ctx.Done():
 				return
 			default:
-				msg, err := adversarialPeerSubscription.Next(ctx)
+				msg, err := adversaryPeerSubscription.Next(ctx)
 				if err != nil {
 					return
 				}

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -970,7 +970,7 @@ func TestImproperlySignedMessageRejected(t *testing.T) {
 		WithStrictSignatureVerification(true),
 	)
 
-	connect(t, hosts[0], hosts[1])
+	connect(t, adversary, honestPeer)
 
 	var (
 		topic            = "foobar"

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -1025,7 +1025,7 @@ func TestImproperlySignedMessageNotRelayed(t *testing.T) {
 		}
 	}(adversaryContext)
 
-	<-time.After(2 * time.Second)
+	<-time.After(1 * time.Second)
 	adversaryCancel()
 
 	if len(adversaryMessages) != 2 {
@@ -1051,7 +1051,7 @@ func TestImproperlySignedMessageNotRelayed(t *testing.T) {
 		}
 	}(honestPeerContext)
 
-	<-time.After(2 * time.Second)
+	<-time.After(1 * time.Second)
 	honestPeerCancel()
 
 	if len(honestPeerMessages) != 1 {

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -948,7 +948,7 @@ func TestWithSigning(t *testing.T) {
 	}
 }
 
-func TestImproperlySignedMessageNotRelayed(t *testing.T) {
+func TestImproperlySignedMessageRejected(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -984,7 +984,7 @@ func TestImproperlySignedMessageNotRelayed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	adversaryPeerSubscription, err := adversaryPubSub.Subscribe(topic)
+	adversarySubscription, err := adversaryPubSub.Subscribe(topic)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1016,7 +1016,7 @@ func TestImproperlySignedMessageNotRelayed(t *testing.T) {
 			case <-ctx.Done():
 				return
 			default:
-				msg, err := adversaryPeerSubscription.Next(ctx)
+				msg, err := adversarySubscription.Next(ctx)
 				if err != nil {
 					return
 				}

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -994,7 +994,8 @@ func TestImproperlySignedMessageRejected(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Change the sign key for the adversarial peer, and send the second message.
+	// Change the sign key for the adversarial peer, and send the second,
+	// incorrectly signed, message.
 	adversaryPubSub.signID = honestPubSub.signID
 	adversaryPubSub.signKey = honestPubSub.host.Peerstore().PrivKey(honestPubSub.signID)
 	err = adversaryPubSub.Publish(topic, incorrectMessage)

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -978,11 +978,6 @@ func TestImproperlySignedMessageRejected(t *testing.T) {
 		incorrectMessage = []byte("this is the incorrect message")
 	)
 
-	_, err := adversaryPubSub.Subscribe(topic)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	adversarySubscription, err := adversaryPubSub.Subscribe(topic)
 	if err != nil {
 		t.Fatal(err)

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -10,12 +10,11 @@ import (
 	"testing"
 	"time"
 
+	bhost "github.com/libp2p/go-libp2p-blankhost"
 	host "github.com/libp2p/go-libp2p-host"
 	peer "github.com/libp2p/go-libp2p-peer"
 	protocol "github.com/libp2p/go-libp2p-protocol"
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
-
-	bhost "github.com/libp2p/go-libp2p-blankhost"
 )
 
 func checkMessageRouting(t *testing.T, topic string, pubs []*PubSub, subs []*Subscription) {

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -1022,6 +1022,9 @@ func TestImproperlySignedMessageRejected(t *testing.T) {
 	<-time.After(1 * time.Second)
 	adversaryCancel()
 
+	// Ensure the adversary successfully publishes the incorrectly signed
+	// message. If the adversary "sees" this, we successfully got through
+	// their local validation.
 	if len(adversaryMessages) != 2 {
 		t.Fatalf("got %d messages, expected 2", len(adversaryMessages))
 	}

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -986,7 +986,7 @@ func TestImproperlySignedMessageRejected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(time.Millisecond * 50)
 
 	// First the adversary sends the correct message.
 	err = adversaryPubSub.Publish(topic, correctMessage)

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -1057,4 +1057,11 @@ func TestImproperlySignedMessageNotRelayed(t *testing.T) {
 	if len(honestPeerMessages) != 1 {
 		t.Fatalf("got %d messages, expected 1", len(honestPeerMessages))
 	}
+	if string(honestPeerMessages[0].GetData()) != string(correctMessage) {
+		t.Fatalf(
+			"got %s, expected message %s",
+			honestPeerMessages[0].GetData(),
+			correctMessage,
+		)
+	}
 }


### PR DESCRIPTION
This PR introduces a test where an adversarial peer can sign a message with a key they
didn't originally register with.

First, an adversarial peer will allow the improperly signed message to pass through
validation (as they turn off strict verification, putting themselves at risk!).

Next, it's tested that an honest peer, with strict verification on, will never see the
malicious message, but they will see the correctly signed message.

We (@keep-network) just stripped out our custom message signing in favor of 
`go-libp2p-pubsub`'s strict message signing and verification. This test seemed 
useful to contribute to mainline. 