### PR TITLE
Add the ability to handle newly subscribed peers

### DIFF
--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -1111,12 +1111,14 @@ func TestSubscriptionJoinNotification(t *testing.T) {
 		wg.Add(1)
 		go func(peersFound map[peer.ID]struct{}) {
 			defer wg.Done()
-			for i := 0; i < numHosts-1; i++ {
-				pid, err := sub.NextPeerJoin(ctx)
+			for len(peersFound) < numHosts-1 {
+				event, err := sub.NextPeerEvent(ctx)
 				if err != nil {
 					t.Fatal(err)
 				}
-				peersFound[pid] = struct{}{}
+				if event.Type == PEER_JOIN {
+					peersFound[event.Peer] = struct{}{}
+				}
 			}
 		}(peersFound)
 	}
@@ -1163,12 +1165,14 @@ func TestSubscriptionLeaveNotification(t *testing.T) {
 		wg.Add(1)
 		go func(peersFound map[peer.ID]struct{}) {
 			defer wg.Done()
-			for i := 0; i < numHosts-1; i++ {
-				pid, err := sub.NextPeerJoin(ctx)
+			for len(peersFound) < numHosts-1 {
+				event, err := sub.NextPeerEvent(ctx)
 				if err != nil {
 					t.Fatal(err)
 				}
-				peersFound[pid] = struct{}{}
+				if event.Type == PEER_JOIN {
+					peersFound[event.Peer] = struct{}{}
+				}
 			}
 		}(peersFound)
 	}
@@ -1186,12 +1190,14 @@ func TestSubscriptionLeaveNotification(t *testing.T) {
 	psubs[0].BlacklistPeer(hosts[3].ID())
 
 	leavingPeers := make(map[peer.ID]struct{})
-	for i := 0; i < 3; i++ {
-		pid, err := msgs[0].NextPeerLeave(ctx)
+	for len(leavingPeers) < 3 {
+		event, err := msgs[0].NextPeerEvent(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		leavingPeers[pid] = struct{}{}
+		if event.Type == PEER_LEAVE {
+			leavingPeers[event.Peer] = struct{}{}
+		}
 	}
 
 	if _, ok := leavingPeers[hosts[1].ID()]; !ok {

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -1063,3 +1063,45 @@ func TestImproperlySignedMessageRejected(t *testing.T) {
 		)
 	}
 }
+
+func TestSubscriptionNotification(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const numHosts = 20
+	hosts := getNetHosts(t, ctx, numHosts)
+
+	psubs := getPubsubs(ctx, hosts)
+
+	msgs := make([]*Subscription, numHosts)
+	subPeersFound := make([]map[peer.ID]struct{}, numHosts)
+	for i, ps := range psubs {
+		subch, err := ps.Subscribe("foobar")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		msgs[i] = subch
+		peersFound := make(map[peer.ID]struct{})
+		subPeersFound[i] = peersFound
+		go func(peersFound map[peer.ID]struct{}) {
+			for i := 0; i < numHosts-1; i++ {
+				pid, err := subch.NextSubscribedPeer(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				peersFound[pid] = struct{}{}
+			}
+		}(peersFound)
+	}
+
+	connectAll(t, hosts)
+
+	time.Sleep(time.Millisecond * 100)
+
+	for _, peersFound := range subPeersFound {
+		if len(peersFound) != numHosts-1 {
+			t.Fatal("incorrect number of peers found")
+		}
+	}
+}

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -1116,7 +1116,7 @@ func TestSubscriptionJoinNotification(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if event.Type == PEER_JOIN {
+				if event.Type == PeerJoin {
 					peersFound[event.Peer] = struct{}{}
 				}
 			}
@@ -1170,7 +1170,7 @@ func TestSubscriptionLeaveNotification(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if event.Type == PEER_JOIN {
+				if event.Type == PeerJoin {
 					peersFound[event.Peer] = struct{}{}
 				}
 			}
@@ -1195,7 +1195,7 @@ func TestSubscriptionLeaveNotification(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if event.Type == PEER_LEAVE {
+		if event.Type == PeerLeave {
 			leavingPeers[event.Peer] = struct{}{}
 		}
 	}
@@ -1252,7 +1252,7 @@ func TestSubscriptionNotificationOverflowSimple(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if event.Type == PEER_JOIN {
+				if event.Type == PeerJoin {
 					peersFound[event.Peer] = struct{}{}
 				}
 			}
@@ -1286,8 +1286,8 @@ func TestSubscriptionNotificationOverflowSimple(t *testing.T) {
 	}
 
 	for _, e := range peerState {
-		if e != PEER_JOIN {
-			t.Fatal("non JOIN event occurred")
+		if e != PeerJoin {
+			t.Fatal("non Join event occurred")
 		}
 	}
 
@@ -1308,8 +1308,8 @@ func TestSubscriptionNotificationOverflowSimple(t *testing.T) {
 	}
 
 	for _, e := range peerState {
-		if e != PEER_LEAVE {
-			t.Fatal("non LEAVE event occurred")
+		if e != PeerLeave {
+			t.Fatal("non Leave event occurred")
 		}
 	}
 }

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -1211,7 +1211,7 @@ func TestSubscriptionLeaveNotification(t *testing.T) {
 	}
 }
 
-func TestSubscriptionNotificationOverflowSimple(t *testing.T) {
+func TestSubscriptionManyNotifications(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1315,25 +1315,6 @@ func TestSubscriptionNotificationOverflowSimple(t *testing.T) {
 }
 
 func TestSubscriptionNotificationSubUnSub(t *testing.T) {
-	// Resubscribe and Unsubscribe a peers and check the state for consistency
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	const topic = "foobar"
-
-	const numHosts = 35
-	hosts := getNetHosts(t, ctx, numHosts)
-	psubs := getPubsubs(ctx, hosts)
-
-	for i := 1; i < numHosts; i++ {
-		connect(t, hosts[0], hosts[i])
-	}
-	time.Sleep(time.Millisecond * 100)
-
-	notifSubThenUnSub(ctx, t, topic, psubs[:11])
-}
-
-func TestSubscriptionNotificationOverflowSubUnSub(t *testing.T) {
 	// Resubscribe and Unsubscribe a peers and check the state for consistency
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pubsub.go
+++ b/pubsub.go
@@ -456,7 +456,7 @@ func (p *PubSub) handleAddSubscription(req *addSubReq) {
 	tmap := p.topics[sub.topic]
 
 	for p := range tmap {
-		sub.evtBacklog[p] = PEER_JOIN
+		sub.evtBacklog[p] = PeerJoin
 	}
 	sub.cancelCh = p.cancelCh
 
@@ -573,7 +573,7 @@ func (p *PubSub) subscribedToMsg(msg *pb.Message) bool {
 func (p *PubSub) notifyLeave(topic string, pid peer.ID) {
 	if subs, ok := p.myTopics[topic]; ok {
 		for s := range subs {
-			s.sendNotification(PeerEvent{PEER_LEAVE, pid})
+			s.sendNotification(PeerEvent{PeerLeave, pid})
 		}
 	}
 }
@@ -593,7 +593,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 				if subs, ok := p.myTopics[t]; ok {
 					peer := rpc.from
 					for s := range subs {
-						s.sendNotification(PeerEvent{PEER_JOIN, peer})
+						s.sendNotification(PeerEvent{PeerJoin, peer})
 					}
 				}
 			}

--- a/pubsub.go
+++ b/pubsub.go
@@ -456,7 +456,7 @@ func (p *PubSub) handleAddSubscription(req *addSubReq) {
 	tmap := p.topics[sub.topic]
 
 	for p := range tmap {
-		sub.evtBacklog[p] = PeerJoin
+		sub.evtLog[p] = PeerJoin
 	}
 	sub.cancelCh = p.cancelCh
 
@@ -697,10 +697,10 @@ func (p *PubSub) SubscribeByTopicDescriptor(td *pb.TopicDescriptor, opts ...SubO
 	sub := &Subscription{
 		topic: td.GetName(),
 
-		ch:         make(chan *Message, 32),
-		peerEvtCh:  make(chan PeerEvent, 1),
-		evtBacklog: make(map[peer.ID]EventType),
-		backlogCh:  make(chan struct{}, 1),
+		ch:        make(chan *Message, 32),
+		peerEvtCh: make(chan PeerEvent, 1),
+		evtLog:    make(map[peer.ID]EventType),
+		evtLogCh:  make(chan struct{}, 1),
 	}
 
 	for _, opt := range opts {

--- a/pubsub.go
+++ b/pubsub.go
@@ -698,9 +698,9 @@ func (p *PubSub) SubscribeByTopicDescriptor(td *pb.TopicDescriptor, opts ...SubO
 		topic: td.GetName(),
 
 		ch:         make(chan *Message, 32),
-		peerEvtCh:  make(chan PeerEvent, 32),
+		peerEvtCh:  make(chan PeerEvent, 1),
 		evtBacklog: make(map[peer.ID]EventType),
-		backlogCh:  make(chan PeerEvent, 1),
+		backlogCh:  make(chan struct{}, 1),
 	}
 
 	for _, opt := range opts {

--- a/subscription.go
+++ b/subscription.go
@@ -49,7 +49,7 @@ func (sub *Subscription) Cancel() {
 	sub.cancelCh <- sub
 }
 
-func (sub *Subscription) close(){
+func (sub *Subscription) close() {
 	close(sub.ch)
 	close(sub.joinCh)
 	close(sub.leaveCh)

--- a/subscription.go
+++ b/subscription.go
@@ -5,7 +5,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-type EventType uint8
+type EventType int8
 
 const (
 	UNKNOWN EventType = iota
@@ -47,6 +47,12 @@ func (sub *Subscription) Next(ctx context.Context) (*Message, error) {
 
 func (sub *Subscription) Cancel() {
 	sub.cancelCh <- sub
+}
+
+func (sub *Subscription) close(){
+	close(sub.ch)
+	close(sub.joinCh)
+	close(sub.leaveCh)
 }
 
 // NextPeerEvent returns the next event regarding subscribed peers

--- a/subscription.go
+++ b/subscription.go
@@ -9,8 +9,8 @@ import (
 type EventType int
 
 const (
-	PEER_JOIN EventType = iota
-	PEER_LEAVE
+	PeerJoin EventType = iota
+	PeerLeave
 )
 
 type Subscription struct {

--- a/subscription.go
+++ b/subscription.go
@@ -60,9 +60,11 @@ func (sub *Subscription) sendNotification(evt PeerEvent) {
 	sub.eventMx.Lock()
 	defer sub.eventMx.Unlock()
 
-	e, ok := sub.evtBacklog[evt.Peer]
-	if ok && e != evt.Type {
-		delete(sub.evtBacklog, evt.Peer)
+	if e, ok := sub.evtBacklog[evt.Peer]; ok {
+		if e != evt.Type {
+			delete(sub.evtBacklog, evt.Peer)
+		}
+		return
 	}
 
 	select {

--- a/subscription.go
+++ b/subscription.go
@@ -5,11 +5,10 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-type EventType int8
+type EventType int
 
 const (
-	UNKNOWN EventType = iota
-	PEER_JOIN
+	PEER_JOIN EventType = iota
 	PEER_LEAVE
 )
 


### PR DESCRIPTION
Per conversations with @vyzo @raulk and @Stebalien we are refactoring the content of #171 which does 2 things.

1. Gives developers control over what messages are broadcast
2. Gives developers an "OnJoin" method that can specify an action to do when first connecting to a peer (e.g. send a specific message, utilize an external protocol, etc.)

Instead of doing this by making routers extensible, we will be leaving router extensibility for a later date and solve the issues above by:

1. Using stateful validators + application layer publishing to effectively control which messages are broadcast. This can happen outside of the `go-libp2p-pubsub` package. 
2. Adding a mechanism for PubSub to expose when it connects to a new peer

This PR deals with the latter.