### PR TITLE
feat: add direct connect ticks option

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -305,6 +305,21 @@ func WithDirectPeers(pis []peer.AddrInfo) Option {
 	}
 }
 
+// WithDirectConnectTicks is a gossipsub router option that sets the number of
+// heartbeat ticks between attempting to reconnect direct peers that are not
+// currently connected. A "tick" is based on the heartbeat interval, which is
+// 1s by default. The default value for direct connect ticks is 300.
+func WithDirectConnectTicks(t uint64) Option {
+	return func(ps *PubSub) error {
+		gs, ok := ps.rt.(*GossipSubRouter)
+		if !ok {
+			return fmt.Errorf("pubsub router is not gossipsub")
+		}
+		gs.directConnectTicks = t
+		return nil
+	}
+}
+
 // GossipSubRouter is a router that implements the gossipsub protocol.
 // For each topic we have joined, we maintain an overlay through which
 // messages flow; this is the mesh map.

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1120,20 +1120,14 @@ func TestGossipsubStarTopologyWithSignedPeerRecords(t *testing.T) {
 }
 
 func TestGossipsubDirectPeers(t *testing.T) {
-	originalGossipSubDirectConnectTicks := GossipSubDirectConnectTicks
-	GossipSubDirectConnectTicks = 2
-	defer func() {
-		GossipSubDirectConnectTicks = originalGossipSubDirectConnectTicks
-	}()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	h := getNetHosts(t, ctx, 3)
 	psubs := []*PubSub{
-		getGossipsub(ctx, h[0]),
-		getGossipsub(ctx, h[1], WithDirectPeers([]peer.AddrInfo{peer.AddrInfo{h[2].ID(), h[2].Addrs()}})),
-		getGossipsub(ctx, h[2], WithDirectPeers([]peer.AddrInfo{peer.AddrInfo{h[1].ID(), h[1].Addrs()}})),
+		getGossipsub(ctx, h[0], WithDirectConnectTicks(2)),
+		getGossipsub(ctx, h[1], WithDirectPeers([]peer.AddrInfo{peer.AddrInfo{h[2].ID(), h[2].Addrs()}}), WithDirectConnectTicks(2)),
+		getGossipsub(ctx, h[2], WithDirectPeers([]peer.AddrInfo{peer.AddrInfo{h[1].ID(), h[1].Addrs()}}), WithDirectConnectTicks(2)),
 	}
 
 	connect(t, h[0], h[1])


### PR DESCRIPTION
In [drand](https://github.com/drand/drand) we have a gossipsub relay to allow users to subscribe to getting random values over pubsub. We want to support pure gossip relays who relay from a relay. For this we need direct peering agreements and want to mitigate the possibility of "missing" randomness messages by ensuring the direct connect ticks period is less than the period between randomness messages.

This PR simply adds a new functional option allowing us to set the direct connect ticks value without modifying the global variable.