### PR TITLE
gossip methods: renames and predicate adjustment

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -527,13 +527,15 @@ func (gs *GossipSubRouter) emitGossip(topic string, exclude map[peer.ID]struct{}
 		return
 	}
 
-	gpeers := gs.getPeers(topic, GossipSubD, func(peer.ID) bool { return true })
-	for _, p := range gpeers {
-		// skip mesh peers
+	// Send gossip to D peers, skipping over the exclude set.
+	gpeers := gs.getPeers(topic, GossipSubD, func(p peer.ID) bool {
 		_, ok := exclude[p]
-		if !ok {
-			gs.pushGossip(p, &pb.ControlIHave{TopicID: &topic, MessageIDs: mids})
-		}
+		return !ok
+	})
+
+	// Emit the IHAVE gossip to the selected peers.
+	for _, p := range gpeers {
+		gs.pushGossip(p, &pb.ControlIHave{TopicID: &topic, MessageIDs: mids})
 	}
 }
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -436,6 +436,8 @@ func (gs *GossipSubRouter) heartbeat() {
 			}
 		}
 
+		// 2nd arg are mesh peers excluded from gossip. We already push
+		// messages to them, so its redundant to gossip IHAVEs.
 		gs.emitGossip(topic, peers)
 	}
 
@@ -472,6 +474,8 @@ func (gs *GossipSubRouter) heartbeat() {
 			}
 		}
 
+		// 2nd arg are fanout peers excluded from gossip. We already push
+		// messages to them, so its redundant to gossip IHAVEs.
 		gs.emitGossip(topic, peers)
 	}
 
@@ -515,7 +519,9 @@ func (gs *GossipSubRouter) sendGraftPrune(tograft, toprune map[peer.ID][]string)
 
 }
 
-func (gs *GossipSubRouter) emitGossip(topic string, peers map[peer.ID]struct{}) {
+// emitGossip emits IHAVE gossip advertising items in the message cache window
+// of this topic.
+func (gs *GossipSubRouter) emitGossip(topic string, exclude map[peer.ID]struct{}) {
 	mids := gs.mcache.GetGossipIDs(topic)
 	if len(mids) == 0 {
 		return
@@ -524,7 +530,7 @@ func (gs *GossipSubRouter) emitGossip(topic string, peers map[peer.ID]struct{}) 
 	gpeers := gs.getPeers(topic, GossipSubD, func(peer.ID) bool { return true })
 	for _, p := range gpeers {
 		// skip mesh peers
-		_, ok := peers[p]
+		_, ok := exclude[p]
 		if !ok {
 			gs.pushGossip(p, &pb.ControlIHave{TopicID: &topic, MessageIDs: mids})
 		}

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -535,7 +535,7 @@ func (gs *GossipSubRouter) emitGossip(topic string, exclude map[peer.ID]struct{}
 
 	// Emit the IHAVE gossip to the selected peers.
 	for _, p := range gpeers {
-		gs.queueGossip(p, &pb.ControlIHave{TopicID: &topic, MessageIDs: mids})
+		gs.enqueueGossip(p, &pb.ControlIHave{TopicID: &topic, MessageIDs: mids})
 	}
 }
 
@@ -555,7 +555,7 @@ func (gs *GossipSubRouter) flush() {
 	}
 }
 
-func (gs *GossipSubRouter) queueGossip(p peer.ID, ihave *pb.ControlIHave) {
+func (gs *GossipSubRouter) enqueueGossip(p peer.ID, ihave *pb.ControlIHave) {
 	gossip := gs.gossip[p]
 	gossip = append(gossip, ihave)
 	gs.gossip[p] = gossip

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -535,7 +535,7 @@ func (gs *GossipSubRouter) emitGossip(topic string, exclude map[peer.ID]struct{}
 
 	// Emit the IHAVE gossip to the selected peers.
 	for _, p := range gpeers {
-		gs.pushGossip(p, &pb.ControlIHave{TopicID: &topic, MessageIDs: mids})
+		gs.queueGossip(p, &pb.ControlIHave{TopicID: &topic, MessageIDs: mids})
 	}
 }
 
@@ -555,7 +555,7 @@ func (gs *GossipSubRouter) flush() {
 	}
 }
 
-func (gs *GossipSubRouter) pushGossip(p peer.ID, ihave *pb.ControlIHave) {
+func (gs *GossipSubRouter) queueGossip(p peer.ID, ihave *pb.ControlIHave) {
 	gossip := gs.gossip[p]
 	gossip = append(gossip, ihave)
 	gs.gossip[p] = gossip


### PR DESCRIPTION
This PR proposes minor renames for accuracy.

It also uses the predicate on `ps.getPeers` to exclude the exclusion set, to sure we source as many as `D` peers to push gossip to. With the current logic, we might select peers that later end up being excluded, resulting in us gossiping to less than `D` peers.