### PR TITLE
Fragment large RPCs into multiple messages

### DIFF
--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1802,12 +1802,6 @@ func (iwe *iwantEverything) handleStream(s network.Stream) {
 	topic := "test"
 	err = w.WriteMsg(&pb.RPC{Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: &truth, Topicid: &topic}}})
 
-	remotePidBytes, err := s.Conn().RemotePeer().MarshalBinary()
-	if err != nil {
-		panic(err)
-	}
-	toPrune := []*pb.PeerInfo{{PeerID: remotePidBytes}}
-
 	var rpc pb.RPC
 	for {
 		rpc.Reset()
@@ -1836,7 +1830,7 @@ func (iwe *iwantEverything) handleStream(s network.Stream) {
 			// send a PRUNE for all grafts, so we don't get direct message deliveries
 			var prunes []*pb.ControlPrune
 			for _, graft := range rpc.Control.Graft {
-				prunes = append(prunes, &pb.ControlPrune{TopicID: graft.TopicID, Peers: toPrune})
+				prunes = append(prunes, &pb.ControlPrune{TopicID: graft.TopicID})
 			}
 
 			var iwants []*pb.ControlIWant

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1752,6 +1752,8 @@ func TestGossipsubRPCFragmentation(t *testing.T) {
 
 	// wait a bit for them to be received via gossip by the fake peer
 	time.Sleep(5 * time.Second)
+	iwe.lk.Lock()
+	defer iwe.lk.Unlock()
 
 	// we should have received all the messages
 	if iwe.msgsReceived != nMessages {
@@ -1778,6 +1780,7 @@ func TestGossipsubRPCFragmentation(t *testing.T) {
 // test that large responses to IWANT requests are fragmented into multiple RPCs.
 type iwantEverything struct {
 	h                host.Host
+	lk               sync.Mutex
 	rpcsWithMessages int
 	msgsReceived     int
 	ihavesReceived   int
@@ -1816,6 +1819,7 @@ func (iwe *iwantEverything) handleStream(s network.Stream) {
 			return
 		}
 
+		iwe.lk.Lock()
 		if len(rpc.Publish) != 0 {
 			iwe.rpcsWithMessages++
 		}
@@ -1852,5 +1856,6 @@ func (iwe *iwantEverything) handleStream(s network.Stream) {
 				panic(err)
 			}
 		}
+		iwe.lk.Unlock()
 	}
 }

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1787,6 +1787,8 @@ type iwantEverything struct {
 }
 
 func (iwe *iwantEverything) handleStream(s network.Stream) {
+	defer s.Close()
+
 	os, err := iwe.h.NewStream(context.Background(), s.Conn().RemotePeer(), GossipSubID_v10)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This adds a `fragmentRPC` function that's used by gossipsub's `sendRPC` method to avoid writing RPC messages that are larger than the maximum message size, which can happen if a peer requests a lot of large messages via gossip.

It can fail if an individual message is larger than the maximum, but I haven't written a test for that code path yet.

closes #307 