### PR TITLE
add sender id to message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/multiformats/go-multistream v0.1.0
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee
 )
+
+go 1.13


### PR DESCRIPTION
Unless I'm mistaken, there's no way to get the sender ID from a message.

`msg.GetFrom()` returns the originator's id, not the most recent sender. There could be use cases where knowing who sent this message is valuable. For instance, I'm building a small benchmark tool and I need to calculate last delivery hop. I do so by logging recipient host id and sender id. My analyzer then parses the logs and calculates each message path.

I don't know if my simple implementation accomplishes this goal correctly or if there is a better way but would love to hear your thoughts.

Thanks!