### PR TITLE
Add preconnected nodes to pubsub

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -32,3 +32,12 @@ func (p *PubSubNotif) Listen(n network.Network, _ ma.Multiaddr) {
 
 func (p *PubSubNotif) ListenClose(n network.Network, _ ma.Multiaddr) {
 }
+
+func (p *PubSubNotif) Initialize() {
+	for _, pr := range p.host.Network().Peers() {
+		select {
+		case p.newPeers <- pr:
+		case <-p.ctx.Done():
+		}
+	}
+}

--- a/pubsub.go
+++ b/pubsub.go
@@ -292,6 +292,8 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 
 	go ps.processLoop(ctx)
 
+	(*PubSubNotif)(ps).Initialize()
+
 	return ps, nil
 }
 


### PR DESCRIPTION
PubSub only tries to add peers to the set of pubsub nodes when they connect. This meant that peers that were already connected to the host (e.g. tests, multiple nodes on the same machine, an application waiting a while to start up pubsub, etc.) would not get treated as pubsub nodes.

This resolves that by simply adding the list of already connected peers to pubsub.

Note: PubSub still does not utilize `Identify` events to figure out if a peer supports one of the valid pubsub protocols or not, that other implementations of PubSub need to run a similar script instead of just toggling on and off support for a protocol like FloodSub.