### PR TITLE
minor bug fix: on join, source peers from gossip[topic] if insufficient peers in fanout[topic]

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -268,6 +268,17 @@ func (gs *GossipSubRouter) Join(topic string) {
 
 	gmap, ok = gs.fanout[topic]
 	if ok {
+		if len(gmap) < GossipSubD {
+			// we need more peers; eager, as this would get fixed in the next heartbeat
+			more := gs.getPeers(topic, GossipSubD-len(gmap), func(p peer.ID) bool {
+				// filter our current peers
+				_, ok := gmap[p]
+				return !ok
+			})
+			for _, p := range more {
+				gmap[p] = struct{}{}
+			}
+		}
 		gs.mesh[topic] = gmap
 		delete(gs.fanout, topic)
 		delete(gs.lastpub, topic)


### PR DESCRIPTION
Closes #194 

This is a very minor bug, as the mesh would get filled in the next heartbeat.