### PR TITLE
Allow peer to be in Relay ONLY mode for a topic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/libp2p/go-libp2p-swarm v0.1.0
 	github.com/multiformats/go-multiaddr v0.0.4
 	github.com/multiformats/go-multistream v0.1.0
+	github.com/pkg/errors v0.8.1
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee
 )

--- a/relay.go
+++ b/relay.go
@@ -1,0 +1,20 @@
+package pubsub
+
+import "context"
+
+type Relay struct {
+	topic    string
+	cancelCh chan<- *Relay
+	ctx      context.Context
+}
+
+func (r *Relay) Topic() string {
+	return r.topic
+}
+
+func (r *Relay) Cancel() {
+	select {
+	case r.cancelCh <- r:
+	case <-r.ctx.Done():
+	}
+}

--- a/subscription.go
+++ b/subscription.go
@@ -14,6 +14,8 @@ const (
 )
 
 type Subscription struct {
+	relay *Relay
+
 	topic    string
 	ch       chan *Message
 	cancelCh chan<- *Subscription


### PR DESCRIPTION
For #28 

@aschmahmann  As discussed, this PR will allow a peer to 'Relay' for a topic without having to 'subscribe'/'consume' messages for that topic. However, a 'Subscriber' will always be a 
'Relayer'.

Please let me know if the tests make sense/we need more tests.