### PR TITLE
Opportunistic grafting

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -951,7 +951,7 @@ func (gs *GossipSubRouter) heartbeat() {
 			medianIndex := len(peers) / 2
 			medianScore := scores[plst[medianIndex]]
 
-			// if the media score is below the threshold, select a better peer (if any) and GRAFT
+			// if the median score is below the threshold, select a better peer (if any) and GRAFT
 			if medianScore < gs.opportunisticGraftThreshold {
 				backoff := gs.backoff[topic]
 				plst = gs.getPeers(topic, 1, func(p peer.ID) bool {

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -221,7 +221,7 @@ type GossipSubRouter struct {
 	// threshold for peer score before we graylist the peer and silently ignore its RPCs
 	graylistThreshold float64
 
-	// threshold for media peer score before triggering opportunistic grafting
+	// threshold for median peer score before triggering opportunistic grafting
 	opportunisticGraftThreshold float64
 
 	// whether to use flood publishing

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -59,6 +59,10 @@ var (
 
 	// timeout for connection attempts
 	GossipSubConnectionTimeout = 30 * time.Second
+
+	// Number of heartbeat ticks for attempting to reconnect direct peers that are not
+	// currently connected
+	GossipSubDirectConnectTicks uint64 = 300
 )
 
 // NewGossipSub returns a new PubSub object using GossipSubRouter as the router.
@@ -983,9 +987,9 @@ func (gs *GossipSubRouter) clearBackoff() {
 }
 
 func (gs *GossipSubRouter) directConnect() {
-	// we donly do this every 150 ticks to allow pending connections to complete and account
+	// we donly do this every some ticks to allow pending connections to complete and account
 	// for restarts/downtime
-	if gs.heartbeatTicks%150 != 0 {
+	if gs.heartbeatTicks%GossipSubDirectConnectTicks != 0 {
 		return
 	}
 

--- a/score_params.go
+++ b/score_params.go
@@ -20,9 +20,13 @@ type PeerScoreThresholds struct {
 	// implementing an effective graylist according to peer score; should be negative and <= PublisThreshold.
 	GraylistThreshold float64
 
-	// acceptPXThreshold is the score threshold below which PX will be ignored; this should be positive
+	// AcceptPXThreshold is the score threshold below which PX will be ignored; this should be positive
 	// and limited to scores attainable by bootstrappers and other trusted nodes.
 	AcceptPXThreshold float64
+
+	// OpportunisticGraftThreshold is the median mesh score threshold before triggering opportunistic
+	// grafting; this should have a small positive value.
+	OpportunisticGraftThreshold float64
 }
 
 func (p *PeerScoreThresholds) validate() error {
@@ -37,6 +41,9 @@ func (p *PeerScoreThresholds) validate() error {
 	}
 	if p.AcceptPXThreshold < 0 {
 		return fmt.Errorf("invalid accept PX threshold; it must be >= 0")
+	}
+	if p.OpportunisticGraftThreshold < 0 {
+		return fmt.Errorf("invalid opportunistic grafting threshold; it must be >= 0")
 	}
 	return nil
 }


### PR DESCRIPTION
Opportunistic grafting attempts to slowly improve underperforming meshes.

It works as follows: we check the median score of peers in the mesh; if this score is below the opportunisticGraftThreshold, we graft a peer at random with score over the median.
 
The intention is to (slowly) improve an underperforming mesh by introducing good scoring peers that may have been gossiping at us. This allows us to get out of sticky situations where we are stuck with poor peers and also recover from churn of good peers.