### PR TITLE
add go-check workflow, fix gofmt, go vet and staticcheck

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -1,0 +1,40 @@
+# File managed by web3-bot. DO NOT EDIT.
+# See https://github.com/protocol/.github/ for details.
+
+on: [push, pull_request]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    name: Go checks
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16.x"
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@be534f007836a777104a15f2456cd1fffd3ddee8 # v2020.2.2
+      - name: Check that go.mod is tidy
+        run: |
+          cp go.mod go.mod.orig
+          cp go.sum go.sum.orig
+          go mod tidy
+          diff go.mod go.mod.orig
+          diff go.sum go.sum.orig
+      - name: gofmt
+        if: ${{ success() || failure() }} # run this step even if the previous one failed
+        run: |
+          out=$(gofmt -s -l .)
+          if [[ -n "$out" ]]; then
+            echo $out | awk '{print "::error file=" $0 ",line=0,col=0::File is not gofmt-ed."}'
+            exit 1
+          fi
+      - name: go vet
+        if: ${{ success() || failure() }} # run this step even if the previous one failed
+        run: go vet ./...
+      - name: staticcheck
+        if: ${{ success() || failure() }} # run this step even if the previous one failed
+        run: |
+          set -o pipefail
+          staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
+

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -292,6 +292,7 @@ func TestGossipSubDiscoveryAfterBootstrap(t *testing.T) {
 	}
 }
 
+//lint:ignore U1000 // function is only unused because TestGossipSubDiscoveryAfterBootstrap is skipped
 func waitUntilGossipsubMeshCount(ps *PubSub, topic string, count int) {
 	done := false
 	doneCh := make(chan bool, 1)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-libp2p-pubsub
 
-go 1.13
+go 1.15
 
 require (
 	github.com/benbjohnson/clock v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
 github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -600,6 +601,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/src-d/go-cli.v0 v0.0.0-20181105080154-d492247bbc0d/go.mod h1:z+K8VcOYVYcSwSjGebuDL6176A1XskgbtNl64NSg+n8=
 gopkg.in/src-d/go-log.v1 v1.0.1/go.mod h1:GN34hKP0g305ysm2/hctJ0Y8nWP3zxXXJ8GFabTyABE=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/gossip_tracer_test.go
+++ b/gossip_tracer_test.go
@@ -23,12 +23,10 @@ func TestBrokenPromises(t *testing.T) {
 	peerB := peer.ID("B")
 	peerC := peer.ID("C")
 
-	var msgs []*pb.Message
 	var mids []string
 	for i := 0; i < 100; i++ {
 		m := makeTestMessage(i)
 		m.From = []byte(peerA)
-		msgs = append(msgs, m)
 		mid := DefaultMsgIdFn(m)
 		mids = append(mids, mid)
 	}

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -840,12 +840,7 @@ func (gs *GossipSubRouter) pxConnect(peers []*pb.PeerInfo) {
 	}
 
 	for _, ci := range toconnect {
-		select {
-		case gs.connect <- ci:
-		default:
-			log.Debugf("ignoring peer connection attempt; too many pending connections")
-			break
-		}
+		gs.connect <- ci
 	}
 }
 
@@ -1240,7 +1235,6 @@ func (gs *GossipSubRouter) heartbeatTimer() {
 }
 
 func (gs *GossipSubRouter) heartbeat() {
-	defer log.EventBegin(gs.p.ctx, "heartbeat").Done()
 
 	gs.heartbeatTicks++
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -840,7 +840,11 @@ func (gs *GossipSubRouter) pxConnect(peers []*pb.PeerInfo) {
 	}
 
 	for _, ci := range toconnect {
-		gs.connect <- ci
+		select {
+		case gs.connect <- ci:
+		default:
+			log.Debugf("ignoring peer connection attempt; too many pending connections")
+		}
 	}
 }
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -611,7 +611,7 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 
 	gs.gossipTracer.AddPromise(p, iwantlst)
 
-	return []*pb.ControlIWant{&pb.ControlIWant{MessageIDs: iwantlst}}
+	return []*pb.ControlIWant{{MessageIDs: iwantlst}}
 }
 
 func (gs *GossipSubRouter) handleIWant(p peer.ID, ctl *pb.ControlMessage) []*pb.Message {
@@ -1021,7 +1021,7 @@ func (gs *GossipSubRouter) Leave(topic string) {
 }
 
 func (gs *GossipSubRouter) sendGraft(p peer.ID, topic string) {
-	graft := []*pb.ControlGraft{&pb.ControlGraft{TopicID: &topic}}
+	graft := []*pb.ControlGraft{{TopicID: &topic}}
 	out := rpcWithControl(nil, nil, nil, graft, nil)
 	gs.sendRPC(p, out)
 }

--- a/gossipsub_connmgr_test.go
+++ b/gossipsub_connmgr_test.go
@@ -79,11 +79,9 @@ func TestGossipsubConnTagMessageDeliveries(t *testing.T) {
 
 	// sybil squatters to be connected later
 	sybilHosts := getNetHosts(t, ctx, nSquatter)
-	squatters := make([]*sybilSquatter, 0, nSquatter)
 	for _, h := range sybilHosts {
 		squatter := &sybilSquatter{h: h}
 		h.SetStreamHandler(GossipSubID_v10, squatter.handleStream)
-		squatters = append(squatters, squatter)
 	}
 
 	// connect the honest hosts
@@ -97,14 +95,12 @@ func TestGossipsubConnTagMessageDeliveries(t *testing.T) {
 
 	// subscribe everyone to the topic
 	topic := "test"
-	var msgs []*Subscription
 	for _, ps := range psubs {
-		subch, err := ps.Subscribe(topic)
+		_, err := ps.Subscribe(topic)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		msgs = append(msgs, subch)
 	}
 
 	// sleep to allow meshes to form

--- a/gossipsub_feat_test.go
+++ b/gossipsub_feat_test.go
@@ -36,13 +36,7 @@ func TestDefaultGossipSubFeatures(t *testing.T) {
 func TestGossipSubCustomProtocols(t *testing.T) {
 	customsub := protocol.ID("customsub/1.0.0")
 	protos := []protocol.ID{customsub, FloodSubID}
-	features := func(feat GossipSubFeature, proto protocol.ID) bool {
-		if proto == customsub {
-			return true
-		}
-
-		return false
-	}
+	features := func(feat GossipSubFeature, proto protocol.ID) bool { return proto == customsub }
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/gossipsub_spam_test.go
+++ b/gossipsub_spam_test.go
@@ -543,6 +543,7 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 					if inMesh {
 						errs <- fmt.Errorf("Expected to not be in the mesh of the legitimate host")
 					}
+					close(errs)
 				}()
 			}
 		}
@@ -703,6 +704,7 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 					if pc == 0 {
 						errs <- fmt.Errorf("Expected attacker node to be PRUNED when score drops low enough")
 					}
+					close(errs)
 				}()
 			}
 		}

--- a/gossipsub_spam_test.go
+++ b/gossipsub_spam_test.go
@@ -88,8 +88,8 @@ func TestGossipsubAttackSpamIWANT(t *testing.T) {
 			if sub.GetSubscribe() {
 				// Reply by subcribing to the topic and grafting to the peer
 				writeMsg(&pb.RPC{
-					Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: sub.Subscribe, Topicid: sub.Topicid}},
-					Control:       &pb.ControlMessage{Graft: []*pb.ControlGraft{&pb.ControlGraft{TopicID: sub.Topicid}}},
+					Subscriptions: []*pb.RPC_SubOpts{{Subscribe: sub.Subscribe, Topicid: sub.Topicid}},
+					Control:       &pb.ControlMessage{Graft: []*pb.ControlGraft{{TopicID: sub.Topicid}}},
 				})
 
 				go func() {
@@ -120,7 +120,7 @@ func TestGossipsubAttackSpamIWANT(t *testing.T) {
 			// to send another message (until it cuts off the attacker for
 			// being spammy)
 			iwantlst := []string{DefaultMsgIdFn(msg)}
-			iwant := []*pb.ControlIWant{&pb.ControlIWant{MessageIDs: iwantlst}}
+			iwant := []*pb.ControlIWant{{MessageIDs: iwantlst}}
 			orpc := rpcWithControl(nil, nil, iwant, nil, nil)
 			writeMsg(&orpc.RPC)
 		}
@@ -192,8 +192,8 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 			if sub.GetSubscribe() {
 				// Reply by subcribing to the topic and grafting to the peer
 				writeMsg(&pb.RPC{
-					Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: sub.Subscribe, Topicid: sub.Topicid}},
-					Control:       &pb.ControlMessage{Graft: []*pb.ControlGraft{&pb.ControlGraft{TopicID: sub.Topicid}}},
+					Subscriptions: []*pb.RPC_SubOpts{{Subscribe: sub.Subscribe, Topicid: sub.Topicid}},
+					Control:       &pb.ControlMessage{Graft: []*pb.ControlGraft{{TopicID: sub.Topicid}}},
 				})
 
 				go func() {
@@ -206,7 +206,7 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					// Send a bunch of IHAVEs
 					for i := 0; i < 3*GossipSubMaxIHaveLength; i++ {
 						ihavelst := []string{"someid" + strconv.Itoa(i)}
-						ihave := []*pb.ControlIHave{&pb.ControlIHave{TopicID: sub.Topicid, MessageIDs: ihavelst}}
+						ihave := []*pb.ControlIHave{{TopicID: sub.Topicid, MessageIDs: ihavelst}}
 						orpc := rpcWithControl(nil, ihave, nil, nil, nil)
 						writeMsg(&orpc.RPC)
 					}
@@ -230,7 +230,7 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					// Send a bunch of IHAVEs
 					for i := 0; i < 3*GossipSubMaxIHaveLength; i++ {
 						ihavelst := []string{"someid" + strconv.Itoa(i+100)}
-						ihave := []*pb.ControlIHave{&pb.ControlIHave{TopicID: sub.Topicid, MessageIDs: ihavelst}}
+						ihave := []*pb.ControlIHave{{TopicID: sub.Topicid, MessageIDs: ihavelst}}
 						orpc := rpcWithControl(nil, ihave, nil, nil, nil)
 						writeMsg(&orpc.RPC)
 					}
@@ -309,14 +309,14 @@ func TestGossipsubAttackGRAFTNonExistentTopic(t *testing.T) {
 			if sub.GetSubscribe() {
 				// Reply by subcribing to the topic and grafting to the peer
 				writeMsg(&pb.RPC{
-					Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: sub.Subscribe, Topicid: sub.Topicid}},
-					Control:       &pb.ControlMessage{Graft: []*pb.ControlGraft{&pb.ControlGraft{TopicID: sub.Topicid}}},
+					Subscriptions: []*pb.RPC_SubOpts{{Subscribe: sub.Subscribe, Topicid: sub.Topicid}},
+					Control:       &pb.ControlMessage{Graft: []*pb.ControlGraft{{TopicID: sub.Topicid}}},
 				})
 
 				// Graft to the peer on a non-existent topic
 				nonExistentTopic := "non-existent"
 				writeMsg(&pb.RPC{
-					Control: &pb.ControlMessage{Graft: []*pb.ControlGraft{&pb.ControlGraft{TopicID: &nonExistentTopic}}},
+					Control: &pb.ControlMessage{Graft: []*pb.ControlGraft{{TopicID: &nonExistentTopic}}},
 				})
 
 				go func() {
@@ -408,9 +408,9 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 		for _, sub := range irpc.GetSubscriptions() {
 			if sub.GetSubscribe() {
 				// Reply by subcribing to the topic and grafting to the peer
-				graft := []*pb.ControlGraft{&pb.ControlGraft{TopicID: sub.Topicid}}
+				graft := []*pb.ControlGraft{{TopicID: sub.Topicid}}
 				writeMsg(&pb.RPC{
-					Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: sub.Subscribe, Topicid: sub.Topicid}},
+					Subscriptions: []*pb.RPC_SubOpts{{Subscribe: sub.Subscribe, Topicid: sub.Topicid}},
 					Control:       &pb.ControlMessage{Graft: graft},
 				})
 
@@ -646,8 +646,8 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 			if sub.GetSubscribe() {
 				// Reply by subcribing to the topic and grafting to the peer
 				writeMsg(&pb.RPC{
-					Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: sub.Subscribe, Topicid: sub.Topicid}},
-					Control:       &pb.ControlMessage{Graft: []*pb.ControlGraft{&pb.ControlGraft{TopicID: sub.Topicid}}},
+					Subscriptions: []*pb.RPC_SubOpts{{Subscribe: sub.Subscribe, Topicid: sub.Topicid}},
+					Control:       &pb.ControlMessage{Graft: []*pb.ControlGraft{{TopicID: sub.Topicid}}},
 				})
 
 				go func() {

--- a/gossipsub_spam_test.go
+++ b/gossipsub_spam_test.go
@@ -2,6 +2,8 @@ package pubsub
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -188,6 +190,7 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 
 	newMockGS(ctx, t, attacker, func(writeMsg func(*pb.RPC), irpc *pb.RPC) {
 		// When the legit host connects it will send us its subscriptions
+		errs := make(chan error)
 		for _, sub := range irpc.GetSubscriptions() {
 			if sub.GetSubscribe() {
 				// Reply by subcribing to the topic and grafting to the peer
@@ -217,14 +220,14 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					// per heartbeat
 					iwc := getIWantCount()
 					if iwc > GossipSubMaxIHaveLength {
-						t.Fatalf("Expecting max %d IWANTs per heartbeat but received %d", GossipSubMaxIHaveLength, iwc)
+						errs <- errors.New(fmt.Sprintf("Expecting max %d IWANTs per heartbeat but received %d", GossipSubMaxIHaveLength, iwc))
 					}
 					firstBatchCount := iwc
 
 					// the score should still be 0 because we haven't broken any promises yet
 					score := ps.rt.(*GossipSubRouter).score.Score(attacker.ID())
 					if score != 0 {
-						t.Fatalf("Expected 0 score, but got %f", score)
+						errs <- errors.New(fmt.Sprintf("Expected 0 score, but got %f", score))
 					}
 
 					// Send a bunch of IHAVEs
@@ -240,11 +243,11 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					// Should have sent more IWANTs after the heartbeat
 					iwc = getIWantCount()
 					if iwc == firstBatchCount {
-						t.Fatal("Expecting to receive more IWANTs after heartbeat but did not")
+						errs <- errors.New(fmt.Sprintf("Expecting to receive more IWANTs after heartbeat but did not"))
 					}
 					// Should not be more than the maximum per heartbeat
 					if iwc-firstBatchCount > GossipSubMaxIHaveLength {
-						t.Fatalf("Expecting max %d IWANTs per heartbeat but received %d", GossipSubMaxIHaveLength, iwc-firstBatchCount)
+						errs <- errors.New(fmt.Sprintf("Expecting max %d IWANTs per heartbeat but received %d", GossipSubMaxIHaveLength, iwc-firstBatchCount))
 					}
 
 					time.Sleep(GossipSubIWantFollowupTime)
@@ -252,10 +255,15 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					// The score should now be negative because of broken promises
 					score = ps.rt.(*GossipSubRouter).score.Score(attacker.ID())
 					if score >= 0 {
-						t.Fatalf("Expected negative score, but got %f", score)
+						errs <- errors.New(fmt.Sprintf("Expected negative score, but got %f", score))
 					}
+					close(errs)
 				}()
 			}
+		}
+
+		for err := range errs {
+			t.Error(err)
 		}
 
 		// Record the count of received IWANT messages
@@ -405,6 +413,7 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 
 	newMockGS(ctx, t, attacker, func(writeMsg func(*pb.RPC), irpc *pb.RPC) {
 		// When the legit host connects it will send us its subscriptions
+		errs := make(chan error)
 		for _, sub := range irpc.GetSubscriptions() {
 			if sub.GetSubscribe() {
 				// Reply by subcribing to the topic and grafting to the peer
@@ -424,7 +433,7 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 					// No PRUNE should have been sent at this stage
 					pc := getPruneCount()
 					if pc != 0 {
-						t.Fatalf("Expected %d PRUNE messages but got %d", 0, pc)
+						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 0, pc))
 					}
 
 					// Send a PRUNE to remove the attacker node from the legit
@@ -440,7 +449,7 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 					// No PRUNE should have been sent at this stage
 					pc = getPruneCount()
 					if pc != 0 {
-						t.Fatalf("Expected %d PRUNE messages but got %d", 0, pc)
+						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 0, pc))
 					}
 
 					// wait for the GossipSubGraftFloodThreshold to pass before attempting another graft
@@ -458,12 +467,12 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 					// yet.
 					pc = getPruneCount()
 					if pc != 1 {
-						t.Fatalf("Expected %d PRUNE messages but got %d", 1, pc)
+						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 1, pc))
 					}
 
 					score1 := ps.rt.(*GossipSubRouter).score.Score(attacker.ID())
 					if score1 >= 0 {
-						t.Fatalf("Expected negative score, but got %f", score1)
+						errs <- errors.New(fmt.Sprintf("Expected negative score, but got %f", score1))
 					}
 
 					// Send a GRAFT again to attempt to rejoin the mesh
@@ -477,12 +486,12 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 					// a PRUNE because we are before the flood threshold
 					pc = getPruneCount()
 					if pc != 2 {
-						t.Fatalf("Expected %d PRUNE messages but got %d", 2, pc)
+						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 2, pc))
 					}
 
 					score2 := ps.rt.(*GossipSubRouter).score.Score(attacker.ID())
 					if score2 >= score1 {
-						t.Fatalf("Expected score below %f, but got %f", score1, score2)
+						errs <- errors.New(fmt.Sprintf("Expected score below %f, but got %f", score1, score2))
 					}
 
 					// Send another GRAFT; this should get us a PRUNE, but penalize us below the graylist threshold
@@ -494,15 +503,18 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 
 					pc = getPruneCount()
 					if pc != 3 {
-						t.Fatalf("Expected %d PRUNE messages but got %d", 3, pc)
+						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 3, pc))
+						close(errs)
 					}
 
 					score3 := ps.rt.(*GossipSubRouter).score.Score(attacker.ID())
 					if score3 >= score2 {
-						t.Fatalf("Expected score below %f, but got %f", score2, score3)
+						errs <- errors.New(fmt.Sprintf("Expected score below %f, but got %f", score2, score3))
+						close(errs)
 					}
 					if score3 >= -1000 {
-						t.Fatalf("Expected score below %f, but got %f", -1000.0, score3)
+						errs <- errors.New(fmt.Sprintf("Expected score below %f, but got %f", -1000.0, score3))
+						close(errs)
 					}
 
 					// Wait for the PRUNE backoff to expire and try again; this time we should fail
@@ -518,7 +530,7 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 
 					pc = getPruneCount()
 					if pc != 3 {
-						t.Fatalf("Expected %d PRUNE messages but got %d", 3, pc)
+						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 3, pc))
 					}
 
 					// make sure we are _not_ in the mesh
@@ -531,10 +543,14 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 
 					inMesh := <-res
 					if inMesh {
-						t.Fatal("Expected to not be in the mesh of the legitimate host")
+						errs <- errors.New(fmt.Sprintf("Expected to not be in the mesh of the legitimate host"))
 					}
 				}()
 			}
+		}
+
+		for err := range errs {
+			t.Fatal(err)
 		}
 
 		if ctl := irpc.GetControl(); ctl != nil {
@@ -642,6 +658,7 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 
 	newMockGS(ctx, t, attacker, func(writeMsg func(*pb.RPC), irpc *pb.RPC) {
 		// When the legit host connects it will send us its subscriptions
+		errs := make(chan error)
 		for _, sub := range irpc.GetSubscriptions() {
 			if sub.GetSubscribe() {
 				// Reply by subcribing to the topic and grafting to the peer
@@ -655,7 +672,7 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 
 					// Attacker score should start at zero
 					if attackerScore() != 0 {
-						t.Fatalf("Expected attacker score to be zero but it's %f", attackerScore())
+						errs <- errors.New(fmt.Sprintf("Expected attacker score to be zero but it's %f", attackerScore()))
 					}
 
 					// Send a bunch of messages with no signature (these will
@@ -677,19 +694,23 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 
 					// The attackers score should now have fallen below zero
 					if attackerScore() >= 0 {
-						t.Fatalf("Expected attacker score to be less than zero but it's %f", attackerScore())
+						errs <- errors.New(fmt.Sprintf("Expected attacker score to be less than zero but it's %f", attackerScore()))
 					}
 					// There should be several rejected messages (because the signature was invalid)
 					if tracer.rejectCount == 0 {
-						t.Fatal("Expected message rejection but got none")
+						errs <- errors.New(fmt.Sprintf("Expected message rejection but got none"))
 					}
 					// The legit node should have sent a PRUNE message
 					pc := getPruneCount()
 					if pc == 0 {
-						t.Fatal("Expected attacker node to be PRUNED when score drops low enough")
+						errs <- errors.New(fmt.Sprintf("Expected attacker node to be PRUNED when score drops low enough"))
 					}
 				}()
 			}
+		}
+
+		for err := range errs {
+			t.Fatal(err)
 		}
 
 		if ctl := irpc.GetControl(); ctl != nil {

--- a/gossipsub_spam_test.go
+++ b/gossipsub_spam_test.go
@@ -2,7 +2,6 @@ package pubsub
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -17,7 +16,6 @@ import (
 
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 
-	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-msgio/protoio"
 )
 
@@ -220,14 +218,14 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					// per heartbeat
 					iwc := getIWantCount()
 					if iwc > GossipSubMaxIHaveLength {
-						errs <- errors.New(fmt.Sprintf("Expecting max %d IWANTs per heartbeat but received %d", GossipSubMaxIHaveLength, iwc))
+						errs <- fmt.Errorf("Expecting max %d IWANTs per heartbeat but received %d", GossipSubMaxIHaveLength, iwc)
 					}
 					firstBatchCount := iwc
 
 					// the score should still be 0 because we haven't broken any promises yet
 					score := ps.rt.(*GossipSubRouter).score.Score(attacker.ID())
 					if score != 0 {
-						errs <- errors.New(fmt.Sprintf("Expected 0 score, but got %f", score))
+						errs <- fmt.Errorf("Expected 0 score, but got %f", score)
 					}
 
 					// Send a bunch of IHAVEs
@@ -243,11 +241,11 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					// Should have sent more IWANTs after the heartbeat
 					iwc = getIWantCount()
 					if iwc == firstBatchCount {
-						errs <- errors.New(fmt.Sprintf("Expecting to receive more IWANTs after heartbeat but did not"))
+						errs <- fmt.Errorf("Expecting to receive more IWANTs after heartbeat but did not")
 					}
 					// Should not be more than the maximum per heartbeat
 					if iwc-firstBatchCount > GossipSubMaxIHaveLength {
-						errs <- errors.New(fmt.Sprintf("Expecting max %d IWANTs per heartbeat but received %d", GossipSubMaxIHaveLength, iwc-firstBatchCount))
+						errs <- fmt.Errorf("Expecting max %d IWANTs per heartbeat but received %d", GossipSubMaxIHaveLength, iwc-firstBatchCount)
 					}
 
 					time.Sleep(GossipSubIWantFollowupTime)
@@ -255,7 +253,7 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					// The score should now be negative because of broken promises
 					score = ps.rt.(*GossipSubRouter).score.Score(attacker.ID())
 					if score >= 0 {
-						errs <- errors.New(fmt.Sprintf("Expected negative score, but got %f", score))
+						errs <- fmt.Errorf("Expected negative score, but got %f", score)
 					}
 					close(errs)
 				}()
@@ -433,7 +431,7 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 					// No PRUNE should have been sent at this stage
 					pc := getPruneCount()
 					if pc != 0 {
-						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 0, pc))
+						errs <- fmt.Errorf("Expected %d PRUNE messages but got %d", 0, pc)
 					}
 
 					// Send a PRUNE to remove the attacker node from the legit
@@ -449,7 +447,7 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 					// No PRUNE should have been sent at this stage
 					pc = getPruneCount()
 					if pc != 0 {
-						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 0, pc))
+						errs <- fmt.Errorf("Expected %d PRUNE messages but got %d", 0, pc)
 					}
 
 					// wait for the GossipSubGraftFloodThreshold to pass before attempting another graft
@@ -467,12 +465,12 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 					// yet.
 					pc = getPruneCount()
 					if pc != 1 {
-						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 1, pc))
+						errs <- fmt.Errorf("Expected %d PRUNE messages but got %d", 1, pc)
 					}
 
 					score1 := ps.rt.(*GossipSubRouter).score.Score(attacker.ID())
 					if score1 >= 0 {
-						errs <- errors.New(fmt.Sprintf("Expected negative score, but got %f", score1))
+						errs <- fmt.Errorf("Expected negative score, but got %f", score1)
 					}
 
 					// Send a GRAFT again to attempt to rejoin the mesh
@@ -486,12 +484,12 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 					// a PRUNE because we are before the flood threshold
 					pc = getPruneCount()
 					if pc != 2 {
-						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 2, pc))
+						errs <- fmt.Errorf("Expected %d PRUNE messages but got %d", 2, pc)
 					}
 
 					score2 := ps.rt.(*GossipSubRouter).score.Score(attacker.ID())
 					if score2 >= score1 {
-						errs <- errors.New(fmt.Sprintf("Expected score below %f, but got %f", score1, score2))
+						errs <- fmt.Errorf("Expected score below %f, but got %f", score1, score2)
 					}
 
 					// Send another GRAFT; this should get us a PRUNE, but penalize us below the graylist threshold
@@ -503,17 +501,17 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 
 					pc = getPruneCount()
 					if pc != 3 {
-						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 3, pc))
+						errs <- fmt.Errorf("Expected %d PRUNE messages but got %d", 3, pc)
 						close(errs)
 					}
 
 					score3 := ps.rt.(*GossipSubRouter).score.Score(attacker.ID())
 					if score3 >= score2 {
-						errs <- errors.New(fmt.Sprintf("Expected score below %f, but got %f", score2, score3))
+						errs <- fmt.Errorf("Expected score below %f, but got %f", score2, score3)
 						close(errs)
 					}
 					if score3 >= -1000 {
-						errs <- errors.New(fmt.Sprintf("Expected score below %f, but got %f", -1000.0, score3))
+						errs <- fmt.Errorf("Expected score below %f, but got %f", -1000.0, score3)
 						close(errs)
 					}
 
@@ -530,7 +528,7 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 
 					pc = getPruneCount()
 					if pc != 3 {
-						errs <- errors.New(fmt.Sprintf("Expected %d PRUNE messages but got %d", 3, pc))
+						errs <- fmt.Errorf("Expected %d PRUNE messages but got %d", 3, pc)
 					}
 
 					// make sure we are _not_ in the mesh
@@ -543,7 +541,7 @@ func TestGossipsubAttackGRAFTDuringBackoff(t *testing.T) {
 
 					inMesh := <-res
 					if inMesh {
-						errs <- errors.New(fmt.Sprintf("Expected to not be in the mesh of the legitimate host"))
+						errs <- fmt.Errorf("Expected to not be in the mesh of the legitimate host")
 					}
 				}()
 			}
@@ -672,7 +670,7 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 
 					// Attacker score should start at zero
 					if attackerScore() != 0 {
-						errs <- errors.New(fmt.Sprintf("Expected attacker score to be zero but it's %f", attackerScore()))
+						errs <- fmt.Errorf("Expected attacker score to be zero but it's %f", attackerScore())
 					}
 
 					// Send a bunch of messages with no signature (these will
@@ -694,16 +692,16 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 
 					// The attackers score should now have fallen below zero
 					if attackerScore() >= 0 {
-						errs <- errors.New(fmt.Sprintf("Expected attacker score to be less than zero but it's %f", attackerScore()))
+						errs <- fmt.Errorf("Expected attacker score to be less than zero but it's %f", attackerScore())
 					}
 					// There should be several rejected messages (because the signature was invalid)
 					if tracer.rejectCount == 0 {
-						errs <- errors.New(fmt.Sprintf("Expected message rejection but got none"))
+						errs <- fmt.Errorf("Expected message rejection but got none")
 					}
 					// The legit node should have sent a PRUNE message
 					pc := getPruneCount()
 					if pc == 0 {
-						errs <- errors.New(fmt.Sprintf("Expected attacker node to be PRUNED when score drops low enough"))
+						errs <- fmt.Errorf("Expected attacker node to be PRUNED when score drops low enough")
 					}
 				}()
 			}
@@ -721,10 +719,6 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 	connect(t, hosts[0], hosts[1])
 
 	<-ctx.Done()
-}
-
-func turnOnPubsubDebug() {
-	logging.SetLogLevel("pubsub", "debug")
 }
 
 type mockGSOnRead func(writeMsg func(*pb.RPC), irpc *pb.RPC)

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1313,13 +1313,11 @@ func TestGossipsubEnoughPeers(t *testing.T) {
 	hosts := getNetHosts(t, ctx, 20)
 	psubs := getGossipsubs(ctx, hosts)
 
-	var subs []*Subscription
 	for _, ps := range psubs {
-		sub, err := ps.Subscribe("test")
+		_, err := ps.Subscribe("test")
 		if err != nil {
 			t.Fatal(err)
 		}
-		subs = append(subs, sub)
 	}
 
 	// at this point we have no connections and no mesh, so EnoughPeers should return false
@@ -1673,11 +1671,10 @@ func TestGossipsubOpportunisticGrafting(t *testing.T) {
 	connectSome(t, hosts[:10], 5)
 
 	// sybil squatters for the remaining 40 hosts
-	squatters := make([]*sybilSquatter, 0, 40)
+
 	for _, h := range hosts[10:] {
 		squatter := &sybilSquatter{h: h}
 		h.SetStreamHandler(GossipSubID_v10, squatter.handleStream)
-		squatters = append(squatters, squatter)
 	}
 
 	// connect all squatters to every real host
@@ -1812,13 +1809,11 @@ func TestGossipsubPeerScoreInspect(t *testing.T) {
 
 	connect(t, hosts[0], hosts[1])
 
-	var subs []*Subscription
 	for _, ps := range psubs {
-		sub, err := ps.Subscribe("test")
+		_, err := ps.Subscribe("test")
 		if err != nil {
 			t.Fatal(err)
 		}
-		subs = append(subs, sub)
 	}
 
 	time.Sleep(time.Second)
@@ -1990,6 +1985,10 @@ func (iwe *iwantEverything) handleStream(s network.Stream) {
 	truth := true
 	topic := "test"
 	err = w.WriteMsg(&pb.RPC{Subscriptions: []*pb.RPC_SubOpts{{Subscribe: &truth, Topicid: &topic}}})
+	if err != nil {
+		s.Reset()
+		return
+	}
 
 	var rpc pb.RPC
 	for {

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1126,8 +1126,8 @@ func TestGossipsubDirectPeers(t *testing.T) {
 	h := getNetHosts(t, ctx, 3)
 	psubs := []*PubSub{
 		getGossipsub(ctx, h[0], WithDirectConnectTicks(2)),
-		getGossipsub(ctx, h[1], WithDirectPeers([]peer.AddrInfo{{h[2].ID(), h[2].Addrs()}}), WithDirectConnectTicks(2)),
-		getGossipsub(ctx, h[2], WithDirectPeers([]peer.AddrInfo{{h[1].ID(), h[1].Addrs()}}), WithDirectConnectTicks(2)),
+		getGossipsub(ctx, h[1], WithDirectPeers([]peer.AddrInfo{{ID: h[2].ID(), Addrs: h[2].Addrs()}}), WithDirectConnectTicks(2)),
+		getGossipsub(ctx, h[2], WithDirectPeers([]peer.AddrInfo{{ID: h[1].ID(), Addrs: h[1].Addrs()}}), WithDirectConnectTicks(2)),
 	}
 
 	connect(t, h[0], h[1])
@@ -1191,8 +1191,8 @@ func TestGossipsubDirectPeersFanout(t *testing.T) {
 	h := getNetHosts(t, ctx, 3)
 	psubs := []*PubSub{
 		getGossipsub(ctx, h[0]),
-		getGossipsub(ctx, h[1], WithDirectPeers([]peer.AddrInfo{{h[2].ID(), h[2].Addrs()}})),
-		getGossipsub(ctx, h[2], WithDirectPeers([]peer.AddrInfo{{h[1].ID(), h[1].Addrs()}})),
+		getGossipsub(ctx, h[1], WithDirectPeers([]peer.AddrInfo{{ID: h[2].ID(), Addrs: h[2].Addrs()}})),
+		getGossipsub(ctx, h[2], WithDirectPeers([]peer.AddrInfo{{ID: h[1].ID(), Addrs: h[1].Addrs()}})),
 	}
 
 	connect(t, h[0], h[1])

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1126,8 +1126,8 @@ func TestGossipsubDirectPeers(t *testing.T) {
 	h := getNetHosts(t, ctx, 3)
 	psubs := []*PubSub{
 		getGossipsub(ctx, h[0], WithDirectConnectTicks(2)),
-		getGossipsub(ctx, h[1], WithDirectPeers([]peer.AddrInfo{peer.AddrInfo{h[2].ID(), h[2].Addrs()}}), WithDirectConnectTicks(2)),
-		getGossipsub(ctx, h[2], WithDirectPeers([]peer.AddrInfo{peer.AddrInfo{h[1].ID(), h[1].Addrs()}}), WithDirectConnectTicks(2)),
+		getGossipsub(ctx, h[1], WithDirectPeers([]peer.AddrInfo{{h[2].ID(), h[2].Addrs()}}), WithDirectConnectTicks(2)),
+		getGossipsub(ctx, h[2], WithDirectPeers([]peer.AddrInfo{{h[1].ID(), h[1].Addrs()}}), WithDirectConnectTicks(2)),
 	}
 
 	connect(t, h[0], h[1])
@@ -1191,8 +1191,8 @@ func TestGossipsubDirectPeersFanout(t *testing.T) {
 	h := getNetHosts(t, ctx, 3)
 	psubs := []*PubSub{
 		getGossipsub(ctx, h[0]),
-		getGossipsub(ctx, h[1], WithDirectPeers([]peer.AddrInfo{peer.AddrInfo{h[2].ID(), h[2].Addrs()}})),
-		getGossipsub(ctx, h[2], WithDirectPeers([]peer.AddrInfo{peer.AddrInfo{h[1].ID(), h[1].Addrs()}})),
+		getGossipsub(ctx, h[1], WithDirectPeers([]peer.AddrInfo{{h[2].ID(), h[2].Addrs()}})),
+		getGossipsub(ctx, h[2], WithDirectPeers([]peer.AddrInfo{{h[1].ID(), h[1].Addrs()}})),
 	}
 
 	connect(t, h[0], h[1])
@@ -1443,7 +1443,7 @@ func TestGossipsubScoreValidatorEx(t *testing.T) {
 				DecayInterval:    time.Second,
 				DecayToZero:      0.01,
 				Topics: map[string]*TopicScoreParams{
-					"test": &TopicScoreParams{
+					"test": {
 						TopicWeight:                    1,
 						TimeInMeshQuantum:              time.Second,
 						InvalidMessageDeliveriesWeight: -1,
@@ -1540,8 +1540,8 @@ func TestGossipsubPiggybackControl(t *testing.T) {
 
 		rpc := &RPC{RPC: pb.RPC{}}
 		gs.piggybackControl(blah, rpc, &pb.ControlMessage{
-			Graft: []*pb.ControlGraft{&pb.ControlGraft{TopicID: &test1}, &pb.ControlGraft{TopicID: &test2}, &pb.ControlGraft{TopicID: &test3}},
-			Prune: []*pb.ControlPrune{&pb.ControlPrune{TopicID: &test1}, &pb.ControlPrune{TopicID: &test2}, &pb.ControlPrune{TopicID: &test3}},
+			Graft: []*pb.ControlGraft{{TopicID: &test1}, {TopicID: &test2}, {TopicID: &test3}},
+			Prune: []*pb.ControlPrune{{TopicID: &test1}, {TopicID: &test2}, {TopicID: &test3}},
 		})
 		res <- rpc
 	}
@@ -1603,7 +1603,7 @@ func TestGossipsubMultipleGraftTopics(t *testing.T) {
 	// Send multiple GRAFT messages to second peer from
 	// 1st peer
 	p1Router.sendGraftPrune(map[peer.ID][]string{
-		secondPeer: []string{firstTopic, secondTopic, thirdTopic},
+		secondPeer: {firstTopic, secondTopic, thirdTopic},
 	}, map[peer.ID][]string{}, map[peer.ID]bool{})
 
 	time.Sleep(time.Second * 1)
@@ -1650,7 +1650,7 @@ func TestGossipsubOpportunisticGrafting(t *testing.T) {
 				DecayInterval:     time.Second,
 				DecayToZero:       0.01,
 				Topics: map[string]*TopicScoreParams{
-					"test": &TopicScoreParams{
+					"test": {
 						TopicWeight:                   1,
 						TimeInMeshWeight:              0.0002777,
 						TimeInMeshQuantum:             time.Second,
@@ -1757,7 +1757,7 @@ func (sq *sybilSquatter) handleStream(s network.Stream) {
 	w := protoio.NewDelimitedWriter(os)
 	truth := true
 	topic := "test"
-	err = w.WriteMsg(&pb.RPC{Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: &truth, Topicid: &topic}}})
+	err = w.WriteMsg(&pb.RPC{Subscriptions: []*pb.RPC_SubOpts{{Subscribe: &truth, Topicid: &topic}}})
 	if err != nil {
 		panic(err)
 	}
@@ -1787,7 +1787,7 @@ func TestGossipsubPeerScoreInspect(t *testing.T) {
 		WithPeerScore(
 			&PeerScoreParams{
 				Topics: map[string]*TopicScoreParams{
-					"test": &TopicScoreParams{
+					"test": {
 						TopicWeight:                    1,
 						TimeInMeshQuantum:              time.Second,
 						FirstMessageDeliveriesWeight:   1,
@@ -1848,7 +1848,7 @@ func TestGossipsubPeerScoreResetTopicParams(t *testing.T) {
 		WithPeerScore(
 			&PeerScoreParams{
 				Topics: map[string]*TopicScoreParams{
-					"test": &TopicScoreParams{
+					"test": {
 						TopicWeight:                    1,
 						TimeInMeshQuantum:              time.Second,
 						FirstMessageDeliveriesWeight:   1,
@@ -1989,7 +1989,7 @@ func (iwe *iwantEverything) handleStream(s network.Stream) {
 	w := protoio.NewDelimitedWriter(os)
 	truth := true
 	topic := "test"
-	err = w.WriteMsg(&pb.RPC{Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: &truth, Topicid: &topic}}})
+	err = w.WriteMsg(&pb.RPC{Subscriptions: []*pb.RPC_SubOpts{{Subscribe: &truth, Topicid: &topic}}})
 
 	var rpc pb.RPC
 	for {

--- a/randomsub_test.go
+++ b/randomsub_test.go
@@ -160,13 +160,11 @@ func TestRandomsubEnoughPeers(t *testing.T) {
 
 	connectSome(t, hosts, 12)
 
-	var subs []*Subscription
 	for _, ps := range psubs {
-		sub, err := ps.Subscribe("test")
+		_, err := ps.Subscribe("test")
 		if err != nil {
 			t.Fatal(err)
 		}
-		subs = append(subs, sub)
 	}
 
 	time.Sleep(time.Second)

--- a/score.go
+++ b/score.go
@@ -700,7 +700,7 @@ func (ps *peerScore) DeliverMessage(msg *Message) {
 
 	// defensive check that this is the first delivery trace -- delivery status should be unknown
 	if drec.status != deliveryUnknown {
-		log.Debugf("unexpected delivery trace: message from %s was first seen %s ago and has delivery status %d", msg.ReceivedFrom, time.Now().Sub(drec.firstSeen), drec.status)
+		log.Debugf("unexpected delivery trace: message from %s was first seen %s ago and has delivery status %d", msg.ReceivedFrom, time.Since(drec.firstSeen), drec.status)
 		return
 	}
 
@@ -751,7 +751,7 @@ func (ps *peerScore) RejectMessage(msg *Message, reason string) {
 
 	// defensive check that this is the first rejection trace -- delivery status should be unknown
 	if drec.status != deliveryUnknown {
-		log.Debugf("unexpected rejection trace: message from %s was first seen %s ago and has delivery status %d", msg.ReceivedFrom, time.Now().Sub(drec.firstSeen), drec.status)
+		log.Debugf("unexpected rejection trace: message from %s was first seen %s ago and has delivery status %d", msg.ReceivedFrom, time.Since(drec.firstSeen), drec.status)
 		return
 	}
 

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -213,7 +213,7 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 		IPColocationFactorWeight:    -1,
 		IPColocationFactorThreshold: 1,
 		Topics: map[string]*TopicScoreParams{
-			"test": &TopicScoreParams{
+			"test": {
 				TopicWeight:                     1,
 				TimeInMeshWeight:                0.01,
 				TimeInMeshQuantum:               time.Second,
@@ -246,7 +246,7 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 		IPColocationFactorWeight:    -1,
 		IPColocationFactorThreshold: 1,
 		Topics: map[string]*TopicScoreParams{
-			"test": &TopicScoreParams{
+			"test": {
 				TopicWeight:                     -1,
 				TimeInMeshWeight:                0.01,
 				TimeInMeshQuantum:               time.Second,
@@ -294,7 +294,7 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 		IPColocationFactorWeight:    -1,
 		IPColocationFactorThreshold: 1,
 		Topics: map[string]*TopicScoreParams{
-			"test": &TopicScoreParams{
+			"test": {
 				TopicWeight:                     math.Inf(0),
 				TimeInMeshWeight:                math.NaN(),
 				TimeInMeshQuantum:               time.Second,

--- a/subscription_filter_test.go
+++ b/subscription_filter_test.go
@@ -19,15 +19,15 @@ func TestBasicSubscriptionFilter(t *testing.T) {
 	topic3 := "test3"
 	yes := true
 	subs := []*pb.RPC_SubOpts{
-		&pb.RPC_SubOpts{
+		{
 			Topicid:   &topic1,
 			Subscribe: &yes,
 		},
-		&pb.RPC_SubOpts{
+		{
 			Topicid:   &topic2,
 			Subscribe: &yes,
 		},
-		&pb.RPC_SubOpts{
+		{
 			Topicid:   &topic3,
 			Subscribe: &yes,
 		},
@@ -108,24 +108,24 @@ func TestSubscriptionFilterDeduplication(t *testing.T) {
 	yes := true
 	no := false
 	subs := []*pb.RPC_SubOpts{
-		&pb.RPC_SubOpts{
+		{
 			Topicid:   &topic1,
 			Subscribe: &yes,
 		},
-		&pb.RPC_SubOpts{
+		{
 			Topicid:   &topic1,
 			Subscribe: &yes,
 		},
 
-		&pb.RPC_SubOpts{
+		{
 			Topicid:   &topic2,
 			Subscribe: &yes,
 		},
-		&pb.RPC_SubOpts{
+		{
 			Topicid:   &topic2,
 			Subscribe: &no,
 		},
-		&pb.RPC_SubOpts{
+		{
 			Topicid:   &topic3,
 			Subscribe: &yes,
 		},

--- a/tag_tracer_test.go
+++ b/tag_tracer_test.go
@@ -237,6 +237,10 @@ func getTagValue(mgr connmgri.ConnManager, p peer.ID, tag string) int {
 	return val
 }
 
+// staticcheck says this function is unused because the tests that use it are skipped.
+// TODO: remove the lint directive when tests are unskipped.
+
+//lint:ignore U1000 unused function
 func tagExists(mgr connmgri.ConnManager, p peer.ID, tag string) bool {
 	info := mgr.GetTagInfo(p)
 	if info == nil {

--- a/topic_test.go
+++ b/topic_test.go
@@ -167,7 +167,7 @@ func TestTopicReuse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(msg.GetData(), firstMsg) != 0 {
+	if bytes.Equal(msg.GetData(), firstMsg) {
 		t.Fatal("received incorrect message")
 	}
 
@@ -194,7 +194,7 @@ func TestTopicReuse(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if bytes.Compare(msg.GetData(), illegalSend) != 0 {
+		if bytes.Equal(msg.GetData(), illegalSend) {
 			t.Fatal("received incorrect message from illegal topic")
 		}
 		t.Fatal("received message sent by illegal topic")
@@ -207,17 +207,17 @@ func TestTopicReuse(t *testing.T) {
 	}
 
 	secondMsg := []byte("2")
-	if err := newSendTopic.Publish(ctx, secondMsg); err != nil {
+	if err := newSendTopic.Publish(timeoutCtx, secondMsg); err != nil {
 		t.Fatal(err)
 	}
 
 	timeoutCtx, timeoutCancel = context.WithTimeout(ctx, time.Second*2)
 	defer timeoutCancel()
-	msg, err = sub.Next(ctx)
+	msg, err = sub.Next(timeoutCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(msg.GetData(), secondMsg) != 0 {
+	if bytes.Equal(msg.GetData(), secondMsg) {
 		t.Fatal("received incorrect message")
 	}
 }

--- a/validation.go
+++ b/validation.go
@@ -143,7 +143,7 @@ func (v *validation) AddValidator(req *addValReq) {
 
 	_, ok := v.topicVals[topic]
 	if ok {
-		req.resp <- fmt.Errorf("Duplicate validator for topic %s", topic)
+		req.resp <- fmt.Errorf("duplicate validator for topic %s", topic)
 		return
 	}
 
@@ -170,7 +170,7 @@ func (v *validation) AddValidator(req *addValReq) {
 		validator = v
 
 	default:
-		req.resp <- fmt.Errorf("Unknown validator type for topic %s; must be an instance of Validator or ValidatorEx", topic)
+		req.resp <- fmt.Errorf("unknown validator type for topic %s; must be an instance of Validator or ValidatorEx", topic)
 		return
 	}
 
@@ -206,7 +206,7 @@ func (v *validation) RemoveValidator(req *rmValReq) {
 		delete(v.topicVals, topic)
 		req.resp <- nil
 	} else {
-		req.resp <- fmt.Errorf("No validator for topic %s", topic)
+		req.resp <- fmt.Errorf("no validator for topic %s", topic)
 	}
 }
 
@@ -384,7 +384,7 @@ func (v *validation) doValidateTopic(vals []*topicVal, src peer.ID, msg *Message
 
 	default:
 		// BUG: this would be an internal programming error, so a panic seems appropiate.
-		panic(fmt.Errorf("Unexpected validation result: %d", result))
+		panic(fmt.Errorf("unexpected validation result: %d", result))
 	}
 }
 


### PR DESCRIPTION
Closes #415. Closes #416.

I see that running `go test` is more complicated on this repo, so we should probably not move it to GitHub Actions (yet).
@coryschwartz did an excellent job fixing all the `go vet` and `staticcheck` errors. We should merge these changes, and add the `go-check` workflow.