### PR TITLE
add PubSub's context to Subscription

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -696,6 +696,7 @@ func (p *PubSub) SubscribeByTopicDescriptor(td *pb.TopicDescriptor, opts ...SubO
 
 	sub := &Subscription{
 		topic: td.GetName(),
+		ctx:   p.ctx,
 
 		ch:        make(chan *Message, 32),
 		peerEvtCh: make(chan PeerEvent, 1),

--- a/subscription.go
+++ b/subscription.go
@@ -18,6 +18,7 @@ type Subscription struct {
 	ch       chan *Message
 	cancelCh chan<- *Subscription
 	err      error
+	ctx      context.Context
 
 	peerEvtCh chan PeerEvent
 	evtLogMx  sync.Mutex
@@ -49,7 +50,10 @@ func (sub *Subscription) Next(ctx context.Context) (*Message, error) {
 }
 
 func (sub *Subscription) Cancel() {
-	sub.cancelCh <- sub
+	select {
+	case sub.cancelCh <- sub:
+	case <-sub.ctx.Done():
+	}
 }
 
 func (sub *Subscription) close() {


### PR DESCRIPTION
Fix for #200

This patch fixes the issue, but what about functions which get outer context as an argument, e.g. `Next(ctx context.Context)`. Should these functions check only outer context for cancellation or inner too?