### PR TITLE
Handle Multiple Graft Topics Correctly

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1550,7 +1550,12 @@ func (gs *GossipSubRouter) sendGraftPrune(tograft, toprune map[peer.ID][]string,
 	for p, topics := range tograft {
 		graft := make([]*pb.ControlGraft, 0, len(topics))
 		for _, topic := range topics {
-			graft = append(graft, &pb.ControlGraft{TopicID: &topic})
+			// copy topic string here since
+			// the reference to the string
+			// topic here changes with every
+			// iteration of the slice.
+			copiedID := topic
+			graft = append(graft, &pb.ControlGraft{TopicID: &copiedID})
 		}
 
 		var prune []*pb.ControlPrune

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1570,10 +1570,9 @@ func TestGossipsubPiggybackControl(t *testing.T) {
 func TestGossipsubMultipleGraftTopics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	hosts := getNetHosts(t, ctx, 2)
-
 	psubs := getGossipsubs(ctx, hosts)
-
 	sparseConnect(t, hosts)
 
 	time.Sleep(time.Second * 1)


### PR DESCRIPTION
**Background**

With every iteration of the heartbeat routine for a peer running gossipsub, it will ascertain whether it has enough peers in its mesh for a topic. If there are not enough peers it will retrieve the relevant peers and add them to its mesh. Doing this for the same peer for multiple topics, we can batch all the `GRAFT` messages for the different topics into a single RPC message. 

**Problem**

In `sendGraftPrune` while looping through all the topics to send a message out for, we take the pointer to string value of the topic and utilize that in our control message. Unfortunately in a loop that reference doesn't hold for each topic, instead changing for each iteration in a loop. So we instead end up referring to the last element in the original topic slice for all the `GRAFT` topic ids in our  new `ControlGraft` message. To illustrate this:

https://play.golang.org/p/1cPEh5fYIvx  

**Solution** 

The solution is simple where we copy each topic before referencing them, this mitigates the problem with the other topics being overwritten in the message. Also a regression test has been added to test this exact case. There maybe more cases like this in the repo but I couldn't find anything similar so far when I scanned though the code.