### PR TITLE
P7: Behaviour pattern penalties

### DIFF
--- a/score_params.go
+++ b/score_params.go
@@ -76,7 +76,8 @@ type PeerScoreParams struct {
 	// P7: behavioural pattern penalties.
 	// This parameter has an associated counter which tracks misbehaviour as detected by the
 	// router.
-	// The value of the parameter is the counter, decaying with BehaviourPatternPenaltyDecay.
+	// The value of the parameter is the square of the counter, decaying with
+	// BehaviourPatternPenaltyDecay.
 	// The weight of the parameter MUST be negative (or zero to disable).
 	BehaviourPenaltyWeight, BehaviourPenaltyDecay float64
 

--- a/score_params.go
+++ b/score_params.go
@@ -164,10 +164,11 @@ func (p *PeerScoreParams) validate() error {
 	if p.IPColocationFactorWeight > 0 {
 		return fmt.Errorf("invalid IPColocationFactorWeight; must be negative (or 0 to disable)")
 	}
-	if p.IPColocationFactorWeight < 0 && p.IPColocationFactorThreshold < 1 {
+	if p.IPColocationFactorWeight != 0 && p.IPColocationFactorThreshold < 1 {
 		return fmt.Errorf("invalid IPColocationFactorThreshold; must be at least 1")
 	}
 
+	// check the behaviour penalty
 	if p.BehaviourPenaltyWeight > 0 {
 		return fmt.Errorf("invalid BehaviourPenaltyWeight; must be negative (or 0 to disable)")
 	}

--- a/score_params.go
+++ b/score_params.go
@@ -73,6 +73,13 @@ type PeerScoreParams struct {
 	IPColocationFactorThreshold int
 	IPColocationFactorWhitelist map[string]struct{}
 
+	// P7: behavioural pattern penalties.
+	// This parameter has an associated counter which tracks misbehaviour as detected by the
+	// router.
+	// The value of the parameter is the counter, decaying with BehaviourPatternPenaltyDecay.
+	// The weight of the parameter MUST be negative (or zero to disable).
+	BehaviourPenaltyWeight, BehaviourPenaltyDecay float64
+
 	// the decay interval for parameter counters.
 	DecayInterval time.Duration
 
@@ -159,6 +166,13 @@ func (p *PeerScoreParams) validate() error {
 	}
 	if p.IPColocationFactorWeight < 0 && p.IPColocationFactorThreshold < 1 {
 		return fmt.Errorf("invalid IPColocationFactorThreshold; must be at least 1")
+	}
+
+	if p.BehaviourPenaltyWeight > 0 {
+		return fmt.Errorf("invalid BehaviourPenaltyWeight; must be negative (or 0 to disable)")
+	}
+	if p.BehaviourPenaltyWeight != 0 && (p.BehaviourPenaltyDecay <= 0 || p.BehaviourPenaltyDecay >= 1) {
+		return fmt.Errorf("invalid BehaviourPenaltyDecay; must be between 0 and 1")
 	}
 
 	// check the decay parameters

--- a/score_params.go
+++ b/score_params.go
@@ -76,8 +76,7 @@ type PeerScoreParams struct {
 	// P7: behavioural pattern penalties.
 	// This parameter has an associated counter which tracks misbehaviour as detected by the
 	// router.
-	// The value of the parameter is the square of the counter, decaying with
-	// BehaviourPatternPenaltyDecay.
+	// The value of the parameter is the square of the counter, which decays with  BehaviourPenaltyDecay.
 	// The weight of the parameter MUST be negative (or zero to disable).
 	BehaviourPenaltyWeight, BehaviourPenaltyDecay float64
 

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -153,17 +153,29 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 	if (&PeerScoreParams{TopicScoreCap: 1, AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 2, IPColocationFactorWeight: -1, IPColocationFactorThreshold: 1}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: 1}) == nil {
+	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: 1}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: -1}) == nil {
+	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: -1}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: -1, BehaviourPenaltyDecay: 2}) == nil {
+	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: -1, BehaviourPenaltyDecay: 2}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
 
 	// don't use these params in production!
+	if (&PeerScoreParams{
+		AppSpecificScore:            appScore,
+		DecayInterval:               time.Second,
+		DecayToZero:                 0.01,
+		IPColocationFactorWeight:    -1,
+		IPColocationFactorThreshold: 1,
+		BehaviourPenaltyWeight:      -1,
+		BehaviourPenaltyDecay:       0.999,
+	}).validate() != nil {
+		t.Fatal("expected validation success")
+	}
+
 	if (&PeerScoreParams{
 		TopicScoreCap:               1,
 		AppSpecificScore:            appScore,
@@ -177,7 +189,6 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 		t.Fatal("expected validation success")
 	}
 
-	// don't use these params in production!
 	if (&PeerScoreParams{
 		TopicScoreCap:               1,
 		AppSpecificScore:            appScore,

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -153,6 +153,15 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 	if (&PeerScoreParams{TopicScoreCap: 1, AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 2, IPColocationFactorWeight: -1, IPColocationFactorThreshold: 1}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
+	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: 1}) == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: -1}) == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: -1, BehaviourPenaltyDecay: 2}) == nil {
+		t.Fatal("expected validation error")
+	}
 
 	// don't use these params in production!
 	if (&PeerScoreParams{
@@ -162,6 +171,8 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 		DecayToZero:                 0.01,
 		IPColocationFactorWeight:    -1,
 		IPColocationFactorThreshold: 1,
+		BehaviourPenaltyWeight:      -1,
+		BehaviourPenaltyDecay:       0.999,
 	}).validate() != nil {
 		t.Fatal("expected validation success")
 	}

--- a/score_test.go
+++ b/score_test.go
@@ -741,6 +741,42 @@ func TestScoreIPColocation(t *testing.T) {
 	}
 }
 
+func TestScoreBehaviourPenalty(t *testing.T) {
+	params := &PeerScoreParams{
+		AppSpecificScore:       func(peer.ID) float64 { return 0 },
+		BehaviourPenaltyWeight: -1,
+		BehaviourPenaltyDecay:  0.99,
+	}
+
+	peerA := peer.ID("A")
+	ps := newPeerScore(params)
+	ps.AddPeer(peerA, "myproto")
+
+	aScore := ps.Score(peerA)
+	if aScore != 0 {
+		t.Errorf("expected peer score to be 0, got %f", aScore)
+	}
+
+	ps.AddPenalty(peerA, 1)
+	aScore = ps.Score(peerA)
+	if aScore != -1 {
+		t.Errorf("expected peer score to be -1, got %f", aScore)
+	}
+
+	ps.AddPenalty(peerA, 1)
+	aScore = ps.Score(peerA)
+	if aScore != -4 {
+		t.Errorf("expected peer score to be -4, got %f", aScore)
+	}
+
+	ps.refreshScores()
+
+	aScore = ps.Score(peerA)
+	if aScore != -3.9204 {
+		t.Errorf("expected peer score to be -3.9204, got %f", aScore)
+	}
+}
+
 func TestScoreRetention(t *testing.T) {
 	// Create parameters with reasonable default values
 	mytopic := "mytopic"

--- a/score_test.go
+++ b/score_test.go
@@ -749,10 +749,30 @@ func TestScoreBehaviourPenalty(t *testing.T) {
 	}
 
 	peerA := peer.ID("A")
-	ps := newPeerScore(params)
+
+	var ps *peerScore
+
+	// first check AddPenalty on a nil peerScore
+	ps.AddPenalty(peerA, 1)
+	aScore := ps.Score(peerA)
+	if aScore != 0 {
+		t.Errorf("expected peer score to be 0, got %f", aScore)
+	}
+
+	// instantiate the peerScore
+	ps = newPeerScore(params)
+
+	// next AddPenalty on a non-existent peer
+	ps.AddPenalty(peerA, 1)
+	aScore = ps.Score(peerA)
+	if aScore != 0 {
+		t.Errorf("expected peer score to be 0, got %f", aScore)
+	}
+
+	// add the peer and test penalties
 	ps.AddPeer(peerA, "myproto")
 
-	aScore := ps.Score(peerA)
+	aScore = ps.Score(peerA)
 	if aScore != 0 {
 		t.Errorf("expected peer score to be 0, got %f", aScore)
 	}


### PR DESCRIPTION
This adds a new score parameter, P7, which is a quadratic counter of behavioural pattern penalties.
In contrast to other parameters, which are implicitly updated through tracing, this counter is explicitly incremented by the router.
It is intended to capture and penalize behavioural patterns in #285 and #286, such as not following up on `IWANT` requests from `IHAVE` advertisements or not respecting the prune backoff, but it can also be used for other behaviours in the future.

cc @raulk 