### PR TITLE
Topic handler bug fixes

### DIFF
--- a/discovery_test.go
+++ b/discovery_test.go
@@ -108,6 +108,21 @@ func (d *mockDiscoveryClient) FindPeers(ctx context.Context, ns string, opts ...
 	return d.server.FindPeers(ns, options.Limit)
 }
 
+type dummyDiscovery struct{}
+
+func (d *dummyDiscovery) Advertise(ctx context.Context, ns string, opts ...discovery.Option) (time.Duration, error) {
+	return time.Hour, nil
+}
+
+func (d *dummyDiscovery) FindPeers(ctx context.Context, ns string, opts ...discovery.Option) (<-chan peer.AddrInfo, error) {
+	retCh := make(chan peer.AddrInfo)
+	go func() {
+		time.Sleep(time.Second)
+		close(retCh)
+	}()
+	return retCh, nil
+}
+
 func TestSimpleDiscovery(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/topic.go
+++ b/topic.go
@@ -23,6 +23,7 @@ type Topic struct {
 // Multiple event handlers may be created and will operate independently of each other
 func (t *Topic) EventHandler(opts ...TopicEventHandlerOpt) (*TopicEventHandler, error) {
 	h := &TopicEventHandler{
+		topic: t,
 		err: nil,
 
 		evtLog:   make(map[peer.ID]EventType),


### PR DESCRIPTION
Fixes the issues named in #224 namely:

Calling Topic.Close() throws an NRE 😨
Calling Topic.Close() still allows some calls to be utilized (e.g. can still Publish after Close)