### PR TITLE
Implement outbound peer quotas and limit overgraft

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -537,6 +537,12 @@ func (gs *GossipSubRouter) handleGraft(p peer.ID, ctl *pb.ControlMessage) []*pb.
 			continue
 		}
 
+		// check if it is already in the mesh; if so do nothing (we might have concurrent grafting)
+		_, inMesh := peers[p]
+		if inMesh {
+			continue
+		}
+
 		// we don't GRAFT to/from direct peers; complain loudly if this happens
 		_, direct := gs.direct[p]
 		if direct {

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -361,12 +361,7 @@ loop:
 		if c.Stat().Direction == network.DirOutbound {
 			// only count the connection if it has a pubsub stream
 			for _, s := range c.GetStreams() {
-				switch s.Protocol() {
-				case FloodSubID:
-					fallthrough
-				case GossipSubID_v10:
-					fallthrough
-				case GossipSubID_v11:
+				if s.Protocol() == proto {
 					outbound = true
 					break loop
 				}


### PR DESCRIPTION
Introduces a new overlay parameter, `D_out`, which is used to control the number of outbound connected peers we should keep in the mesh.

During mesh maintenance:
- when pruning because of over subscription, we constrain the survivor set to include D_out outbound peers.
- when we have less than `D_out` peers in the mesh, we graft some outbound peers.

In addition, when receiving a graft over the `D_hi` limit, the graft is rejected unless it comes from an outbound peer.

cc @daviddias @raulk 