### PR TITLE
Define a public error for sub.Next() on a cancelled subscription

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -31,7 +31,7 @@ var (
 
 	// ErrSubscriptionCancelled may be returned when a subscription Next() is called after the
 	// subscription has been cancelled.
-	ErrSubscriptionCancelled = errors.New("subscription cancelled by calling sub.Cancel()")
+	ErrSubscriptionCancelled = errors.New("subscription cancelled")
 )
 
 var log = logging.Logger("pubsub")

--- a/pubsub.go
+++ b/pubsub.go
@@ -28,6 +28,10 @@ const DefaultMaxMessageSize = 1 << 20
 
 var (
 	TimeCacheDuration = 120 * time.Second
+
+	// ErrSubscriptionCancelled may be returned when a subscription Next() is called after the
+	// subscription has been cancelled.
+	ErrSubscriptionCancelled = errors.New("subscription cancelled by calling sub.Cancel()")
 )
 
 var log = logging.Logger("pubsub")
@@ -629,7 +633,7 @@ func (p *PubSub) handleRemoveSubscription(sub *Subscription) {
 		return
 	}
 
-	sub.err = fmt.Errorf("subscription cancelled by calling sub.Cancel()")
+	sub.err = ErrSubscriptionCancelled
 	sub.close()
 	delete(subs, sub)
 


### PR DESCRIPTION
We find this error happens often in Prysm with our frequently changing pubsub topic subscriptions. We would like to ignore this error by referencing the publicly defined ErrSubscriptionCancelled.

Context: https://github.com/prysmaticlabs/prysm/issues/6449
