### PR TITLE
drop warning about failure to open stream to a debug log

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -71,7 +71,7 @@ func (p *PubSub) handleNewStream(s network.Stream) {
 func (p *PubSub) handleNewPeer(ctx context.Context, pid peer.ID, outgoing <-chan *RPC) {
 	s, err := p.host.NewStream(p.ctx, pid, p.rt.Protocols()...)
 	if err != nil {
-		log.Warn("opening new stream to peer: ", err, pid)
+		log.Debug("opening new stream to peer: ", err, pid)
 
 		var ch chan peer.ID
 		if err == ms.ErrNotSupported {


### PR DESCRIPTION
This shows up all the time in filecoin as there are a bunch of peers connected to the network that don't support pubsub.