### PR TITLE
Add warning about messageIDs

### DIFF
--- a/pb/rpc.proto
+++ b/pb/rpc.proto
@@ -32,10 +32,12 @@ message ControlMessage {
 
 message ControlIHave {
 	optional string topicID = 1;
+	// implementors from other languages should use bytes here - go protobuf emits invalid utf8 strings
 	repeated string messageIDs = 2;
 }
 
 message ControlIWant {
+	// implementors from other languages should use bytes here - go protobuf emits invalid utf8 strings
 	repeated string messageIDs = 1;
 }
 


### PR DESCRIPTION
See https://github.com/libp2p/specs/pull/285 and https://github.com/libp2p/go-libp2p-pubsub/issues/361

The problem is that many people implementing a protocol will not look at the specs, but grab the proto definition from the most mature impl, which is go-libp2p. But most languages, including rust, produce protobuf that rejects non-utf8 strings, leading to issues like https://github.com/libp2p/rust-libp2p/issues/1671 .

Ideally, in the long term this should be changed to bytes here as well. Bytes is just the better choice for an opaque id, where you might want to use compact random data and/or hashes.