### PR TITLE
Add api for dynamically setting topic score parameters

### DIFF
--- a/score.go
+++ b/score.go
@@ -182,9 +182,11 @@ func newPeerScore(params *PeerScoreParams) *peerScore {
 	}
 }
 
-// update interface
+// SetTopicScoreParams sets new score parameters for a topic.
+// If the topic previously had parameters and the parameters are lowering delivery caps,
+// then the score counters are recapped appropriately.
+// Note: assumes that the topic score parameters have already been validated
 func (ps *peerScore) SetTopicScoreParams(topic string, p *TopicScoreParams) error {
-	// Note: assumes that the topic score parameters have already been validated
 	ps.Lock()
 	defer ps.Unlock()
 

--- a/score_test.go
+++ b/score_test.go
@@ -842,7 +842,7 @@ func TestScoreRetention(t *testing.T) {
 	}
 }
 
-func TestScoreResetTopicParams(t *testing.T) {
+func TestScoreRecapTopicParams(t *testing.T) {
 	// Create parameters with reasonable default values
 	mytopic := "mytopic"
 	params := &PeerScoreParams{


### PR DESCRIPTION
Closes #346 

Adds a `SetScoreParams` to Topic so that we can dynamically set topic score parameters.