### PR TITLE
Random Early Drop for overloaded validation queue

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+  annotations: false

--- a/floodsub.go
+++ b/floodsub.go
@@ -67,8 +67,8 @@ func (fs *FloodSubRouter) EnoughPeers(topic string, suggested int) bool {
 	return false
 }
 
-func (fs *FloodSubRouter) AcceptFrom(peer.ID) bool {
-	return true
+func (fs *FloodSubRouter) AcceptFrom(peer.ID) AcceptStatus {
+	return AcceptAll
 }
 
 func (fs *FloodSubRouter) HandleRPC(rpc *RPC) {}

--- a/gossip_tracer.go
+++ b/gossip_tracer.go
@@ -14,8 +14,14 @@ import (
 // The tracking of promises is probabilistic to avoid using too much memory.
 type gossipTracer struct {
 	sync.Mutex
-	msgID        MsgIdFunction
-	promises     map[string]map[peer.ID]time.Time
+
+	msgID MsgIdFunction
+
+	// promises for messages by message ID; for each message tracked, we track the promise
+	// expiration time for each peer.
+	promises map[string]map[peer.ID]time.Time
+	// promises for each peer; for each peer, we track the promised message IDs.
+	// this index allows us to quickly void promises when a peer is throttled.
 	peerPromises map[peer.ID]map[string]struct{}
 }
 

--- a/gossip_tracer_test.go
+++ b/gossip_tracer_test.go
@@ -21,6 +21,7 @@ func TestBrokenPromises(t *testing.T) {
 
 	peerA := peer.ID("A")
 	peerB := peer.ID("B")
+	peerC := peer.ID("C")
 
 	var msgs []*pb.Message
 	var mids []string
@@ -34,12 +35,16 @@ func TestBrokenPromises(t *testing.T) {
 
 	gt.AddPromise(peerA, mids)
 	gt.AddPromise(peerB, mids)
+	gt.AddPromise(peerC, mids)
 
 	// no broken promises yet
 	brokenPromises := gt.GetBrokenPromises()
 	if brokenPromises != nil {
 		t.Fatal("expected no broken promises")
 	}
+
+	// throttle one of the peers to save his promises
+	gt.ThrottlePeer(peerC)
 
 	// make promises break
 	time.Sleep(GossipSubIWantFollowupTime + 10*time.Millisecond)

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -505,9 +505,18 @@ func (gs *GossipSubRouter) EnoughPeers(topic string, suggested int) bool {
 	return false
 }
 
-func (gs *GossipSubRouter) AcceptFrom(p peer.ID) bool {
+func (gs *GossipSubRouter) AcceptFrom(p peer.ID) AcceptStatus {
 	_, direct := gs.direct[p]
-	return direct || gs.score.Score(p) >= gs.graylistThreshold
+	if direct {
+		return AcceptAll
+	}
+
+	if gs.score.Score(p) < gs.graylistThreshold {
+		return AcceptNone
+	}
+
+	// TODO throttle tracking and reaction
+	return AcceptAll
 }
 
 func (gs *GossipSubRouter) HandleRPC(rpc *RPC) {

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -347,6 +347,7 @@ type GossipSubRouter struct {
 	score        *peerScore
 	gossipTracer *gossipTracer
 	tagTracer    *tagTracer
+	gate         *peerGater
 
 	// whether PX is enabled; this should be enabled in bootstrappers and other well connected/trusted
 	// nodes.
@@ -515,8 +516,7 @@ func (gs *GossipSubRouter) AcceptFrom(p peer.ID) AcceptStatus {
 		return AcceptNone
 	}
 
-	// TODO throttle tracking and reaction
-	return AcceptAll
+	return gs.gate.AcceptFrom(p)
 }
 
 func (gs *GossipSubRouter) HandleRPC(rpc *RPC) {

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -23,7 +23,7 @@ var (
 	DefaultPeerGaterIgnoreWeight    = 1.0
 	DefaultPeerGaterRejectWeight    = 4.0
 	DefaultPeerGaterThreshold       = 0.33
-	DefaultPeerGaterGlobalDecay     = ScoreParameterDecay(10 * time.Minute)
+	DefaultPeerGaterGlobalDecay     = ScoreParameterDecay(2 * time.Minute)
 	DefaultPeerGaterSourceDecay     = ScoreParameterDecay(time.Hour)
 )
 

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -62,7 +62,11 @@ func WithPeerGater(threshold, decay float64) Option {
 }
 
 func newPeerGater(ctx context.Context, threshold, decay float64) *peerGater {
-	pg := &peerGater{threshold: threshold, decay: decay}
+	pg := &peerGater{
+		threshold: threshold,
+		decay:     decay,
+		stats:     make(map[peer.ID]*peerGaterStats),
+	}
 	go pg.background(ctx)
 	return pg
 }

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -233,3 +233,4 @@ func (pg *peerGater) RejectMessage(msg *Message, reason string) {
 }
 
 func (pg *peerGater) DuplicateMessage(msg *Message) {}
+func (pg *peerGater) ThrottlePeer(p peer.ID)        {}

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -216,7 +216,7 @@ func (pg *peerGater) AcceptFrom(p peer.ID) AcceptStatus {
 
 	st := pg.getPeerStats(p)
 
-	total := st.deliver + 0.5*st.duplicate + st.ignore + 2*st.reject
+	total := st.deliver + 0.25*st.duplicate + st.ignore + 4*st.reject
 	if total == 0 {
 		return AcceptAll
 	}

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -1,25 +1,50 @@
 package pubsub
 
 import (
+	"context"
 	"fmt"
+	"math/rand"
+	"sync"
+	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
 )
 
+var PeerGaterRetainStats = 6 * time.Hour
+var PeerGaterQuiet = time.Minute
+
 type peerGater struct {
+	sync.Mutex
+
+	threshold, decay   float64
+	validate, throttle float64
+
+	lastThrottle time.Time
+
+	stats map[peer.ID]*peerGaterStats
+}
+
+type peerGaterStats struct {
+	connected bool
+	expire    time.Time
+
+	deliver, ignore, reject float64
 }
 
 // WithPeerGater is a gossipsub router option that enables reactive validation queue
 // management.
-func WithPeerGater() Option {
+// The threshold parameter is the threshold of throttled/validated messages before the gating
+// kicks in.
+// The decay parameter is the (linear) decay of counters per second.
+func WithPeerGater(threshold, decay float64) Option {
 	return func(ps *PubSub) error {
 		gs, ok := ps.rt.(*GossipSubRouter)
 		if !ok {
 			return fmt.Errorf("pubsub router is not gossipsub")
 		}
 
-		gs.gate = newPeerGater()
+		gs.gate = newPeerGater(ps.ctx, threshold, decay)
 
 		// hook the tracer
 		if ps.tracer != nil {
@@ -36,8 +61,71 @@ func WithPeerGater() Option {
 	}
 }
 
-func newPeerGater() *peerGater {
-	return &peerGater{}
+func newPeerGater(ctx context.Context, threshold, decay float64) *peerGater {
+	pg := &peerGater{threshold: threshold, decay: decay}
+	go pg.background(ctx)
+	return pg
+}
+
+func (pg *peerGater) background(ctx context.Context) {
+	tick := time.NewTicker(DefaultDecayInterval)
+
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-tick.C:
+			pg.decayStats()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (pg *peerGater) decayStats() {
+	pg.Lock()
+	defer pg.Unlock()
+
+	pg.validate *= pg.decay
+	if pg.validate < DefaultDecayToZero {
+		pg.validate = 0
+	}
+
+	pg.throttle *= pg.throttle
+	if pg.throttle < DefaultDecayToZero {
+		pg.throttle = 0
+	}
+
+	now := time.Now()
+	for p, st := range pg.stats {
+		if st.connected {
+			st.deliver *= pg.decay
+			if st.deliver < DefaultDecayToZero {
+				st.deliver = 0
+			}
+
+			st.ignore *= pg.decay
+			if st.ignore < DefaultDecayToZero {
+				st.ignore = 0
+			}
+
+			st.reject *= pg.decay
+			if st.reject < DefaultDecayToZero {
+				st.reject = 0
+			}
+		} else if st.expire.Before(now) {
+			delete(pg.stats, p)
+		}
+	}
+}
+
+func (pg *peerGater) getPeerStats(p peer.ID) *peerGaterStats {
+	st, ok := pg.stats[p]
+	if !ok {
+		st = &peerGaterStats{}
+		pg.stats[p] = st
+	}
+	return st
 }
 
 func (pg *peerGater) AcceptFrom(p peer.ID) AcceptStatus {
@@ -45,16 +133,103 @@ func (pg *peerGater) AcceptFrom(p peer.ID) AcceptStatus {
 		return AcceptAll
 	}
 
-	return AcceptAll
+	pg.Lock()
+	defer pg.Unlock()
+
+	if time.Since(pg.lastThrottle) > PeerGaterQuiet {
+		return AcceptAll
+	}
+
+	if pg.throttle == 0 {
+		return AcceptAll
+	}
+
+	if pg.validate != 0 && pg.throttle/pg.validate < pg.threshold {
+		return AcceptAll
+	}
+
+	st := pg.getPeerStats(p)
+
+	total := st.deliver + st.ignore + st.reject
+	if total == 0 {
+		return AcceptAll
+	}
+
+	// we make a randomized decision based on the goodput of the peer
+	goodput := st.deliver / total
+	if rand.Float64() < goodput {
+		return AcceptAll
+	}
+
+	log.Debugf("throttling peer %s with goodput %f", p, goodput)
+	return AcceptControl
 }
 
-func (pg *peerGater) AddPeer(p peer.ID, proto protocol.ID)      {}
-func (pg *peerGater) RemovePeer(p peer.ID)                      {}
-func (pg *peerGater) Join(topic string)                         {}
-func (pg *peerGater) Leave(topic string)                        {}
-func (pg *peerGater) Graft(p peer.ID, topic string)             {}
-func (pg *peerGater) Prune(p peer.ID, topic string)             {}
-func (pg *peerGater) ValidateMessage(msg *Message)              {}
-func (pg *peerGater) DeliverMessage(msg *Message)               {}
-func (pg *peerGater) RejectMessage(msg *Message, reason string) {}
-func (pg *peerGater) DuplicateMessage(msg *Message)             {}
+func (pg *peerGater) AddPeer(p peer.ID, proto protocol.ID) {
+	pg.Lock()
+	defer pg.Unlock()
+
+	st := pg.getPeerStats(p)
+	st.connected = true
+	st.expire = time.Time{}
+}
+
+func (pg *peerGater) RemovePeer(p peer.ID) {
+	pg.Lock()
+	defer pg.Unlock()
+
+	st := pg.getPeerStats(p)
+	st.connected = false
+	st.expire = time.Now().Add(PeerGaterRetainStats)
+}
+
+func (pg *peerGater) Join(topic string)             {}
+func (pg *peerGater) Leave(topic string)            {}
+func (pg *peerGater) Graft(p peer.ID, topic string) {}
+func (pg *peerGater) Prune(p peer.ID, topic string) {}
+
+func (pg *peerGater) ValidateMessage(msg *Message) {
+	pg.Lock()
+	defer pg.Unlock()
+
+	pg.validate++
+}
+
+func (pg *peerGater) DeliverMessage(msg *Message) {
+	pg.Lock()
+	defer pg.Unlock()
+
+	st := pg.getPeerStats(msg.ReceivedFrom)
+	st.deliver++
+}
+
+func (pg *peerGater) RejectMessage(msg *Message, reason string) {
+	pg.Lock()
+	defer pg.Unlock()
+
+	switch reason {
+	case rejectValidationQueueFull:
+		fallthrough
+	case rejectValidationThrottled:
+		pg.lastThrottle = time.Now()
+		pg.throttle++
+
+	case rejectValidationIgnored:
+		st := pg.getPeerStats(msg.ReceivedFrom)
+		st.ignore++
+
+	case rejectMissingSignature:
+		fallthrough
+	case rejectUnexpectedSignature:
+		fallthrough
+	case rejectUnexpectedAuthInfo:
+		fallthrough
+	case rejectInvalidSignature:
+		fallthrough
+	case rejectValidationFailed:
+		st := pg.getPeerStats(msg.ReceivedFrom)
+		st.reject++
+	}
+}
+
+func (pg *peerGater) DuplicateMessage(msg *Message) {}

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -19,9 +19,9 @@ import (
 var (
 	DefaultPeerGaterRetainStats     = 6 * time.Hour
 	DefaultPeerGaterQuiet           = time.Minute
-	DefaultPeerGaterDuplicateWeight = 0.25
+	DefaultPeerGaterDuplicateWeight = 0.125
 	DefaultPeerGaterIgnoreWeight    = 1.0
-	DefaultPeerGaterRejectWeight    = 4.0
+	DefaultPeerGaterRejectWeight    = 16.0
 	DefaultPeerGaterThreshold       = 0.33
 	DefaultPeerGaterGlobalDecay     = ScoreParameterDecay(2 * time.Minute)
 	DefaultPeerGaterSourceDecay     = ScoreParameterDecay(time.Hour)

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -271,6 +271,7 @@ func (pg *peerGater) getPeerIP(p peer.ID) string {
 		remote := c.RemoteMultiaddr()
 		ip, err := manet.ToIP(remote)
 		if err != nil {
+			log.Warnf("error determining IP for remote peer in %s: %s", remote, err)
 			return "<unknown>"
 		}
 		return ip.String()

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -227,15 +227,7 @@ func (pg *peerGater) RejectMessage(msg *Message, reason string) {
 		st := pg.getPeerStats(msg.ReceivedFrom)
 		st.ignore++
 
-	case rejectMissingSignature:
-		fallthrough
-	case rejectUnexpectedSignature:
-		fallthrough
-	case rejectUnexpectedAuthInfo:
-		fallthrough
-	case rejectInvalidSignature:
-		fallthrough
-	case rejectValidationFailed:
+	default:
 		st := pg.getPeerStats(msg.ReceivedFrom)
 		st.reject++
 	}

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -165,12 +165,12 @@ func (pg *peerGater) AcceptFrom(p peer.ID) AcceptStatus {
 	}
 
 	// we make a randomized decision based on the goodput of the peer
-	goodput := st.deliver / total
-	if rand.Float64() < goodput {
+	threshold := (1 + st.deliver) / (1 + total)
+	if rand.Float64() < threshold {
 		return AcceptAll
 	}
 
-	log.Debugf("throttling peer %s with goodput %f", p, goodput)
+	log.Debugf("throttling peer %s with threshold %f", p, threshold)
 	return AcceptControl
 }
 

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -159,7 +159,7 @@ func (pg *peerGater) AcceptFrom(p peer.ID) AcceptStatus {
 
 	st := pg.getPeerStats(p)
 
-	total := st.deliver + st.duplicate + st.ignore + st.reject
+	total := st.deliver + 0.5*st.duplicate + st.ignore + 2*st.reject
 	if total == 0 {
 		return AcceptAll
 	}

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -1,0 +1,60 @@
+package pubsub
+
+import (
+	"fmt"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/protocol"
+)
+
+type peerGater struct {
+}
+
+// WithPeerGater is a gossipsub router option that enables reactive validation queue
+// management.
+func WithPeerGater() Option {
+	return func(ps *PubSub) error {
+		gs, ok := ps.rt.(*GossipSubRouter)
+		if !ok {
+			return fmt.Errorf("pubsub router is not gossipsub")
+		}
+
+		gs.gate = newPeerGater()
+
+		// hook the tracer
+		if ps.tracer != nil {
+			ps.tracer.internal = append(ps.tracer.internal, gs.gate)
+		} else {
+			ps.tracer = &pubsubTracer{
+				internal: []internalTracer{gs.gate},
+				pid:      ps.host.ID(),
+				msgID:    ps.msgID,
+			}
+		}
+
+		return nil
+	}
+}
+
+func newPeerGater() *peerGater {
+	return &peerGater{}
+}
+
+func (pg *peerGater) AcceptFrom(p peer.ID) AcceptStatus {
+	if pg == nil {
+		return AcceptAll
+	}
+
+	return AcceptAll
+}
+
+func (pg *peerGater) AddPeer(p peer.ID, proto protocol.ID)      {}
+func (pg *peerGater) RemovePeer(p peer.ID)                      {}
+func (pg *peerGater) Join(topic string)                         {}
+func (pg *peerGater) Leave(topic string)                        {}
+func (pg *peerGater) Graft(p peer.ID, topic string)             {}
+func (pg *peerGater) Prune(p peer.ID, topic string)             {}
+func (pg *peerGater) ValidateMessage(msg *Message)              {}
+func (pg *peerGater) DeliverMessage(msg *Message)               {}
+func (pg *peerGater) RejectMessage(msg *Message, reason string) {}
+func (pg *peerGater) DuplicateMessage(msg *Message)             {}

--- a/peer_gater_test.go
+++ b/peer_gater_test.go
@@ -15,7 +15,13 @@ func TestPeerGater(t *testing.T) {
 	peerA := peer.ID("A")
 	peerAip := "1.2.3.4"
 
-	pg := newPeerGater(ctx, nil, .1, .9)
+	params := NewPeerGaterParams(.1, .9)
+	err := params.validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pg := newPeerGater(ctx, nil, params)
 	pg.getIP = func(p peer.ID) string {
 		switch p {
 		case peerA:

--- a/peer_gater_test.go
+++ b/peer_gater_test.go
@@ -1,0 +1,88 @@
+package pubsub
+
+import (
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+func TestPeerGater(t *testing.T) {
+	pg := &peerGater{threshold: 0.1, decay: .9, stats: make(map[peer.ID]*peerGaterStats)}
+
+	peerA := peer.ID("A")
+	pg.AddPeer(peerA, "")
+
+	status := pg.AcceptFrom(peerA)
+	if status != AcceptAll {
+		t.Fatal("expected AcceptAll")
+	}
+
+	msg := &Message{ReceivedFrom: peerA}
+
+	pg.ValidateMessage(msg)
+	status = pg.AcceptFrom(peerA)
+	if status != AcceptAll {
+		t.Fatal("expected AcceptAll")
+	}
+
+	pg.RejectMessage(msg, rejectValidationQueueFull)
+	status = pg.AcceptFrom(peerA)
+	if status != AcceptAll {
+		t.Fatal("expected AcceptAll")
+	}
+
+	pg.RejectMessage(msg, rejectValidationThrottled)
+	status = pg.AcceptFrom(peerA)
+	if status != AcceptAll {
+		t.Fatal("expected AcceptAll")
+	}
+
+	pg.RejectMessage(msg, rejectValidationIgnored)
+	status = pg.AcceptFrom(peerA)
+	if status != AcceptControl {
+		t.Fatal("expected AcceptControl")
+	}
+
+	pg.RejectMessage(msg, rejectValidationFailed)
+	status = pg.AcceptFrom(peerA)
+	if status != AcceptControl {
+		t.Fatal("expected AcceptControl")
+	}
+
+	for i := 0; i < 100; i++ {
+		pg.DeliverMessage(msg)
+	}
+
+	accepted := false
+	for i := 0; !accepted && i < 1000; i++ {
+		status = pg.AcceptFrom(peerA)
+		if status == AcceptAll {
+			accepted = true
+		}
+	}
+	if !accepted {
+		t.Fatal("expected to accept at least once")
+	}
+
+	for i := 0; i < 100; i++ {
+		pg.decayStats()
+	}
+
+	status = pg.AcceptFrom(peerA)
+	if status != AcceptAll {
+		t.Fatal("expected AcceptAll")
+	}
+
+	pg.RemovePeer(peerA)
+	pg.stats[peerA].expire = time.Now()
+
+	time.Sleep(time.Millisecond)
+
+	pg.decayStats()
+
+	_, ok := pg.stats[peerA]
+	if ok {
+		t.Fatal("still have a stat record for peerA")
+	}
+}

--- a/peer_gater_test.go
+++ b/peer_gater_test.go
@@ -93,20 +93,29 @@ func TestPeerGater(t *testing.T) {
 	}
 
 	pg.RemovePeer(peerA)
+	pg.Lock()
 	_, ok := pg.peerStats[peerA]
+	pg.Unlock()
 	if ok {
 		t.Fatal("still have a stat record for peerA")
 	}
 
+	pg.Lock()
 	_, ok = pg.ipStats[peerAip]
+	pg.Unlock()
 	if !ok {
 		t.Fatal("expected to still have a stat record for peerA's ip")
 	}
 
+	pg.Lock()
 	pg.ipStats[peerAip].expire = time.Now()
+	pg.Unlock()
 
 	time.Sleep(2 * time.Second)
+
+	pg.Lock()
 	_, ok = pg.ipStats["1.2.3.4"]
+	pg.Unlock()
 	if ok {
 		t.Fatal("still have a stat record for peerA's ip")
 	}

--- a/peer_gater_test.go
+++ b/peer_gater_test.go
@@ -38,15 +38,19 @@ func TestPeerGater(t *testing.T) {
 		t.Fatal("expected AcceptAll")
 	}
 
-	pg.RejectMessage(msg, rejectValidationIgnored)
-	status = pg.AcceptFrom(peerA)
-	if status != AcceptControl {
-		t.Fatal("expected AcceptControl")
+	for i := 0; i < 100; i++ {
+		pg.RejectMessage(msg, rejectValidationIgnored)
+		pg.RejectMessage(msg, rejectValidationFailed)
 	}
 
-	pg.RejectMessage(msg, rejectValidationFailed)
-	status = pg.AcceptFrom(peerA)
-	if status != AcceptControl {
+	accepted := false
+	for i := 0; !accepted && i < 1000; i++ {
+		status = pg.AcceptFrom(peerA)
+		if status == AcceptControl {
+			accepted = true
+		}
+	}
+	if !accepted {
 		t.Fatal("expected AcceptControl")
 	}
 
@@ -54,7 +58,7 @@ func TestPeerGater(t *testing.T) {
 		pg.DeliverMessage(msg)
 	}
 
-	accepted := false
+	accepted = false
 	for i := 0; !accepted && i < 1000; i++ {
 		status = pg.AcceptFrom(peerA)
 		if status == AcceptAll {

--- a/peer_gater_test.go
+++ b/peer_gater_test.go
@@ -15,7 +15,7 @@ func TestPeerGater(t *testing.T) {
 	peerA := peer.ID("A")
 	peerAip := "1.2.3.4"
 
-	params := NewPeerGaterParams(.1, .9)
+	params := NewPeerGaterParams(.1, .9, .999)
 	err := params.validate()
 	if err != nil {
 		t.Fatal(err)

--- a/pubsub.go
+++ b/pubsub.go
@@ -943,6 +943,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 		if len(rpc.GetPublish()) > 0 {
 			log.Debugf("peer %s was throttled by router; ignoring %d payload messages", rpc.from, len(rpc.GetPublish()))
 		}
+		p.tracer.ThrottlePeer(rpc.from)
 
 	case AcceptAll:
 		for _, pmsg := range rpc.GetPublish() {

--- a/pubsub.go
+++ b/pubsub.go
@@ -188,7 +188,8 @@ type AcceptStatus int
 const (
 	// AcceptAll signals to accept the incoming RPC for full processing
 	AcceptNone AcceptStatus = iota
-	// AcceptControl signals to accept the incoming RPC only for control message processing
+	// AcceptControl signals to accept the incoming RPC only for control message processing by
+	// the router. Included payload messages will _not_ be pushed to the validation queue.
 	AcceptControl
 	// AcceptNone signals to drop the incoming RPC
 	AcceptAll

--- a/pubsub.go
+++ b/pubsub.go
@@ -936,18 +936,18 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 	// ask the router to vet the peer before commiting any processing resources
 	switch p.rt.AcceptFrom(rpc.from) {
 	case AcceptNone:
-		log.Debugf("received message from router graylisted peer %s; dropping RPC", rpc.from)
+		log.Debugf("received RPC from router graylisted peer %s; dropping RPC", rpc.from)
 		return
 
 	case AcceptControl:
 		if len(rpc.GetPublish()) > 0 {
-			log.Debugf("ignoring payload in message from peer %s", rpc.from)
+			log.Debugf("peer %s was throttled by router; ignoring %d payload messages", rpc.from, len(rpc.GetPublish()))
 		}
 
 	case AcceptAll:
 		for _, pmsg := range rpc.GetPublish() {
 			if !(p.subscribedToMsg(pmsg) || p.canRelayMsg(pmsg)) {
-				log.Debug("received message we didn't subscribe to; ignoring payload message")
+				log.Debug("received message in topic we didn't subscribe to; ignoring message")
 				continue
 			}
 

--- a/randomsub.go
+++ b/randomsub.go
@@ -90,8 +90,8 @@ func (rs *RandomSubRouter) EnoughPeers(topic string, suggested int) bool {
 	return false
 }
 
-func (rs *RandomSubRouter) AcceptFrom(peer.ID) bool {
-	return true
+func (rs *RandomSubRouter) AcceptFrom(peer.ID) AcceptStatus {
+	return AcceptAll
 }
 
 func (rs *RandomSubRouter) HandleRPC(rpc *RPC) {}
@@ -133,7 +133,7 @@ func (rs *RandomSubRouter) Publish(msg *Message) {
 		}
 		xpeers := peerMapToList(rspeers)
 		shufflePeers(xpeers)
-		xpeers = xpeers[:RandomSubD]
+		xpeers = xpeers[:target]
 		for _, p := range xpeers {
 			tosend[p] = struct{}{}
 		}

--- a/score.go
+++ b/score.go
@@ -749,6 +749,8 @@ func (ps *peerScore) DuplicateMessage(msg *Message) {
 	}
 }
 
+func (ps *peerScore) ThrottlePeer(p peer.ID) {}
+
 // message delivery records
 func (d *messageDeliveries) getRecord(id string) *deliveryRecord {
 	rec, ok := d.records[id]

--- a/tag_tracer.go
+++ b/tag_tracer.go
@@ -252,4 +252,5 @@ func (t *tagTracer) RejectMessage(msg *Message, reason string) {
 	}
 }
 
-func (t *tagTracer) RemovePeer(peer.ID) {}
+func (t *tagTracer) RemovePeer(peer.ID)      {}
+func (gt *tagTracer) ThrottlePeer(p peer.ID) {}

--- a/trace.go
+++ b/trace.go
@@ -26,6 +26,7 @@ type internalTracer interface {
 	DeliverMessage(msg *Message)
 	RejectMessage(msg *Message, reason string)
 	DuplicateMessage(msg *Message)
+	ThrottlePeer(p peer.ID)
 }
 
 // pubsub tracer details
@@ -463,4 +464,14 @@ func (t *pubsubTracer) Prune(p peer.ID, topic string) {
 	}
 
 	t.tracer.Trace(evt)
+}
+
+func (t *pubsubTracer) ThrottlePeer(p peer.ID) {
+	if t == nil {
+		return
+	}
+
+	for _, tr := range t.internal {
+		tr.ThrottlePeer(p)
+	}
 }


### PR DESCRIPTION
Introduces a new peer gater for gossipsub, which allows us to do random early drops when we are experiencing elevated validation throttling, because of elevated load or a spam attack targetting the validation queue.