### PR TITLE
Topic relay

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -19,7 +19,18 @@ import (
 // get the initial RPC containing all of our subscriptions to send to new peers
 func (p *PubSub) getHelloPacket() *RPC {
 	var rpc RPC
+
+	subscriptions := make(map[string]bool)
+
 	for t := range p.mySubs {
+		subscriptions[t] = true
+	}
+
+	for t := range p.myRelays {
+		subscriptions[t] = true
+	}
+
+	for t := range subscriptions {
 		as := &pb.RPC_SubOpts{
 			Topicid:   proto.String(t),
 			Subscribe: proto.Bool(true),

--- a/pubsub.go
+++ b/pubsub.go
@@ -623,13 +623,13 @@ func (p *PubSub) handleRemoveSubscription(sub *Subscription) {
 
 	if len(subs) == 0 {
 		delete(p.mySubs, sub.topic)
-	}
 
-	// stop announcing only if there are no more subs and relays
-	if len(subs) == 0 && p.myRelays[sub.topic] == 0 {
-		p.disc.StopAdvertise(sub.topic)
-		p.announce(sub.topic, false)
-		p.rt.Leave(sub.topic)
+		// stop announcing only if there are no more subs and relays
+		if p.myRelays[sub.topic] == 0 {
+			p.disc.StopAdvertise(sub.topic)
+			p.announce(sub.topic, false)
+			p.rt.Leave(sub.topic)
+		}
 	}
 }
 
@@ -698,13 +698,13 @@ func (p *PubSub) handleRemoveRelay(topic string) {
 
 	if p.myRelays[topic] == 0 {
 		delete(p.myRelays, topic)
-	}
 
-	// stop announcing only if there are no more relays and subs
-	if p.myRelays[topic] == 0 && len(p.mySubs[topic]) == 0 {
-		p.disc.StopAdvertise(topic)
-		p.announce(topic, false)
-		p.rt.Leave(topic)
+		// stop announcing only if there are no more relays and subs
+		if len(p.mySubs[topic]) == 0 {
+			p.disc.StopAdvertise(topic)
+			p.announce(topic, false)
+			p.rt.Leave(topic)
+		}
 	}
 }
 

--- a/pubsub.go
+++ b/pubsub.go
@@ -667,14 +667,14 @@ func (p *PubSub) handleAddSubscription(req *addSubReq) {
 func (p *PubSub) handleAddRelay(req *addRelayReq) {
 	topic := req.topic
 
+	p.myRelays[topic]++
+
 	// announce we want this topic if neither relays nor subs exist so far
-	if p.myRelays[topic] == 0 && len(p.mySubs[topic]) == 0 {
+	if p.myRelays[topic] == 1 && len(p.mySubs[topic]) == 0 {
 		p.disc.Advertise(topic)
 		p.announce(topic, true)
 		p.rt.Join(topic)
 	}
-
-	p.myRelays[topic]++
 
 	req.resp <- func() {
 		select {

--- a/topic_test.go
+++ b/topic_test.go
@@ -629,7 +629,20 @@ func TestTopicRelayReuse(t *testing.T) {
 		t.Fatal("incorrect number of relays")
 	}
 
+	// only the first invocation should take effect
 	relay1Cancel()
+	relay1Cancel()
+	relay1Cancel()
+
+	pubsubs[0].eval <- func() {
+		res <- pubsubs[0].myRelays[topic] == 2
+	}
+
+	isCorrectNumber = <-res
+	if !isCorrectNumber {
+		t.Fatal("incorrect number of relays")
+	}
+
 	relay2Cancel()
 	relay3Cancel()
 

--- a/topic_test.go
+++ b/topic_test.go
@@ -619,7 +619,13 @@ func TestTopicRelayReuse(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	if pubsubs[0].myRelays[topic] != 3 {
+	res := make(chan bool, 1)
+	pubsubs[0].eval <- func() {
+		res <- pubsubs[0].myRelays[topic] == 3
+	}
+
+	isCorrectNumber := <-res
+	if !isCorrectNumber {
 		t.Fatal("incorrect number of relays")
 	}
 
@@ -629,7 +635,12 @@ func TestTopicRelayReuse(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	if pubsubs[0].myRelays[topic] != 0 {
+	pubsubs[0].eval <- func() {
+		res <- pubsubs[0].myRelays[topic] == 0
+	}
+
+	isCorrectNumber = <-res
+	if !isCorrectNumber {
 		t.Fatal("incorrect number of relays")
 	}
 }


### PR DESCRIPTION
Refs #28 #292 

This pull request ships an implementation of the topic `Relay` operation. That opens the possibility to take part in voluntary topic dissemination by all interested nodes without the need for subscribing.  

**Implementation details**

This implementation tries to follow @vyzo [comment](https://github.com/libp2p/go-libp2p-pubsub/issues/292#issuecomment-619058811) thus it uses a relay reference counter and try to not conflate with subscriptions. However, regarding peer discovery, we probably must follow the same logic as subscriptions which is reflected in the implementation. Also, relays canceling logic has probably a place for improvements so I'd appreciate suggestions on how I can do it better to satisfy all possible use cases.