### PR TITLE
add behaviour penalty threshold

### DIFF
--- a/score.go
+++ b/score.go
@@ -274,8 +274,11 @@ func (ps *peerScore) score(p peer.ID) float64 {
 	score += p6 * ps.params.IPColocationFactorWeight
 
 	// P7: behavioural pattern penalty
-	p7 := pstats.behaviourPenalty * pstats.behaviourPenalty
-	score += p7 * ps.params.BehaviourPenaltyWeight
+	if pstats.behaviourPenalty > ps.params.BehaviourPenaltyThreshold {
+		excess := pstats.behaviourPenalty - ps.params.BehaviourPenaltyThreshold
+		p7 := excess * excess
+		score += p7 * ps.params.BehaviourPenaltyWeight
+	}
 
 	return score
 }

--- a/score_params.go
+++ b/score_params.go
@@ -79,9 +79,10 @@ type PeerScoreParams struct {
 	// - attempting to re-graft before the prune backoff time has elapsed.
 	// - not following up in IWANT requests for messages advertised with IHAVE.
 	//
-	// The value of the parameter is the square of the counter, which decays with  BehaviourPenaltyDecay.
+	// The value of the parameter is the square of the counter over the threshold, which decays with
+	// BehaviourPenaltyDecay.
 	// The weight of the parameter MUST be negative (or zero to disable).
-	BehaviourPenaltyWeight, BehaviourPenaltyDecay float64
+	BehaviourPenaltyWeight, BehaviourPenaltyThreshold, BehaviourPenaltyDecay float64
 
 	// the decay interval for parameter counters.
 	DecayInterval time.Duration
@@ -178,6 +179,9 @@ func (p *PeerScoreParams) validate() error {
 	}
 	if p.BehaviourPenaltyWeight != 0 && (p.BehaviourPenaltyDecay <= 0 || p.BehaviourPenaltyDecay >= 1) {
 		return fmt.Errorf("invalid BehaviourPenaltyDecay; must be between 0 and 1")
+	}
+	if p.BehaviourPenaltyThreshold < 0 {
+		return fmt.Errorf("invalid BehaviourPenaltyThreshold; must be >= 0")
 	}
 
 	// check the decay parameters


### PR DESCRIPTION
Adds a (optional) threshold for behaviour penalties, above which it activates.
This is similar to the IPColocation threshold.
Behaviour is unchanged if the threshold is unset (0).

Rationale: it has been observed that some overloaded lotus nodes fail to to follow up to IWANT requests; this threshold allows us to reduce the impact and only penalize the peer if the misbehaviour is persistent.
