### PR TITLE
Signing policy + optional Signature, From and Seqno

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -140,9 +140,9 @@ type PubSub struct {
 	// function used to compute the ID for a message
 	msgID MsgIdFunction
 
-	// key for signing messages; nil when signing is disabled (default for now)
+	// key for signing messages; nil when signing is disabled
 	signKey crypto.PrivKey
-	// source ID for signed messages; corresponds to signKey
+	// source ID for signed messages; corresponds to signKey, empty when signing is disabled
 	signID peer.ID
 	// strict mode rejects all unsigned messages prior to validation
 	signPolicy MessageSignaturePolicy

--- a/pubsub.go
+++ b/pubsub.go
@@ -980,6 +980,17 @@ func (p *PubSub) pushMsg(msg *Message) {
 				p.tracer.RejectMessage(msg, rejectUnexpectedSignature)
 				return
 			}
+			// If we are expecting signed messages, and not authoring messages,
+			// then do no accept seq numbers, from data, or key data.
+			// The default msgID function still relies on Seqno and From,
+			// but is not used if we are not authoring messages ourselves.
+			if p.signID == "" {
+				if msg.Seqno != nil || msg.From != nil || msg.Key != nil {
+					log.Debugf("dropping message with unexpected auth info from %s", src)
+					p.tracer.RejectMessage(msg, rejectUnexpectedAuthInfo)
+					return
+				}
+			}
 		}
 	}
 

--- a/pubsub.go
+++ b/pubsub.go
@@ -142,7 +142,8 @@ type PubSub struct {
 
 	// key for signing messages; nil when signing is disabled
 	signKey crypto.PrivKey
-	// source ID for signed messages; corresponds to signKey, empty when signing is disabled
+	// source ID for signed messages; corresponds to signKey, empty when signing is disabled.
+	// If empty, the author and seq-nr are completely omitted from the messages.
 	signID peer.ID
 	// strict mode rejects all unsigned messages prior to validation
 	signPolicy MessageSignaturePolicy
@@ -345,7 +346,8 @@ func WithMessageAuthor(author peer.ID) Option {
 	}
 }
 
-// WithNoAuthor omits the author data of pubsub messages, and disables the use of signatures.
+// WithNoAuthor omits the author and seq-number data of messages, and disables the use of signatures.
+// Not recommended to use with the default message ID function, see WithMessageIdFn.
 func WithNoAuthor() Option {
 	return func(p *PubSub) error {
 		p.signID = ""

--- a/score.go
+++ b/score.go
@@ -572,6 +572,8 @@ func (ps *peerScore) RejectMessage(msg *Message, reason string) {
 		fallthrough
 	case rejectUnexpectedSignature:
 		fallthrough
+	case rejectUnexpectedAuthInfo:
+		fallthrough
 	case rejectSelfOrigin:
 		ps.markInvalidMessageDelivery(msg.ReceivedFrom, msg)
 		return

--- a/score.go
+++ b/score.go
@@ -570,6 +570,8 @@ func (ps *peerScore) RejectMessage(msg *Message, reason string) {
 		fallthrough
 	case rejectInvalidSignature:
 		fallthrough
+	case rejectUnexpectedSignature:
+		fallthrough
 	case rejectSelfOrigin:
 		ps.markInvalidMessageDelivery(msg.ReceivedFrom, msg)
 		return

--- a/sign.go
+++ b/sign.go
@@ -9,6 +9,41 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
+// MessageSignaturePolicy describes if signatures are produced, expected, and/or verified.
+type MessageSignaturePolicy uint8
+
+// LaxSign and LaxNoSign are deprecated. In the future msgSigning and msgVerification can be unified.
+const (
+	// msgSigning is set when the locally produced messages must be signed
+	msgSigning MessageSignaturePolicy = 1 << iota
+	// msgVerification is set when external messages must be verfied
+	msgVerification
+)
+
+const (
+	// StrictSign produces signatures and expects and verifies incoming signatures
+	StrictSign = msgSigning | msgVerification
+	// StrictNoSign does not produce signatures and drops and penalises incoming messages that carry one
+	StrictNoSign = msgVerification
+	// LaxSign produces signatures and validates incoming signatures iff one is present
+	// Deprecated: it is recommend to either strictly enable, or strictly disable, signatures.
+	LaxSign = msgSigning
+	// LaxNoSign does not produce signatures and validates incoming signatures iff one is present
+	// Deprecated: it is recommend to either strictly enable, or strictly disable, signatures.
+	LaxNoSign = 0
+)
+
+// mustVerify is true when a message signature must be verified.
+// If signatures are not expected, verification checks if the signature is absent.
+func (policy MessageSignaturePolicy) mustVerify() bool {
+	return policy&msgVerification != 0
+}
+
+// mustSign is true when messages should be signed, and incoming messages are expected to have a signature.
+func (policy MessageSignaturePolicy) mustSign() bool {
+	return policy&msgSigning != 0
+}
+
 const SignPrefix = "libp2p-pubsub:"
 
 func verifyMessageSignature(m *pb.Message) error {

--- a/tracer.go
+++ b/tracer.go
@@ -29,6 +29,7 @@ const (
 	rejectBlacklstedPeer      = "blacklisted peer"
 	rejectBlacklistedSource   = "blacklisted source"
 	rejectMissingSignature    = "missing signature"
+	rejectUnexpectedSignature = "unexpected signature"
 	rejectInvalidSignature    = "invalid signature"
 	rejectValidationQueueFull = "validation queue full"
 	rejectValidationThrottled = "validation throttled"

--- a/tracer.go
+++ b/tracer.go
@@ -30,6 +30,7 @@ const (
 	rejectBlacklistedSource   = "blacklisted source"
 	rejectMissingSignature    = "missing signature"
 	rejectUnexpectedSignature = "unexpected signature"
+	rejectUnexpectedAuthInfo  = "unexpected auth info"
 	rejectInvalidSignature    = "invalid signature"
 	rejectValidationQueueFull = "validation queue full"
 	rejectValidationThrottled = "validation throttled"

--- a/validation.go
+++ b/validation.go
@@ -241,6 +241,8 @@ func (v *validation) validateWorker() {
 // signature validation is performed synchronously, while user validators are invoked
 // asynchronously, throttled by the global validation throttle.
 func (v *validation) validate(vals []*topicVal, src peer.ID, msg *Message) {
+	// If signature verification is enabled, but signing is disabled,
+	// the Signature is required to be nil upon receiving the message in PubSub.pushMsg.
 	if msg.Signature != nil {
 		if !v.validateSignature(msg) {
 			log.Warnf("message signature validation failed; dropping message from %s", src)


### PR DESCRIPTION
This PR proposes new non-breaking PubSub options, to force stricter validation (avoid hypothethical network split), and avoid privacy problems in Eth2.

### Why

#### Privacy

The current gossip message ID is purely based on a hash of the contents, but it is still wrapped in a protobuf that carries `From`, `Seqno` and `Signature`.
The `From` and `Seqno` affect privacy: we don't need, or want, the original source of the message to be known. Currently, I believe that if messages are not re-published,
but propagated, that at least in the Go implementation these details remain in the gossip message.

While `From` is problematic (and previously known to be, just not fixed by anyone), `Seqno` alone is also problematic, since (in Go at least) it is initialized as nanosecond time of the node, and then only increments by 1. Because of the slow non-random increase on top of a big number, it's effectively a unique identifier of the origin, embedded in every message.
This could be used to quickly correlate messages, and narrow down which validators (based on message contents) run on which nodes.

#### Network split

The "Signature" is not really used, and empty. However, the Go implementation seems to validate it anyway, if it is non-empty.
Now other gossip implementations don't use it at all, or have a stalled PR open that implements similar behavior.
In our case, the signature is dangerous, because it can make different nodes mislike eachother:
- attacker sends message to A with bad signature.
- A doesn't verify signature
- A propagates to B
- B does verify the signature (since it's a non-empty field)
- B recognizes it as bad
- B decreases score of A, or outright bans/kicks A.

### Changes

Loosely based on discussion with @raulk:
- Introduce a `MessageSignaturePolicy` enum:
  ```golang
	// MessageSignaturePolicy describes if signatures are produced, expected, and/or verified.
	type MessageSignaturePolicy uint8
	
	// LaxSign and LaxNoSign are deprecated. In the future msgSigning and msgVerification can be unified.
	const (
		// msgSigning is set when the locally produced messages must be signed
		msgSigning MessageSignaturePolicy = 1 << iota
		// msgVerification is set when external messages must be verfied
		msgVerification
	)
	
	const (
		// StrictSign produces signatures and expects and verifies incoming signatures
		StrictSign = msgSigning | msgVerification
		// StrictNoSign does not produce signatures and drops and penalises incoming messages that carry one
		StrictNoSign = msgVerification
		// LaxSign produces signatures and validates incoming signatures iff one is present
		// Deprecated: it is recommend to either strictly enable, or strictly disable, signatures.
		LaxSign = msgSigning
		// LaxNoSign does not produce signatures and validates incoming signatures iff one is present
		// Deprecated: it is recommend to either strictly enable, or strictly disable, signatures.
		LaxNoSign = 0
	)
  ```
  - This preserves the option for older "Lax" behavior (which we may just want to remove entirely instead, if nobody relies on it)
- Update `WithStrictSignatureVerification` and `WithMessageSigning` to use the enum. This refactors out the logic away from the function, and into the constructor (but minimal). This avoids an unnecessary peerstore private-key lookup (getting the host private key when not using it as signing key)
- Introduce `WithMessageSignaturePolicy` to set the singing policy. I have doubts here, alternatively we could not deprecate `WithMessageSigning`, and eventually just say that the verification bool is always on. `not signing && verification` means that signatures must be nil to be valid.
- `pushMsg` now checks if the signature is nil, given the right circumstances (and added a trace for it)
  - It still defers signature verification till after the message-seen check. The nil check is cheap and simple enough to do immediately, mirroring the non-nil check if signing was turned on.
- New `WithNoAuthor` option, to not sign any messages, and omit any origin data (seq no and signer identity)
  - TODO: unfamiliar with `pb.Message` `Key` attribute, but might need to be omitted or handled as well?
  - whenever the `signID` is nil, the signing option is disabled: you can't be not signing while also requiring signatures. (matches previous "non sensical option" check in constructor). Instead of returning an error I am disabling the signing now. But maybe it should just error instead?
- Possible bugfix: `Message.From` should be set to the signer, not the current host (since they may be different, and potentially it is used for signature checking via key extraction, unless `Key` is set?).

Any feedback welcome, I can make changes, or change the approach.