### PR TITLE
fix: duplicate topic label name

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -157,7 +157,7 @@
 - name: topic/multi-language
   color: bf0f73
   description: "Topic: Multi-language"
-- name: topic/docs
+- name: topic/specs
   color: bf0f73
   description: "Topic: Specs"
 - name: topic/docs


### PR DESCRIPTION
Also note that there are multiple references to testground in here - testground, sidecar etc. I assume not intentional?