### PR TITLE
add test with signed peer records

### DIFF
--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1007,10 +1007,8 @@ func TestGossipsubStarTopologyWithSignedPeerRecords(t *testing.T) {
 	psubs := getGossipsubs(ctx, hosts, WithPeerExchange(true))
 
 	// manually create signed peer records for each host and add them to the
-	// peerstores of the other hosts.
-	// this is necessary until the identify service is updated to exchange
-	// signed records
-	for i := range hosts {
+	// peerstore of the center of the star, which is doing the bootstrapping
+	for i := range hosts[1:] {
 		privKey := hosts[i].Peerstore().PrivKey(hosts[i].ID())
 		if privKey == nil {
 			t.Fatalf("unable to get private key for host %s", hosts[i].ID().Pretty())
@@ -1022,18 +1020,13 @@ func TestGossipsubStarTopologyWithSignedPeerRecords(t *testing.T) {
 			t.Fatalf("error creating signed peer record: %s", err)
 		}
 
-		for j := range hosts {
-			if i == j {
-				continue
-			}
-			cab, ok := peerstore.GetCertifiedAddrBook(hosts[j].Peerstore())
-			if !ok {
-				t.Fatal("peerstore does not implement CertifiedAddrBook")
-			}
-			_, err := cab.ConsumePeerRecord(signedRec, peerstore.PermanentAddrTTL)
-			if err != nil {
-				t.Fatalf("error adding signed peer record: %s", err)
-			}
+		cab, ok := peerstore.GetCertifiedAddrBook(hosts[0].Peerstore())
+		if !ok {
+			t.Fatal("peerstore does not implement CertifiedAddrBook")
+		}
+		_, err = cab.ConsumePeerRecord(signedRec, peerstore.PermanentAddrTTL)
+		if err != nil {
+			t.Fatalf("error adding signed peer record: %s", err)
 		}
 	}
 

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/libp2p/go-libp2p-core/record"
 	"io"
 	"math/rand"
 	"testing"
@@ -16,6 +15,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
+	"github.com/libp2p/go-libp2p-core/record"
 
 	bhost "github.com/libp2p/go-libp2p-blankhost"
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -948,17 +948,29 @@ func TestGossipsubStarTopology(t *testing.T) {
 	GossipSubDhi = GossipSubD + 1
 	originalGossipSubDlo := GossipSubDlo
 	GossipSubDlo = GossipSubD - 1
+	originalGossipSubDscore := GossipSubDscore
+	GossipSubDscore = GossipSubDlo
 	defer func() {
 		GossipSubD = originalGossipSubD
 		GossipSubDhi = originalGossipSubDhi
 		GossipSubDlo = originalGossipSubDlo
+		GossipSubDscore = originalGossipSubDscore
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 20)
-	psubs := getGossipsubs(ctx, hosts, WithPeerExchange(true))
+	psubs := getGossipsubs(ctx, hosts, WithPeerExchange(true), WithFloodPublish(true))
+
+	// configure the center of the star with a very low D
+	psubs[0].eval <- func() {
+		gs := psubs[0].rt.(*GossipSubRouter)
+		gs.D = 0
+		gs.Dlo = 0
+		gs.Dhi = 0
+		gs.Dscore = 0
+	}
 
 	// add all peer addresses to the peerstores
 	// this is necessary because we can't have signed address records witout identify
@@ -1020,17 +1032,29 @@ func TestGossipsubStarTopologyWithSignedPeerRecords(t *testing.T) {
 	GossipSubDhi = GossipSubD + 1
 	originalGossipSubDlo := GossipSubDlo
 	GossipSubDlo = GossipSubD - 1
+	originalGossipSubDscore := GossipSubDscore
+	GossipSubDscore = GossipSubDlo
 	defer func() {
 		GossipSubD = originalGossipSubD
 		GossipSubDhi = originalGossipSubDhi
 		GossipSubDlo = originalGossipSubDlo
+		GossipSubDscore = originalGossipSubDscore
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 20)
-	psubs := getGossipsubs(ctx, hosts, WithPeerExchange(true))
+	psubs := getGossipsubs(ctx, hosts, WithPeerExchange(true), WithFloodPublish(true))
+
+	// configure the center of the star with a very low D
+	psubs[0].eval <- func() {
+		gs := psubs[0].rt.(*GossipSubRouter)
+		gs.D = 0
+		gs.Dlo = 0
+		gs.Dhi = 0
+		gs.Dscore = 0
+	}
 
 	// manually create signed peer records for each host and add them to the
 	// peerstore of the center of the star, which is doing the bootstrapping

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -942,6 +942,18 @@ func TestGossipsubTreeTopology(t *testing.T) {
 // this tests overlay bootstrapping through px in Gossipsub v1.1
 // we start with a star topology and rely on px through prune to build the mesh
 func TestGossipsubStarTopology(t *testing.T) {
+	originalGossipSubD := GossipSubD
+	GossipSubD = 4
+	originalGossipSubDhi := GossipSubDhi
+	GossipSubDhi = GossipSubD + 1
+	originalGossipSubDlo := GossipSubDlo
+	GossipSubDlo = GossipSubD - 1
+	defer func() {
+		GossipSubD = originalGossipSubD
+		GossipSubDhi = originalGossipSubDhi
+		GossipSubDlo = originalGossipSubDlo
+	}()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -965,6 +977,8 @@ func TestGossipsubStarTopology(t *testing.T) {
 		connect(t, hosts[0], hosts[i])
 	}
 
+	time.Sleep(time.Second)
+
 	// build the mesh
 	var subs []*Subscription
 	for _, ps := range psubs {
@@ -979,9 +993,9 @@ func TestGossipsubStarTopology(t *testing.T) {
 	time.Sleep(10 * time.Second)
 
 	// check that all peers have > 1 connection
-	for _, h := range hosts {
+	for i, h := range hosts {
 		if len(h.Network().Conns()) == 1 {
-			t.Error("peer has ony a single connection")
+			t.Errorf("peer %d has ony a single connection", i)
 		}
 	}
 
@@ -1000,6 +1014,18 @@ func TestGossipsubStarTopology(t *testing.T) {
 // exchanged in signed peer records.
 // we start with a star topology and rely on px through prune to build the mesh
 func TestGossipsubStarTopologyWithSignedPeerRecords(t *testing.T) {
+	originalGossipSubD := GossipSubD
+	GossipSubD = 4
+	originalGossipSubDhi := GossipSubDhi
+	GossipSubDhi = GossipSubD + 1
+	originalGossipSubDlo := GossipSubDlo
+	GossipSubDlo = GossipSubD - 1
+	defer func() {
+		GossipSubD = originalGossipSubD
+		GossipSubDhi = originalGossipSubDhi
+		GossipSubDlo = originalGossipSubDlo
+	}()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1035,6 +1061,8 @@ func TestGossipsubStarTopologyWithSignedPeerRecords(t *testing.T) {
 		connect(t, hosts[0], hosts[i])
 	}
 
+	time.Sleep(time.Second)
+
 	// build the mesh
 	var subs []*Subscription
 	for _, ps := range psubs {
@@ -1049,9 +1077,9 @@ func TestGossipsubStarTopologyWithSignedPeerRecords(t *testing.T) {
 	time.Sleep(10 * time.Second)
 
 	// check that all peers have > 1 connection
-	for _, h := range hosts {
+	for i, h := range hosts {
 		if len(h.Network().Conns()) == 1 {
-			t.Error("peer has ony a single connection")
+			t.Errorf("peer %d has ony a single connection", i)
 		}
 	}
 


### PR DESCRIPTION
@vyzo as suggested, I just copied the star topology test and tweaked it a bit. It manually creates a signed peer record for each host and adds it to all the other hosts' peer stores.

I'm not sure how to test the error cases (e.g. failing to marshal the signed peer record), but at least this gets rid of the big red block in the coverage.
