### PR TITLE
Fix gossipsub race condition for heartbeat

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -231,7 +231,7 @@ func (gs *GossipSubRouter) Publish(from peer.ID, msg *pb.Message) {
 		if !ok {
 			// we are not in the mesh for topic, use fanout peers
 			gmap, ok = gs.fanout[topic]
-			if !ok {
+			if !ok || len(gmap) == 0 {
 				// we don't have any, pick some
 				peers := gs.getPeers(topic, GossipSubD, func(peer.ID) bool { return true })
 


### PR DESCRIPTION
In using gossipsub on a system with a number of ephemeral peers, we noticed messages would occasionally fail to route to their intended targets even though a subscribe had been received.

In a basic example, given there are 2 peers connected, PeerA & PeerB. For TopicA, PeerA is not in the mesh, but has seen and gossiped it before to PeerC, which is now disconnected and no longer subscribed. 

When a Subscribe request for TopicA is issued from PeerB, then PeerA adds that peer onto the PubSub.topics map:
https://github.com/libp2p/go-libp2p-pubsub/blob/49274b0e8aecdf6cad59d768e5702ff00aa48488/pubsub.go#L566-L573

However, its not that map that is used for publishing messages back out from PeerA when its not in the mesh:
https://github.com/libp2p/go-libp2p-pubsub/blob/49274b0e8aecdf6cad59d768e5702ff00aa48488/gossipsub.go#L233-L242

Line `#233` there uses `GossipSubRouter.fanout` as its map, which is updated during the heartbeat process: 
https://github.com/libp2p/go-libp2p-pubsub/blob/49274b0e8aecdf6cad59d768e5702ff00aa48488/gossipsub.go#L441-L448

In between the 1 second of a heartbeat, these two maps can be out of date with each other, which is to be expected. However, on https://github.com/libp2p/go-libp2p-pubsub/blob/49274b0e8aecdf6cad59d768e5702ff00aa48488/gossipsub.go#L234 the `!ok` only works as a fallback for the initial iteration, if the map is empty because all other Peers have been unsubscribed (PeerC) then it doesn't fallback to `getPeers`.

This PR is to change that conditional to check for empty map cases so that the fallback still happens. The other option is to make the key for the topic be set back to nil instead of an empty map inside the heartbeat process.