### PR TITLE
Strengthen Validation Of Gossip Scoring Parameters

### DIFF
--- a/score_params.go
+++ b/score_params.go
@@ -32,20 +32,20 @@ type PeerScoreThresholds struct {
 }
 
 func (p *PeerScoreThresholds) validate() error {
-	if p.GossipThreshold > 0 {
-		return fmt.Errorf("invalid gossip threshold; it must be <= 0")
+	if p.GossipThreshold > 0 || isInvalidNumber(p.GossipThreshold) {
+		return fmt.Errorf("invalid gossip threshold; it must be <= 0 and a valid number")
 	}
-	if p.PublishThreshold > 0 || p.PublishThreshold > p.GossipThreshold {
-		return fmt.Errorf("invalid publish threshold; it must be <= 0 and <= gossip threshold")
+	if p.PublishThreshold > 0 || p.PublishThreshold > p.GossipThreshold || isInvalidNumber(p.PublishThreshold) {
+		return fmt.Errorf("invalid publish threshold; it must be <= 0 and <= gossip threshold and a valid number")
 	}
-	if p.GraylistThreshold > 0 || p.GraylistThreshold > p.PublishThreshold {
-		return fmt.Errorf("invalid graylist threshold; it must be <= 0 and <= publish threshold")
+	if p.GraylistThreshold > 0 || p.GraylistThreshold > p.PublishThreshold || isInvalidNumber(p.GraylistThreshold) {
+		return fmt.Errorf("invalid graylist threshold; it must be <= 0 and <= publish threshold and a valid number")
 	}
-	if p.AcceptPXThreshold < 0 {
-		return fmt.Errorf("invalid accept PX threshold; it must be >= 0")
+	if p.AcceptPXThreshold < 0 || isInvalidNumber(p.AcceptPXThreshold) {
+		return fmt.Errorf("invalid accept PX threshold; it must be >= 0 and a valid number")
 	}
-	if p.OpportunisticGraftThreshold < 0 {
-		return fmt.Errorf("invalid opportunistic grafting threshold; it must be >= 0")
+	if p.OpportunisticGraftThreshold < 0 || isInvalidNumber(p.OpportunisticGraftThreshold) {
+		return fmt.Errorf("invalid opportunistic grafting threshold; it must be >= 0 and a valid number")
 	}
 	return nil
 }

--- a/score_params.go
+++ b/score_params.go
@@ -229,7 +229,7 @@ func (p *TopicScoreParams) validate() error {
 	}
 
 	// check P3
-	if p.MeshMessageDeliveriesWeight > 0 || isInvalidNumber(p.MeshFailurePenaltyWeight) {
+	if p.MeshMessageDeliveriesWeight > 0 || isInvalidNumber(p.MeshMessageDeliveriesWeight) {
 		return fmt.Errorf("invalid MeshMessageDeliveriesWeight; must be negative (or 0 to disable) and a valid number")
 	}
 	if p.MeshMessageDeliveriesWeight != 0 && (p.MeshMessageDeliveriesDecay <= 0 || p.MeshMessageDeliveriesDecay >= 1 || isInvalidNumber(p.MeshMessageDeliveriesDecay)) {

--- a/score_params.go
+++ b/score_params.go
@@ -157,8 +157,8 @@ func (p *PeerScoreParams) validate() error {
 	}
 
 	// check that the topic score is 0 or something positive
-	if p.TopicScoreCap < 0 {
-		return fmt.Errorf("invalid topic score cap; must be positive (or 0 for no cap)")
+	if p.TopicScoreCap < 0 || isInvalidNumber(p.TopicScoreCap) {
+		return fmt.Errorf("invalid topic score cap; must be positive (or 0 for no cap) and a valid number")
 	}
 
 	// check that we have an app specific score; the weight can be anything (but expected positive)
@@ -167,29 +167,29 @@ func (p *PeerScoreParams) validate() error {
 	}
 
 	// check the IP colocation factor
-	if p.IPColocationFactorWeight > 0 {
-		return fmt.Errorf("invalid IPColocationFactorWeight; must be negative (or 0 to disable)")
+	if p.IPColocationFactorWeight > 0 || isInvalidNumber(p.IPColocationFactorWeight) {
+		return fmt.Errorf("invalid IPColocationFactorWeight; must be negative (or 0 to disable) and a valid number")
 	}
 	if p.IPColocationFactorWeight != 0 && p.IPColocationFactorThreshold < 1 {
 		return fmt.Errorf("invalid IPColocationFactorThreshold; must be at least 1")
 	}
 
 	// check the behaviour penalty
-	if p.BehaviourPenaltyWeight > 0 {
-		return fmt.Errorf("invalid BehaviourPenaltyWeight; must be negative (or 0 to disable)")
+	if p.BehaviourPenaltyWeight > 0 || isInvalidNumber(p.BehaviourPenaltyWeight) {
+		return fmt.Errorf("invalid BehaviourPenaltyWeight; must be negative (or 0 to disable) and a valid number")
 	}
-	if p.BehaviourPenaltyWeight != 0 && (p.BehaviourPenaltyDecay <= 0 || p.BehaviourPenaltyDecay >= 1) {
+	if p.BehaviourPenaltyWeight != 0 && (p.BehaviourPenaltyDecay <= 0 || p.BehaviourPenaltyDecay >= 1 || isInvalidNumber(p.BehaviourPenaltyDecay)) {
 		return fmt.Errorf("invalid BehaviourPenaltyDecay; must be between 0 and 1")
 	}
-	if p.BehaviourPenaltyThreshold < 0 {
-		return fmt.Errorf("invalid BehaviourPenaltyThreshold; must be >= 0")
+	if p.BehaviourPenaltyThreshold < 0 || isInvalidNumber(p.BehaviourPenaltyThreshold) {
+		return fmt.Errorf("invalid BehaviourPenaltyThreshold; must be >= 0 and a valid number")
 	}
 
 	// check the decay parameters
 	if p.DecayInterval < time.Second {
 		return fmt.Errorf("invalid DecayInterval; must be at least 1s")
 	}
-	if p.DecayToZero <= 0 || p.DecayToZero >= 1 {
+	if p.DecayToZero <= 0 || p.DecayToZero >= 1 || isInvalidNumber(p.DecayToZero) {
 		return fmt.Errorf("invalid DecayToZero; must be between 0 and 1")
 	}
 

--- a/score_params.go
+++ b/score_params.go
@@ -199,47 +199,47 @@ func (p *PeerScoreParams) validate() error {
 
 func (p *TopicScoreParams) validate() error {
 	// make sure we have a sane topic weight
-	if p.TopicWeight < 0 {
-		return fmt.Errorf("invalid topic weight; must be >= 0")
+	if p.TopicWeight < 0 || isInvalidNumber(p.TopicWeight) {
+		return fmt.Errorf("invalid topic weight; must be >= 0 and a valid number")
 	}
 
 	// check P1
 	if p.TimeInMeshQuantum == 0 {
 		return fmt.Errorf("invalid TimeInMeshQuantum; must be non zero")
 	}
-	if p.TimeInMeshWeight < 0 {
-		return fmt.Errorf("invalid TimeInMeshWeight; must be positive (or 0 to disable)")
+	if p.TimeInMeshWeight < 0 || isInvalidNumber(p.TimeInMeshWeight) {
+		return fmt.Errorf("invalid TimeInMeshWeight; must be positive (or 0 to disable) and a valid number")
 	}
 	if p.TimeInMeshWeight != 0 && p.TimeInMeshQuantum <= 0 {
 		return fmt.Errorf("invalid TimeInMeshQuantum; must be positive")
 	}
-	if p.TimeInMeshWeight != 0 && p.TimeInMeshCap <= 0 {
-		return fmt.Errorf("invalid TimeInMeshCap; must be positive")
+	if p.TimeInMeshWeight != 0 && (p.TimeInMeshCap <= 0 || isInvalidNumber(p.TimeInMeshCap)) {
+		return fmt.Errorf("invalid TimeInMeshCap; must be positive and a valid number")
 	}
 
 	// check P2
-	if p.FirstMessageDeliveriesWeight < 0 {
-		return fmt.Errorf("invallid FirstMessageDeliveriesWeight; must be positive (or 0 to disable)")
+	if p.FirstMessageDeliveriesWeight < 0 || isInvalidNumber(p.FirstMessageDeliveriesWeight) {
+		return fmt.Errorf("invallid FirstMessageDeliveriesWeight; must be positive (or 0 to disable) and a valid number")
 	}
-	if p.FirstMessageDeliveriesWeight != 0 && (p.FirstMessageDeliveriesDecay <= 0 || p.FirstMessageDeliveriesDecay >= 1) {
+	if p.FirstMessageDeliveriesWeight != 0 && (p.FirstMessageDeliveriesDecay <= 0 || p.FirstMessageDeliveriesDecay >= 1 || isInvalidNumber(p.FirstMessageDeliveriesDecay)) {
 		return fmt.Errorf("invalid FirstMessageDeliveriesDecay; must be between 0 and 1")
 	}
-	if p.FirstMessageDeliveriesWeight != 0 && p.FirstMessageDeliveriesCap <= 0 {
-		return fmt.Errorf("invalid FirstMessageDeliveriesCap; must be positive")
+	if p.FirstMessageDeliveriesWeight != 0 && (p.FirstMessageDeliveriesCap <= 0 || isInvalidNumber(p.FirstMessageDeliveriesCap)) {
+		return fmt.Errorf("invalid FirstMessageDeliveriesCap; must be positive and a valid number")
 	}
 
 	// check P3
-	if p.MeshMessageDeliveriesWeight > 0 {
-		return fmt.Errorf("invalid MeshMessageDeliveriesWeight; must be negative (or 0 to disable)")
+	if p.MeshMessageDeliveriesWeight > 0 || isInvalidNumber(p.MeshFailurePenaltyWeight) {
+		return fmt.Errorf("invalid MeshMessageDeliveriesWeight; must be negative (or 0 to disable) and a valid number")
 	}
-	if p.MeshMessageDeliveriesWeight != 0 && (p.MeshMessageDeliveriesDecay <= 0 || p.MeshMessageDeliveriesDecay >= 1) {
+	if p.MeshMessageDeliveriesWeight != 0 && (p.MeshMessageDeliveriesDecay <= 0 || p.MeshMessageDeliveriesDecay >= 1 || isInvalidNumber(p.MeshMessageDeliveriesDecay)) {
 		return fmt.Errorf("invalid MeshMessageDeliveriesDecay; must be between 0 and 1")
 	}
-	if p.MeshMessageDeliveriesWeight != 0 && p.MeshMessageDeliveriesCap <= 0 {
-		return fmt.Errorf("invalid MeshMessageDeliveriesCap; must be positive")
+	if p.MeshMessageDeliveriesWeight != 0 && (p.MeshMessageDeliveriesCap <= 0 || isInvalidNumber(p.MeshMessageDeliveriesCap)) {
+		return fmt.Errorf("invalid MeshMessageDeliveriesCap; must be positive and a valid number")
 	}
-	if p.MeshMessageDeliveriesWeight != 0 && p.MeshMessageDeliveriesThreshold <= 0 {
-		return fmt.Errorf("invalid MeshMessageDeliveriesThreshold; must be positive")
+	if p.MeshMessageDeliveriesWeight != 0 && (p.MeshMessageDeliveriesThreshold <= 0 || isInvalidNumber(p.MeshMessageDeliveriesThreshold)) {
+		return fmt.Errorf("invalid MeshMessageDeliveriesThreshold; must be positive and a valid number")
 	}
 	if p.MeshMessageDeliveriesWindow < 0 {
 		return fmt.Errorf("invalid MeshMessageDeliveriesWindow; must be non-negative")
@@ -249,18 +249,18 @@ func (p *TopicScoreParams) validate() error {
 	}
 
 	// check P3b
-	if p.MeshFailurePenaltyWeight > 0 {
-		return fmt.Errorf("invalid MeshFailurePenaltyWeight; must be negative (or 0 to disable)")
+	if p.MeshFailurePenaltyWeight > 0 || isInvalidNumber(p.MeshFailurePenaltyWeight) {
+		return fmt.Errorf("invalid MeshFailurePenaltyWeight; must be negative (or 0 to disable) and a valid number")
 	}
-	if p.MeshFailurePenaltyWeight != 0 && (p.MeshFailurePenaltyDecay <= 0 || p.MeshFailurePenaltyDecay >= 1) {
+	if p.MeshFailurePenaltyWeight != 0 && (isInvalidNumber(p.MeshFailurePenaltyDecay) || p.MeshFailurePenaltyDecay <= 0 || p.MeshFailurePenaltyDecay >= 1) {
 		return fmt.Errorf("invalid MeshFailurePenaltyDecay; must be between 0 and 1")
 	}
 
 	// check P4
-	if p.InvalidMessageDeliveriesWeight > 0 {
-		return fmt.Errorf("invalid InvalidMessageDeliveriesWeight; must be negative (or 0 to disable)")
+	if p.InvalidMessageDeliveriesWeight > 0 || isInvalidNumber(p.InvalidMessageDeliveriesWeight) {
+		return fmt.Errorf("invalid InvalidMessageDeliveriesWeight; must be negative (or 0 to disable) and a valid number")
 	}
-	if p.InvalidMessageDeliveriesDecay <= 0 || p.InvalidMessageDeliveriesDecay >= 1 {
+	if p.InvalidMessageDeliveriesDecay <= 0 || p.InvalidMessageDeliveriesDecay >= 1 || isInvalidNumber(p.InvalidMessageDeliveriesDecay) {
 		return fmt.Errorf("invalid InvalidMessageDeliveriesDecay; must be between 0 and 1")
 	}
 
@@ -284,4 +284,10 @@ func ScoreParameterDecayWithBase(decay time.Duration, base time.Duration, decayT
 	// so factor^n = decayToZero => factor = decayToZero^(1/n)
 	ticks := float64(decay / base)
 	return math.Pow(decayToZero, 1/ticks)
+}
+
+// checks whether the provided floating-point number is `Not a Number`
+// or an infinite number.
+func isInvalidNumber(num float64) bool {
+	return math.IsNaN(num) || math.IsInf(num, 0)
 }

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -30,6 +30,21 @@ func TestPeerScoreThresholdsValidation(t *testing.T) {
 	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: -2, GraylistThreshold: -3, AcceptPXThreshold: 1, OpportunisticGraftThreshold: 2}).validate() != nil {
 		t.Fatal("expected validation success")
 	}
+	if (&PeerScoreThresholds{GossipThreshold: math.Inf(-1), PublishThreshold: -2, GraylistThreshold: -3, AcceptPXThreshold: 1, OpportunisticGraftThreshold: 2}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: math.Inf(-1), GraylistThreshold: -3, AcceptPXThreshold: 1, OpportunisticGraftThreshold: 2}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: -2, GraylistThreshold: math.Inf(-1), AcceptPXThreshold: 1, OpportunisticGraftThreshold: 2}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: -2, GraylistThreshold: -3, AcceptPXThreshold: math.NaN(), OpportunisticGraftThreshold: 2}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: -2, GraylistThreshold: -3, AcceptPXThreshold: 1, OpportunisticGraftThreshold: math.Inf(0)}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
 }
 
 func TestTopicScoreParamsValidation(t *testing.T) {

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -272,6 +272,20 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 
 	// Checks the topic parameters for invalid values such as infinite and
 	// NaN numbers.
+
+	// Don't use these params in production!
+	if (&PeerScoreParams{
+		AppSpecificScore:            appScore,
+		DecayInterval:               time.Second,
+		DecayToZero:                 math.Inf(0),
+		IPColocationFactorWeight:    math.Inf(-1),
+		IPColocationFactorThreshold: 1,
+		BehaviourPenaltyWeight:      math.Inf(0),
+		BehaviourPenaltyDecay:       math.NaN(),
+	}).validate() == nil {
+		t.Fatal("expected validation failure")
+	}
+
 	if (&PeerScoreParams{
 		TopicScoreCap:               1,
 		AppSpecificScore:            appScore,

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -1,6 +1,7 @@
 package pubsub
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -248,6 +249,40 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 				MeshFailurePenaltyDecay:         0.5,
 				InvalidMessageDeliveriesWeight:  -1,
 				InvalidMessageDeliveriesDecay:   0.5,
+			},
+		},
+	}).validate() == nil {
+		t.Fatal("expected validation failure")
+	}
+
+	// Checks the topic parameters for invalid values such as infinite and
+	// NaN numbers.
+	if (&PeerScoreParams{
+		TopicScoreCap:               1,
+		AppSpecificScore:            appScore,
+		DecayInterval:               time.Second,
+		DecayToZero:                 0.01,
+		IPColocationFactorWeight:    -1,
+		IPColocationFactorThreshold: 1,
+		Topics: map[string]*TopicScoreParams{
+			"test": &TopicScoreParams{
+				TopicWeight:                     math.Inf(0),
+				TimeInMeshWeight:                math.NaN(),
+				TimeInMeshQuantum:               time.Second,
+				TimeInMeshCap:                   10,
+				FirstMessageDeliveriesWeight:    math.Inf(1),
+				FirstMessageDeliveriesDecay:     0.5,
+				FirstMessageDeliveriesCap:       10,
+				MeshMessageDeliveriesWeight:     math.Inf(-1),
+				MeshMessageDeliveriesDecay:      math.NaN(),
+				MeshMessageDeliveriesCap:        math.Inf(0),
+				MeshMessageDeliveriesThreshold:  5,
+				MeshMessageDeliveriesWindow:     time.Millisecond,
+				MeshMessageDeliveriesActivation: time.Second,
+				MeshFailurePenaltyWeight:        -1,
+				MeshFailurePenaltyDecay:         math.NaN(),
+				InvalidMessageDeliveriesWeight:  math.Inf(0),
+				InvalidMessageDeliveriesDecay:   math.NaN(),
 			},
 		},
 	}).validate() == nil {


### PR DESCRIPTION
During further testing of our parameters for peer scoring, we came across some unusual scores for a significant amount of our peers, with a large amount giving their score as `NaN`. On further investigation it came about that when initializing the scoring parameter there had been an arithmetic error when determining the parameter. This lead to the parameter being initialized with a negative infinite value.  The parameter validation was unable to capture this, which is the main reason this PR has been opened up.

- [x] Add in validation for both `NaN` and `Infinite` floating point values and throw an error if any of the topic parameters are initialized as such.
- [x] Add regression test for it. 