### PR TITLE
Subnet whitelisting for IPColocation

### DIFF
--- a/score.go
+++ b/score.go
@@ -336,10 +336,20 @@ func (ps *peerScore) ipColocationFactor(p peer.ID) float64 {
 	}
 
 	var result float64
+loop:
 	for _, ip := range pstats.ips {
 		_, whitelisted := ps.params.IPColocationFactorWhitelist[ip]
 		if whitelisted {
 			continue
+		}
+
+		if len(ps.params.IPColocationFactorWhitelistSubnets) > 0 {
+			ipObj := net.ParseIP(ip)
+			for _, ipNet := range ps.params.IPColocationFactorWhitelistSubnets {
+				if ipNet.Contains(ipObj) {
+					continue loop
+				}
+			}
 		}
 
 		// P6 has a cliff (IPColocationFactorThreshold); it's only applied iff

--- a/score.go
+++ b/score.go
@@ -338,14 +338,9 @@ func (ps *peerScore) ipColocationFactor(p peer.ID) float64 {
 	var result float64
 loop:
 	for _, ip := range pstats.ips {
-		_, whitelisted := ps.params.IPColocationFactorWhitelist[ip]
-		if whitelisted {
-			continue
-		}
-
-		if len(ps.params.IPColocationFactorWhitelistSubnets) > 0 {
+		if len(ps.params.IPColocationFactorWhitelist) > 0 {
 			ipObj := net.ParseIP(ip)
-			for _, ipNet := range ps.params.IPColocationFactorWhitelistSubnets {
+			for _, ipNet := range ps.params.IPColocationFactorWhitelist {
 				if ipNet.Contains(ipObj) {
 					continue loop
 				}

--- a/score_params.go
+++ b/score_params.go
@@ -3,6 +3,7 @@ package pubsub
 import (
 	"fmt"
 	"math"
+	"net"
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -69,9 +70,10 @@ type PeerScoreParams struct {
 	// The weight of the parameter MUST be negative, unless you want to disable for testing.
 	// Note: In order to simulate many IPs in a managable manner when testing, you can set the weight to 0
 	//       thus disabling the IP colocation penalty.
-	IPColocationFactorWeight    float64
-	IPColocationFactorThreshold int
-	IPColocationFactorWhitelist map[string]struct{}
+	IPColocationFactorWeight           float64
+	IPColocationFactorThreshold        int
+	IPColocationFactorWhitelist        map[string]struct{}
+	IPColocationFactorWhitelistSubnets []*net.IPNet
 
 	// P7: behavioural pattern penalties.
 	// This parameter has an associated counter which tracks misbehaviour as detected by the

--- a/score_params.go
+++ b/score_params.go
@@ -70,10 +70,9 @@ type PeerScoreParams struct {
 	// The weight of the parameter MUST be negative, unless you want to disable for testing.
 	// Note: In order to simulate many IPs in a managable manner when testing, you can set the weight to 0
 	//       thus disabling the IP colocation penalty.
-	IPColocationFactorWeight           float64
-	IPColocationFactorThreshold        int
-	IPColocationFactorWhitelist        map[string]struct{}
-	IPColocationFactorWhitelistSubnets []*net.IPNet
+	IPColocationFactorWeight    float64
+	IPColocationFactorThreshold int
+	IPColocationFactorWhitelist []*net.IPNet
 
 	// P7: behavioural pattern penalties.
 	// This parameter has an associated counter which tracks misbehaviour as detected by the

--- a/score_test.go
+++ b/score_test.go
@@ -743,7 +743,7 @@ func TestScoreIPColocation(t *testing.T) {
 	}
 }
 
-func TestScoreIPColocationWhitelistSubnet(t *testing.T) {
+func TestScoreIPColocationWhitelist(t *testing.T) {
 	// Create parameters with reasonable default values
 	mytopic := "mytopic"
 
@@ -753,11 +753,11 @@ func TestScoreIPColocationWhitelistSubnet(t *testing.T) {
 	}
 
 	params := &PeerScoreParams{
-		AppSpecificScore:                   func(peer.ID) float64 { return 0 },
-		IPColocationFactorThreshold:        1,
-		IPColocationFactorWeight:           -1,
-		IPColocationFactorWhitelistSubnets: []*net.IPNet{ipNet},
-		Topics:                             make(map[string]*TopicScoreParams),
+		AppSpecificScore:            func(peer.ID) float64 { return 0 },
+		IPColocationFactorThreshold: 1,
+		IPColocationFactorWeight:    -1,
+		IPColocationFactorWhitelist: []*net.IPNet{ipNet},
+		Topics:                      make(map[string]*TopicScoreParams),
 	}
 
 	peerA := peer.ID("A")


### PR DESCRIPTION
This changes the IP whitelist to support subnets when considering the IPColocation factor.

Note: this is a (very minor) breaking change, but I don't see the reason of keeping the ip whitelist when we have subnets.

cc @travisperson 