### PR TITLE
don't apply penalty in self origin rejections

### DIFF
--- a/gossip_tracer.go
+++ b/gossip_tracer.go
@@ -111,8 +111,6 @@ func (gt *gossipTracer) RejectMessage(msg *Message, reason string) {
 		return
 	case rejectInvalidSignature:
 		return
-	case rejectSelfOrigin:
-		return
 	}
 
 	mid := gt.msgID(msg.Message)


### PR DESCRIPTION
It's possible to advertise a message with out of sync seen caches and end up sending a self-origin message; we shouldn't apply a behaviour penalty in this case.
This has been observed to happen in lotus.