### PR TITLE
Configurable message id function

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -75,6 +75,8 @@ func (gs *GossipSubRouter) Protocols() []protocol.ID {
 func (gs *GossipSubRouter) Attach(p *PubSub) {
 	gs.p = p
 	gs.tracer = p.tracer
+	// start using the same msg ID function as PubSub for caching messages.
+	gs.mcache.ChangeMsgIdFn(p.msgID)
 	go gs.heartbeatTimer()
 }
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -76,7 +76,7 @@ func (gs *GossipSubRouter) Attach(p *PubSub) {
 	gs.p = p
 	gs.tracer = p.tracer
 	// start using the same msg ID function as PubSub for caching messages.
-	gs.mcache.ChangeMsgIdFn(p.msgID)
+	gs.mcache.SetMsgIdFn(p.msgID)
 	go gs.heartbeatTimer()
 }
 

--- a/mcache.go
+++ b/mcache.go
@@ -28,6 +28,7 @@ func NewMessageCache(gossip, history int) *MessageCache {
 		msgs:    make(map[string]*pb.Message),
 		history: make([][]CacheEntry, history),
 		gossip:  gossip,
+		msgID:   DefaultMsgIdFn,
 	}
 }
 
@@ -35,6 +36,11 @@ type MessageCache struct {
 	msgs    map[string]*pb.Message
 	history [][]CacheEntry
 	gossip  int
+	msgID   MsgIdFunction
+}
+
+func (mc *MessageCache) ChangeMsgIdFn(msgID MsgIdFunction) {
+	mc.msgID = msgID
 }
 
 type CacheEntry struct {
@@ -43,7 +49,7 @@ type CacheEntry struct {
 }
 
 func (mc *MessageCache) Put(msg *pb.Message) {
-	mid := msgID(msg)
+	mid := mc.msgID(msg)
 	mc.msgs[mid] = msg
 	mc.history[0] = append(mc.history[0], CacheEntry{mid: mid, topics: msg.GetTopicIDs()})
 }

--- a/mcache.go
+++ b/mcache.go
@@ -39,7 +39,7 @@ type MessageCache struct {
 	msgID   MsgIdFunction
 }
 
-func (mc *MessageCache) ChangeMsgIdFn(msgID MsgIdFunction) {
+func (mc *MessageCache) SetMsgIdFn(msgID MsgIdFunction) {
 	mc.msgID = msgID
 }
 

--- a/mcache_test.go
+++ b/mcache_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestMessageCache(t *testing.T) {
 	mcache := NewMessageCache(3, 5)
+	msgID := DefaultMsgIdFn
 
 	msgs := make([]*pb.Message, 60)
 	for i := range msgs {

--- a/pubsub.go
+++ b/pubsub.go
@@ -254,6 +254,10 @@ type MsgIdFunction func(pmsg *pb.Message) string
 func WithMessageIdFn(fn MsgIdFunction) Option {
 	return func(p *PubSub) error {
 		p.msgID = fn
+		// the tracer Option may already be set. Update its message ID function to make options order-independent.
+		if p.tracer != nil {
+			p.tracer.msgID = fn
+		}
 		return nil
 	}
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -117,6 +117,9 @@ type PubSub struct {
 	seenMessagesMx sync.Mutex
 	seenMessages   *timecache.TimeCache
 
+	// function used to compute the ID for a message
+	msgID MsgIdFunction
+
 	// key for signing messages; nil when signing is disabled (default for now)
 	signKey crypto.PrivKey
 	// source ID for signed messages; corresponds to signKey
@@ -208,6 +211,7 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		blacklist:             NewMapBlacklist(),
 		blacklistPeer:         make(chan peer.ID),
 		seenMessages:          timecache.NewTimeCache(TimeCacheDuration),
+		msgID:                 DefaultMsgIdFn,
 		counter:               uint64(time.Now().UnixNano()),
 	}
 
@@ -238,6 +242,20 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 	go ps.processLoop(ctx)
 
 	return ps, nil
+}
+
+// MsgIdFunction returns a unique ID for the passed Message, and PubSub can be customized to use any
+// implementation of this function by configuring it with the Option from WithMessageIdFn.
+type MsgIdFunction func(pmsg *pb.Message) string
+
+// WithMessageIdFn is an option to customize the way a message ID is computed for a pubsub message.
+// The default ID function is DefaultMsgIdFn (concatenate source and seq nr.),
+// but it can be customized to e.g. the hash of the message.
+func WithMessageIdFn(fn MsgIdFunction) Option {
+	return func(p *PubSub) error {
+		p.msgID = fn
+		return nil
+	}
 }
 
 // WithPeerOutboundQueueSize is an option to set the buffer size for outbound messages to a peer
@@ -326,7 +344,7 @@ func WithDiscovery(d discovery.Discovery, opts ...DiscoverOpt) Option {
 // WithEventTracer provides a tracer for the pubsub system
 func WithEventTracer(tracer EventTracer) Option {
 	return func(p *PubSub) error {
-		p.tracer = &pubsubTracer{tracer: tracer, pid: p.host.ID()}
+		p.tracer = &pubsubTracer{tracer: tracer, pid: p.host.ID(), msgID: p.msgID}
 		return nil
 	}
 }
@@ -730,8 +748,8 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 	p.rt.HandleRPC(rpc)
 }
 
-// msgID returns a unique ID of the passed Message
-func msgID(pmsg *pb.Message) string {
+// DefaultMsgIdFn returns a unique ID of the passed Message
+func DefaultMsgIdFn(pmsg *pb.Message) string {
 	return string(pmsg.GetFrom()) + string(pmsg.GetSeqno())
 }
 
@@ -760,7 +778,7 @@ func (p *PubSub) pushMsg(msg *Message) {
 	}
 
 	// have we already seen and validated this message?
-	id := msgID(msg.Message)
+	id := p.msgID(msg.Message)
 	if p.seenMessage(id) {
 		p.tracer.DuplicateMessage(msg)
 		return

--- a/validation.go
+++ b/validation.go
@@ -201,7 +201,7 @@ func (v *validation) validate(vals []*topicVal, src peer.ID, msg *Message) {
 
 	// we can mark the message as seen now that we have verified the signature
 	// and avoid invoking user validators more than once
-	id := msgID(msg.Message)
+	id := v.p.msgID(msg.Message)
 	if !v.p.markSeen(id) {
 		v.tracer.DuplicateMessage(msg)
 		return


### PR DESCRIPTION
See #247: this PR is fully backwards compatible, no public API changes, except for the addition of:
- configuration method ~~`ChangeMsgIdFn`~~ `SetMsgIdFn` to `MessageCache`. The cache doesn't really need a single message id function from the start, so changing it with a method seems fine. And this way it doesn't break any existing code. Note that users of caches like this can update it once they get hold of the exact msg id function to use. E.g. gossipsub updates it when PubSub attaches the router. So it also avoids a painful early design choice of PubSub getting all options, and gossipsub not being able to adapt based on these Options, before initializing PubSub.
- introduction of `MsgIdFunction`, which has the same signature as the previous private `msgID` helper, but now it's configurable! The old `msgID` is now `DefaultMsgIdFn`.
- a PubSub `Option` created with `WithMessageIdFn` to apply your own message ID function to PubSub :)

PS: I thought this was an easy and important issue to just fix it myself, and although I have some previous experience hacking on this repo (I looked deep into its concurrency and simulation for eth2 tooling for aggregation modeling), I can definitely appreciate a review since I don't normally contribute code upstream here.

Closes #247 

cc @AgeManning
