### PR TITLE
set sendTo to remote peer id in trace events

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -165,7 +165,7 @@ func (t *pubsubTracer) SendRPC(rpc *RPC, p peer.ID) {
 		PeerID:    []byte(t.pid),
 		Timestamp: &now,
 		SendRPC: &pb.TraceEvent_SendRPC{
-			SendTo: []byte(rpc.from),
+			SendTo: []byte(p),
 			Meta:   t.traceRPCMeta(rpc),
 		},
 	}
@@ -184,7 +184,7 @@ func (t *pubsubTracer) DropRPC(rpc *RPC, p peer.ID) {
 		PeerID:    []byte(t.pid),
 		Timestamp: &now,
 		DropRPC: &pb.TraceEvent_DropRPC{
-			SendTo: []byte(rpc.from),
+			SendTo: []byte(p),
 			Meta:   t.traceRPCMeta(rpc),
 		},
 	}


### PR DESCRIPTION
I noticed as I was playing with the tracer output that the `sendTo` field for `SendRPC` and `DropRPC` trace events was always missing. 

This changes the `SendRPC` and `DropRPC` tracer methods to use the remote peer id instead of `rpc.from`.
