### PR TITLE
Peers should be able to ONLY Relay for a topic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/libp2p/go-libp2p-swarm v0.2.2
 	github.com/multiformats/go-multiaddr v0.1.1
 	github.com/multiformats/go-multistream v0.1.0
+	github.com/stretchr/testify v1.3.0
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee
 )
 

--- a/pubsub.go
+++ b/pubsub.go
@@ -602,6 +602,9 @@ func (p *PubSub) notifySubs(msg *Message) {
 	for _, topic := range msg.GetTopicIDs() {
 		subs := p.mySubs[topic]
 		for f := range subs {
+			if f.relayOnly {
+				continue
+			}
 			select {
 			case f.ch <- msg:
 			default:

--- a/relay.go
+++ b/relay.go
@@ -1,0 +1,25 @@
+package pubsub
+
+// Relay handles the details of a particular Topic relay.
+// Only one Relay will exist per topic.
+type Relay struct {
+	sub *Subscription
+}
+
+// Topic returns the topic handle associated with the relay
+func (r *Relay) Topic() *Topic {
+	return r.sub.topicHandle
+}
+
+// Cancel closes the Relay & removes it from the topic handle it is relaying for
+// If this is the last active subscription, then pubsub will send an unsubscribe
+// announcement to the network.
+func (r *Relay) Cancel() {
+	select {
+	case r.sub.cancelCh <- r.sub:
+	case <-r.sub.ctx.Done():
+	}
+	r.sub.topicHandle.removeRelay(r)
+}
+
+type RelayOpt func(r *Relay) error

--- a/subscription.go
+++ b/subscription.go
@@ -7,11 +7,14 @@ import (
 // Subscription handles the details of a particular Topic subscription.
 // There may be many subscriptions for a given Topic.
 type Subscription struct {
-	topic    string
-	ch       chan *Message
-	cancelCh chan<- *Subscription
-	ctx      context.Context
-	err      error
+	topicHandle *Topic
+	topic       string
+	ch          chan *Message
+	cancelCh    chan<- *Subscription
+	ctx         context.Context
+	err         error
+
+	relayOnly bool // message channel "ch" will be nil if this is set to true
 }
 
 // Topic returns the topic string associated with the Subscription
@@ -43,5 +46,7 @@ func (sub *Subscription) Cancel() {
 }
 
 func (sub *Subscription) close() {
-	close(sub.ch)
+	if !sub.relayOnly {
+		close(sub.ch)
+	}
 }


### PR DESCRIPTION
For #28  as enlisted in #220 

@aschmahmann @vyzo @Stebalien Please take a look.

Relay only messages will also pass through the validator pipeline as discussed in https://github.com/libp2p/go-libp2p-pubsub/issues/198#issuecomment-543798308)