### PR TITLE
fix: avoid validating messages from ourself before sending

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -1045,7 +1045,7 @@ func (p *PubSub) pushMsg(msg *Message) {
 		return
 	}
 
-	if !p.val.Push(src, msg) {
+	if src != self && !p.val.Push(src, msg) {
 		return
 	}
 


### PR DESCRIPTION
The potential downside is that we could get blocked for sending invalid messages. But the upside is that outbound messages:

* Don't incur a validation cost.
* Can't get dropped because our validation queue is overloaded.

fixes #398