### PR TITLE
feat: re-generate protobufs with gogofaster

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -32,8 +32,8 @@ func (p *PubSub) getHelloPacket() *RPC {
 
 	for t := range subscriptions {
 		as := &pb.RPC_SubOpts{
-			Topicid:   proto.String(t),
-			Subscribe: proto.Bool(true),
+			Topicid:   t,
+			Subscribe: true,
 		}
 		rpc.Subscriptions = append(rpc.Subscriptions, as)
 	}

--- a/compat_test.go
+++ b/compat_test.go
@@ -15,7 +15,7 @@ func TestMultitopicMessageCompatibility(t *testing.T) {
 		From:      []byte("A"),
 		Data:      []byte("blah"),
 		Seqno:     []byte("123"),
-		Topic:     &topic1,
+		Topic:     topic1,
 		Signature: []byte("a-signature"),
 		Key:       []byte("a-key"),
 	}

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
 github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -600,6 +601,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/src-d/go-cli.v0 v0.0.0-20181105080154-d492247bbc0d/go.mod h1:z+K8VcOYVYcSwSjGebuDL6176A1XskgbtNl64NSg+n8=
 gopkg.in/src-d/go-log.v1 v1.0.1/go.mod h1:GN34hKP0g305ysm2/hctJ0Y8nWP3zxXXJ8GFabTyABE=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/gossipsub_spam_test.go
+++ b/gossipsub_spam_test.go
@@ -316,7 +316,7 @@ func TestGossipsubAttackGRAFTNonExistentTopic(t *testing.T) {
 				// Graft to the peer on a non-existent topic
 				nonExistentTopic := "non-existent"
 				writeMsg(&pb.RPC{
-					Control: &pb.ControlMessage{Graft: []*pb.ControlGraft{&pb.ControlGraft{TopicID: &nonExistentTopic}}},
+					Control: &pb.ControlMessage{Graft: []*pb.ControlGraft{&pb.ControlGraft{TopicID: nonExistentTopic}}},
 				})
 
 				go func() {
@@ -663,7 +663,7 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 					for i := 0; i < 100; i++ {
 						msg := &pb.Message{
 							Data:  []byte("some data" + strconv.Itoa(i)),
-							Topic: &mytopic,
+							Topic: mytopic,
 							From:  []byte(attacker.ID()),
 							Seqno: []byte{byte(i + 1)},
 						}

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1579,8 +1579,8 @@ func TestGossipsubPiggybackControl(t *testing.T) {
 
 		rpc := &RPC{RPC: pb.RPC{}}
 		gs.piggybackControl(blah, rpc, &pb.ControlMessage{
-			Graft: []*pb.ControlGraft{&pb.ControlGraft{TopicID: &test1}, &pb.ControlGraft{TopicID: &test2}, &pb.ControlGraft{TopicID: &test3}},
-			Prune: []*pb.ControlPrune{&pb.ControlPrune{TopicID: &test1}, &pb.ControlPrune{TopicID: &test2}, &pb.ControlPrune{TopicID: &test3}},
+			Graft: []*pb.ControlGraft{&pb.ControlGraft{TopicID: test1}, &pb.ControlGraft{TopicID: test2}, &pb.ControlGraft{TopicID: test3}},
+			Prune: []*pb.ControlPrune{&pb.ControlPrune{TopicID: test1}, &pb.ControlPrune{TopicID: test2}, &pb.ControlPrune{TopicID: test3}},
 		})
 		res <- rpc
 	}
@@ -1796,7 +1796,7 @@ func (sq *sybilSquatter) handleStream(s network.Stream) {
 	w := protoio.NewDelimitedWriter(os)
 	truth := true
 	topic := "test"
-	err = w.WriteMsg(&pb.RPC{Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: &truth, Topicid: &topic}}})
+	err = w.WriteMsg(&pb.RPC{Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: truth, Topicid: topic}}})
 	if err != nil {
 		panic(err)
 	}
@@ -2028,7 +2028,7 @@ func (iwe *iwantEverything) handleStream(s network.Stream) {
 	w := protoio.NewDelimitedWriter(os)
 	truth := true
 	topic := "test"
-	err = w.WriteMsg(&pb.RPC{Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: &truth, Topicid: &topic}}})
+	err = w.WriteMsg(&pb.RPC{Subscriptions: []*pb.RPC_SubOpts{&pb.RPC_SubOpts{Subscribe: truth, Topicid: topic}}})
 
 	var rpc pb.RPC
 	for {
@@ -2127,8 +2127,8 @@ func TestFragmentRPCFunction(t *testing.T) {
 	truth := true
 	rpc.Subscriptions = []*pb.RPC_SubOpts{
 		{
-			Subscribe: &truth,
-			Topicid:   &topic,
+			Subscribe: truth,
+			Topicid:   topic,
 		},
 	}
 	rpc.Publish = make([]*pb.Message, nMessages)
@@ -2162,8 +2162,8 @@ func TestFragmentRPCFunction(t *testing.T) {
 	// the control messages should be in a separate RPC at the end
 	// reuse RPC from prev test, but add a control message
 	rpc.Control = &pb.ControlMessage{
-		Graft: []*pb.ControlGraft{{TopicID: &topic}},
-		Prune: []*pb.ControlPrune{{TopicID: &topic}},
+		Graft: []*pb.ControlGraft{{TopicID: topic}},
+		Prune: []*pb.ControlPrune{{TopicID: topic}},
 		Ihave: []*pb.ControlIHave{{MessageIDs: []string{"foo"}}},
 		Iwant: []*pb.ControlIWant{{MessageIDs: []string{"bar"}}},
 	}

--- a/mcache_test.go
+++ b/mcache_test.go
@@ -160,7 +160,7 @@ func makeTestMessage(n int) *pb.Message {
 	topic := "test"
 	return &pb.Message{
 		Data:  data,
-		Topic: &topic,
+		Topic: topic,
 		From:  []byte("test"),
 		Seqno: seqno,
 	}

--- a/pb/Makefile
+++ b/pb/Makefile
@@ -4,7 +4,7 @@ GO = $(PB:.proto=.pb.go)
 all: $(GO)
 
 %.pb.go: %.proto
-		protoc --proto_path=$(GOPATH)/src:. --gogofast_out=. $<
+		protoc --proto_path=$(GOPATH)/src:. --gogofaster_out=. $<
 
 clean:
 		rm -f *.pb.go

--- a/pb/rpc.pb.go
+++ b/pb/rpc.pb.go
@@ -109,12 +109,9 @@ func (TopicDescriptor_EncOpts_EncMode) EnumDescriptor() ([]byte, []int) {
 }
 
 type RPC struct {
-	Subscriptions        []*RPC_SubOpts  `protobuf:"bytes,1,rep,name=subscriptions" json:"subscriptions,omitempty"`
-	Publish              []*Message      `protobuf:"bytes,2,rep,name=publish" json:"publish,omitempty"`
-	Control              *ControlMessage `protobuf:"bytes,3,opt,name=control" json:"control,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
-	XXX_unrecognized     []byte          `json:"-"`
-	XXX_sizecache        int32           `json:"-"`
+	Subscriptions []*RPC_SubOpts  `protobuf:"bytes,1,rep,name=subscriptions" json:"subscriptions,omitempty"`
+	Publish       []*Message      `protobuf:"bytes,2,rep,name=publish" json:"publish,omitempty"`
+	Control       *ControlMessage `protobuf:"bytes,3,opt,name=control" json:"control,omitempty"`
 }
 
 func (m *RPC) Reset()         { *m = RPC{} }
@@ -172,11 +169,8 @@ func (m *RPC) GetControl() *ControlMessage {
 }
 
 type RPC_SubOpts struct {
-	Subscribe            *bool    `protobuf:"varint,1,opt,name=subscribe" json:"subscribe,omitempty"`
-	Topicid              *string  `protobuf:"bytes,2,opt,name=topicid" json:"topicid,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Subscribe bool   `protobuf:"varint,1,opt,name=subscribe" json:"subscribe"`
+	Topicid   string `protobuf:"bytes,2,opt,name=topicid" json:"topicid"`
 }
 
 func (m *RPC_SubOpts) Reset()         { *m = RPC_SubOpts{} }
@@ -213,29 +207,26 @@ func (m *RPC_SubOpts) XXX_DiscardUnknown() {
 var xxx_messageInfo_RPC_SubOpts proto.InternalMessageInfo
 
 func (m *RPC_SubOpts) GetSubscribe() bool {
-	if m != nil && m.Subscribe != nil {
-		return *m.Subscribe
+	if m != nil {
+		return m.Subscribe
 	}
 	return false
 }
 
 func (m *RPC_SubOpts) GetTopicid() string {
-	if m != nil && m.Topicid != nil {
-		return *m.Topicid
+	if m != nil {
+		return m.Topicid
 	}
 	return ""
 }
 
 type Message struct {
-	From                 []byte   `protobuf:"bytes,1,opt,name=from" json:"from,omitempty"`
-	Data                 []byte   `protobuf:"bytes,2,opt,name=data" json:"data,omitempty"`
-	Seqno                []byte   `protobuf:"bytes,3,opt,name=seqno" json:"seqno,omitempty"`
-	Topic                *string  `protobuf:"bytes,4,opt,name=topic" json:"topic,omitempty"`
-	Signature            []byte   `protobuf:"bytes,5,opt,name=signature" json:"signature,omitempty"`
-	Key                  []byte   `protobuf:"bytes,6,opt,name=key" json:"key,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	From      []byte `protobuf:"bytes,1,opt,name=from" json:"from"`
+	Data      []byte `protobuf:"bytes,2,opt,name=data" json:"data"`
+	Seqno     []byte `protobuf:"bytes,3,opt,name=seqno" json:"seqno"`
+	Topic     string `protobuf:"bytes,4,opt,name=topic" json:"topic"`
+	Signature []byte `protobuf:"bytes,5,opt,name=signature" json:"signature"`
+	Key       []byte `protobuf:"bytes,6,opt,name=key" json:"key"`
 }
 
 func (m *Message) Reset()         { *m = Message{} }
@@ -293,8 +284,8 @@ func (m *Message) GetSeqno() []byte {
 }
 
 func (m *Message) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
@@ -314,13 +305,10 @@ func (m *Message) GetKey() []byte {
 }
 
 type ControlMessage struct {
-	Ihave                []*ControlIHave `protobuf:"bytes,1,rep,name=ihave" json:"ihave,omitempty"`
-	Iwant                []*ControlIWant `protobuf:"bytes,2,rep,name=iwant" json:"iwant,omitempty"`
-	Graft                []*ControlGraft `protobuf:"bytes,3,rep,name=graft" json:"graft,omitempty"`
-	Prune                []*ControlPrune `protobuf:"bytes,4,rep,name=prune" json:"prune,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
-	XXX_unrecognized     []byte          `json:"-"`
-	XXX_sizecache        int32           `json:"-"`
+	Ihave []*ControlIHave `protobuf:"bytes,1,rep,name=ihave" json:"ihave,omitempty"`
+	Iwant []*ControlIWant `protobuf:"bytes,2,rep,name=iwant" json:"iwant,omitempty"`
+	Graft []*ControlGraft `protobuf:"bytes,3,rep,name=graft" json:"graft,omitempty"`
+	Prune []*ControlPrune `protobuf:"bytes,4,rep,name=prune" json:"prune,omitempty"`
 }
 
 func (m *ControlMessage) Reset()         { *m = ControlMessage{} }
@@ -385,12 +373,9 @@ func (m *ControlMessage) GetPrune() []*ControlPrune {
 }
 
 type ControlIHave struct {
-	TopicID *string `protobuf:"bytes,1,opt,name=topicID" json:"topicID,omitempty"`
+	TopicID string `protobuf:"bytes,1,opt,name=topicID" json:"topicID"`
 	// implementors from other languages should use bytes here - go protobuf emits invalid utf8 strings
-	MessageIDs           []string `protobuf:"bytes,2,rep,name=messageIDs" json:"messageIDs,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	MessageIDs []string `protobuf:"bytes,2,rep,name=messageIDs" json:"messageIDs,omitempty"`
 }
 
 func (m *ControlIHave) Reset()         { *m = ControlIHave{} }
@@ -427,8 +412,8 @@ func (m *ControlIHave) XXX_DiscardUnknown() {
 var xxx_messageInfo_ControlIHave proto.InternalMessageInfo
 
 func (m *ControlIHave) GetTopicID() string {
-	if m != nil && m.TopicID != nil {
-		return *m.TopicID
+	if m != nil {
+		return m.TopicID
 	}
 	return ""
 }
@@ -442,10 +427,7 @@ func (m *ControlIHave) GetMessageIDs() []string {
 
 type ControlIWant struct {
 	// implementors from other languages should use bytes here - go protobuf emits invalid utf8 strings
-	MessageIDs           []string `protobuf:"bytes,1,rep,name=messageIDs" json:"messageIDs,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	MessageIDs []string `protobuf:"bytes,1,rep,name=messageIDs" json:"messageIDs,omitempty"`
 }
 
 func (m *ControlIWant) Reset()         { *m = ControlIWant{} }
@@ -489,10 +471,7 @@ func (m *ControlIWant) GetMessageIDs() []string {
 }
 
 type ControlGraft struct {
-	TopicID              *string  `protobuf:"bytes,1,opt,name=topicID" json:"topicID,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	TopicID string `protobuf:"bytes,1,opt,name=topicID" json:"topicID"`
 }
 
 func (m *ControlGraft) Reset()         { *m = ControlGraft{} }
@@ -529,19 +508,16 @@ func (m *ControlGraft) XXX_DiscardUnknown() {
 var xxx_messageInfo_ControlGraft proto.InternalMessageInfo
 
 func (m *ControlGraft) GetTopicID() string {
-	if m != nil && m.TopicID != nil {
-		return *m.TopicID
+	if m != nil {
+		return m.TopicID
 	}
 	return ""
 }
 
 type ControlPrune struct {
-	TopicID              *string     `protobuf:"bytes,1,opt,name=topicID" json:"topicID,omitempty"`
-	Peers                []*PeerInfo `protobuf:"bytes,2,rep,name=peers" json:"peers,omitempty"`
-	Backoff              *uint64     `protobuf:"varint,3,opt,name=backoff" json:"backoff,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
-	XXX_unrecognized     []byte      `json:"-"`
-	XXX_sizecache        int32       `json:"-"`
+	TopicID string      `protobuf:"bytes,1,opt,name=topicID" json:"topicID"`
+	Peers   []*PeerInfo `protobuf:"bytes,2,rep,name=peers" json:"peers,omitempty"`
+	Backoff uint64      `protobuf:"varint,3,opt,name=backoff" json:"backoff"`
 }
 
 func (m *ControlPrune) Reset()         { *m = ControlPrune{} }
@@ -578,8 +554,8 @@ func (m *ControlPrune) XXX_DiscardUnknown() {
 var xxx_messageInfo_ControlPrune proto.InternalMessageInfo
 
 func (m *ControlPrune) GetTopicID() string {
-	if m != nil && m.TopicID != nil {
-		return *m.TopicID
+	if m != nil {
+		return m.TopicID
 	}
 	return ""
 }
@@ -592,18 +568,15 @@ func (m *ControlPrune) GetPeers() []*PeerInfo {
 }
 
 func (m *ControlPrune) GetBackoff() uint64 {
-	if m != nil && m.Backoff != nil {
-		return *m.Backoff
+	if m != nil {
+		return m.Backoff
 	}
 	return 0
 }
 
 type PeerInfo struct {
-	PeerID               []byte   `protobuf:"bytes,1,opt,name=peerID" json:"peerID,omitempty"`
-	SignedPeerRecord     []byte   `protobuf:"bytes,2,opt,name=signedPeerRecord" json:"signedPeerRecord,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	PeerID           []byte `protobuf:"bytes,1,opt,name=peerID" json:"peerID"`
+	SignedPeerRecord []byte `protobuf:"bytes,2,opt,name=signedPeerRecord" json:"signedPeerRecord"`
 }
 
 func (m *PeerInfo) Reset()         { *m = PeerInfo{} }
@@ -654,12 +627,9 @@ func (m *PeerInfo) GetSignedPeerRecord() []byte {
 }
 
 type TopicDescriptor struct {
-	Name                 *string                   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	Auth                 *TopicDescriptor_AuthOpts `protobuf:"bytes,2,opt,name=auth" json:"auth,omitempty"`
-	Enc                  *TopicDescriptor_EncOpts  `protobuf:"bytes,3,opt,name=enc" json:"enc,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
-	XXX_unrecognized     []byte                    `json:"-"`
-	XXX_sizecache        int32                     `json:"-"`
+	Name string                    `protobuf:"bytes,1,opt,name=name" json:"name"`
+	Auth *TopicDescriptor_AuthOpts `protobuf:"bytes,2,opt,name=auth" json:"auth,omitempty"`
+	Enc  *TopicDescriptor_EncOpts  `protobuf:"bytes,3,opt,name=enc" json:"enc,omitempty"`
 }
 
 func (m *TopicDescriptor) Reset()         { *m = TopicDescriptor{} }
@@ -696,8 +666,8 @@ func (m *TopicDescriptor) XXX_DiscardUnknown() {
 var xxx_messageInfo_TopicDescriptor proto.InternalMessageInfo
 
 func (m *TopicDescriptor) GetName() string {
-	if m != nil && m.Name != nil {
-		return *m.Name
+	if m != nil {
+		return m.Name
 	}
 	return ""
 }
@@ -717,11 +687,8 @@ func (m *TopicDescriptor) GetEnc() *TopicDescriptor_EncOpts {
 }
 
 type TopicDescriptor_AuthOpts struct {
-	Mode                 *TopicDescriptor_AuthOpts_AuthMode `protobuf:"varint,1,opt,name=mode,enum=pubsub.pb.TopicDescriptor_AuthOpts_AuthMode" json:"mode,omitempty"`
-	Keys                 [][]byte                           `protobuf:"bytes,2,rep,name=keys" json:"keys,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                           `json:"-"`
-	XXX_unrecognized     []byte                             `json:"-"`
-	XXX_sizecache        int32                              `json:"-"`
+	Mode TopicDescriptor_AuthOpts_AuthMode `protobuf:"varint,1,opt,name=mode,enum=pubsub.pb.TopicDescriptor_AuthOpts_AuthMode" json:"mode"`
+	Keys [][]byte                          `protobuf:"bytes,2,rep,name=keys" json:"keys,omitempty"`
 }
 
 func (m *TopicDescriptor_AuthOpts) Reset()         { *m = TopicDescriptor_AuthOpts{} }
@@ -758,8 +725,8 @@ func (m *TopicDescriptor_AuthOpts) XXX_DiscardUnknown() {
 var xxx_messageInfo_TopicDescriptor_AuthOpts proto.InternalMessageInfo
 
 func (m *TopicDescriptor_AuthOpts) GetMode() TopicDescriptor_AuthOpts_AuthMode {
-	if m != nil && m.Mode != nil {
-		return *m.Mode
+	if m != nil {
+		return m.Mode
 	}
 	return TopicDescriptor_AuthOpts_NONE
 }
@@ -772,11 +739,8 @@ func (m *TopicDescriptor_AuthOpts) GetKeys() [][]byte {
 }
 
 type TopicDescriptor_EncOpts struct {
-	Mode                 *TopicDescriptor_EncOpts_EncMode `protobuf:"varint,1,opt,name=mode,enum=pubsub.pb.TopicDescriptor_EncOpts_EncMode" json:"mode,omitempty"`
-	KeyHashes            [][]byte                         `protobuf:"bytes,2,rep,name=keyHashes" json:"keyHashes,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                         `json:"-"`
-	XXX_unrecognized     []byte                           `json:"-"`
-	XXX_sizecache        int32                            `json:"-"`
+	Mode      TopicDescriptor_EncOpts_EncMode `protobuf:"varint,1,opt,name=mode,enum=pubsub.pb.TopicDescriptor_EncOpts_EncMode" json:"mode"`
+	KeyHashes [][]byte                        `protobuf:"bytes,2,rep,name=keyHashes" json:"keyHashes,omitempty"`
 }
 
 func (m *TopicDescriptor_EncOpts) Reset()         { *m = TopicDescriptor_EncOpts{} }
@@ -813,8 +777,8 @@ func (m *TopicDescriptor_EncOpts) XXX_DiscardUnknown() {
 var xxx_messageInfo_TopicDescriptor_EncOpts proto.InternalMessageInfo
 
 func (m *TopicDescriptor_EncOpts) GetMode() TopicDescriptor_EncOpts_EncMode {
-	if m != nil && m.Mode != nil {
-		return *m.Mode
+	if m != nil {
+		return m.Mode
 	}
 	return TopicDescriptor_EncOpts_NONE
 }
@@ -846,49 +810,51 @@ func init() {
 func init() { proto.RegisterFile("rpc.proto", fileDescriptor_77a6da22d6a3feb1) }
 
 var fileDescriptor_77a6da22d6a3feb1 = []byte{
-	// 662 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xcf, 0x6e, 0xd3, 0x4a,
-	0x14, 0xc6, 0xef, 0xd4, 0x4e, 0x1d, 0x9f, 0xba, 0xbd, 0xd1, 0xdc, 0xab, 0x62, 0xaa, 0x2a, 0x8a,
-	0x8c, 0x84, 0x42, 0x29, 0x5e, 0x04, 0x24, 0x36, 0x08, 0x51, 0x9a, 0x88, 0x44, 0xa8, 0x6d, 0x34,
-	0xad, 0x54, 0xb1, 0xb4, 0x9d, 0x49, 0x63, 0xa5, 0xf1, 0x18, 0xff, 0x29, 0xea, 0x1b, 0xb0, 0x61,
-	0xc7, 0xb3, 0xf0, 0x0c, 0x2c, 0x58, 0xf0, 0x08, 0xa8, 0x3b, 0xde, 0x02, 0xcd, 0xf1, 0x38, 0x71,
-	0x5a, 0x5a, 0x58, 0xf9, 0xcc, 0x99, 0xdf, 0x77, 0xce, 0x37, 0xc7, 0x33, 0x60, 0x26, 0x71, 0xe0,
-	0xc6, 0x89, 0xc8, 0x04, 0x35, 0xe3, 0xdc, 0x4f, 0x73, 0xdf, 0x8d, 0x7d, 0xe7, 0x27, 0x01, 0x8d,
-	0x0d, 0xf7, 0xe9, 0x0b, 0x58, 0x4f, 0x73, 0x3f, 0x0d, 0x92, 0x30, 0xce, 0x42, 0x11, 0xa5, 0x36,
-	0x69, 0x69, 0xed, 0xb5, 0xce, 0xa6, 0x3b, 0x47, 0x5d, 0x36, 0xdc, 0x77, 0x8f, 0x73, 0xff, 0x28,
-	0xce, 0x52, 0xb6, 0x0c, 0xd3, 0x5d, 0x30, 0xe2, 0xdc, 0x3f, 0x0f, 0xd3, 0x89, 0xbd, 0x82, 0x3a,
-	0x5a, 0xd1, 0x1d, 0xf0, 0x34, 0xf5, 0xce, 0x38, 0x2b, 0x11, 0xfa, 0x14, 0x8c, 0x40, 0x44, 0x59,
-	0x22, 0xce, 0x6d, 0xad, 0x45, 0xda, 0x6b, 0x9d, 0xfb, 0x15, 0x7a, 0xbf, 0xd8, 0x99, 0x8b, 0x14,
-	0xb9, 0xb5, 0x07, 0x86, 0x6a, 0x4e, 0xb7, 0xc1, 0x54, 0xed, 0x7d, 0x6e, 0x93, 0x16, 0x69, 0xd7,
-	0xd9, 0x22, 0x41, 0x6d, 0x30, 0x32, 0x11, 0x87, 0x41, 0x38, 0xb2, 0x57, 0x5a, 0xa4, 0x6d, 0xb2,
-	0x72, 0xe9, 0x7c, 0x22, 0x60, 0xa8, 0xba, 0x94, 0x82, 0x3e, 0x4e, 0xc4, 0x0c, 0xe5, 0x16, 0xc3,
-	0x58, 0xe6, 0x46, 0x5e, 0xe6, 0xa1, 0xcc, 0x62, 0x18, 0xd3, 0xff, 0xa1, 0x96, 0xf2, 0xf7, 0x91,
-	0x40, 0xa7, 0x16, 0x2b, 0x16, 0x32, 0x8b, 0x45, 0x6d, 0x1d, 0x3b, 0x14, 0x0b, 0xf4, 0x15, 0x9e,
-	0x45, 0x5e, 0x96, 0x27, 0xdc, 0xae, 0x21, 0xbf, 0x48, 0xd0, 0x06, 0x68, 0x53, 0x7e, 0x69, 0xaf,
-	0x62, 0x5e, 0x86, 0xce, 0x37, 0x02, 0x1b, 0xcb, 0xc7, 0xa5, 0x4f, 0xa0, 0x16, 0x4e, 0xbc, 0x0b,
-	0xae, 0xc6, 0x7f, 0xef, 0xe6, 0x60, 0x06, 0x7d, 0xef, 0x82, 0xb3, 0x82, 0x42, 0xfc, 0x83, 0x17,
-	0x65, 0x6a, 0xea, 0xbf, 0xc3, 0x4f, 0xbd, 0x28, 0x63, 0x05, 0x25, 0xf1, 0xb3, 0xc4, 0x1b, 0x67,
-	0xb6, 0x76, 0x1b, 0xfe, 0x46, 0x6e, 0xb3, 0x82, 0x92, 0x78, 0x9c, 0xe4, 0x11, 0xb7, 0xf5, 0xdb,
-	0xf0, 0xa1, 0xdc, 0x66, 0x05, 0xe5, 0xf4, 0xc1, 0xaa, 0x7a, 0x9c, 0xff, 0x88, 0x41, 0x17, 0xa7,
-	0x5c, 0xfe, 0x88, 0x41, 0x97, 0x36, 0x01, 0x66, 0xc5, 0x81, 0x07, 0xdd, 0x14, 0xbd, 0x9b, 0xac,
-	0x92, 0x71, 0xdc, 0x45, 0x25, 0x69, 0xff, 0x1a, 0x4f, 0x6e, 0xf0, 0xed, 0x39, 0x8f, 0xfe, 0x6f,
-	0xef, 0xec, 0xcc, 0xe6, 0x24, 0x5a, 0xbf, 0xc3, 0xe3, 0x23, 0xa8, 0xc5, 0x9c, 0x27, 0xa9, 0x1a,
-	0xed, 0x7f, 0x95, 0xc3, 0x0f, 0x39, 0x4f, 0x06, 0xd1, 0x58, 0xb0, 0x82, 0x90, 0x45, 0x7c, 0x2f,
-	0x98, 0x8a, 0xf1, 0x18, 0x6f, 0x89, 0xce, 0xca, 0xa5, 0x73, 0x08, 0xf5, 0x12, 0xa6, 0x9b, 0xb0,
-	0x2a, 0x71, 0xd5, 0xc9, 0x62, 0x6a, 0x45, 0x77, 0xa0, 0x21, 0x2f, 0x09, 0x1f, 0x49, 0x92, 0xf1,
-	0x40, 0x24, 0x23, 0x75, 0x03, 0x6f, 0xe4, 0x9d, 0x2f, 0x1a, 0xfc, 0x7b, 0x22, 0x0d, 0x76, 0x79,
-	0xf1, 0xfa, 0x44, 0x22, 0x6f, 0x6d, 0xe4, 0xcd, 0xb8, 0xf2, 0x8f, 0x31, 0x7d, 0x0e, 0xba, 0x97,
-	0x67, 0x13, 0xac, 0xb3, 0xd6, 0x79, 0x50, 0xf1, 0x7e, 0x4d, 0xed, 0xee, 0xe5, 0xd9, 0x04, 0x5f,
-	0x34, 0x0a, 0xe8, 0x33, 0xd0, 0x78, 0x14, 0xa8, 0x67, 0xe9, 0xdc, 0xa1, 0xeb, 0x45, 0x01, 0xca,
-	0x24, 0xbe, 0xf5, 0x91, 0x40, 0xbd, 0x2c, 0x44, 0x5f, 0x81, 0x3e, 0x13, 0xa3, 0xc2, 0xcf, 0x46,
-	0x67, 0xf7, 0x2f, 0x7a, 0x63, 0x70, 0x20, 0x46, 0x9c, 0xa1, 0x52, 0x9e, 0x68, 0xca, 0x2f, 0x8b,
-	0xc9, 0x5b, 0x0c, 0x63, 0xe7, 0x61, 0xd1, 0x41, 0x52, 0xb4, 0x0e, 0xfa, 0xe1, 0xd1, 0x61, 0xaf,
-	0xf1, 0x0f, 0x35, 0x40, 0x7b, 0xdb, 0x7b, 0xd7, 0x20, 0x32, 0x38, 0x3d, 0x3a, 0x69, 0xac, 0x6c,
-	0x7d, 0x26, 0x60, 0x28, 0x6f, 0xf4, 0xe5, 0x92, 0x93, 0x9d, 0x3f, 0x9f, 0x46, 0x7e, 0x2b, 0x3e,
-	0xb6, 0xc1, 0x9c, 0xf2, 0xcb, 0xbe, 0x97, 0x4e, 0x78, 0x69, 0x66, 0x91, 0x70, 0x1e, 0x63, 0xa3,
-	0x6b, 0x86, 0xd6, 0xc1, 0x3c, 0xee, 0xef, 0xb1, 0x5e, 0x77, 0xd9, 0xd6, 0x6b, 0xeb, 0xeb, 0x55,
-	0x93, 0x7c, 0xbf, 0x6a, 0x92, 0x1f, 0x57, 0x4d, 0xf2, 0x2b, 0x00, 0x00, 0xff, 0xff, 0xfc, 0x52,
-	0x7a, 0xa2, 0x8b, 0x05, 0x00, 0x00,
+	// 690 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x94, 0xcf, 0x6e, 0xd3, 0x4e,
+	0x10, 0xc7, 0xb3, 0xb5, 0x53, 0xc7, 0xd3, 0x3f, 0xbf, 0x68, 0x7f, 0x52, 0x31, 0x51, 0x65, 0x22,
+	0x23, 0xa1, 0x00, 0xc5, 0x42, 0x01, 0x89, 0x0b, 0x97, 0xb6, 0x09, 0x34, 0x42, 0x6d, 0xa3, 0x6d,
+	0xa5, 0x0a, 0x6e, 0xb6, 0xb3, 0x69, 0xac, 0x34, 0x5e, 0xe3, 0x3f, 0x45, 0x79, 0x09, 0xc4, 0x99,
+	0xb7, 0xe0, 0x2d, 0x7a, 0xe0, 0xd0, 0x23, 0x27, 0x84, 0xda, 0x67, 0xe0, 0x8e, 0x76, 0xbd, 0x4e,
+	0xec, 0x96, 0xb6, 0x9c, 0xb2, 0xfa, 0xce, 0x67, 0x66, 0xbe, 0xb3, 0xb3, 0x0e, 0xe8, 0x51, 0xe8,
+	0xd9, 0x61, 0xc4, 0x12, 0x86, 0xf5, 0x30, 0x75, 0xe3, 0xd4, 0xb5, 0x43, 0xd7, 0xfa, 0x8d, 0x40,
+	0x21, 0xfd, 0x6d, 0xfc, 0x1a, 0x56, 0xe2, 0xd4, 0x8d, 0xbd, 0xc8, 0x0f, 0x13, 0x9f, 0x05, 0xb1,
+	0x81, 0x9a, 0x4a, 0x6b, 0xa9, 0xbd, 0x66, 0xcf, 0x50, 0x9b, 0xf4, 0xb7, 0xed, 0x83, 0xd4, 0xdd,
+	0x0f, 0x93, 0x98, 0x94, 0x61, 0xbc, 0x01, 0x5a, 0x98, 0xba, 0x27, 0x7e, 0x3c, 0x32, 0x16, 0x44,
+	0x1e, 0x2e, 0xe4, 0xed, 0xd2, 0x38, 0x76, 0x8e, 0x29, 0xc9, 0x11, 0xfc, 0x02, 0x34, 0x8f, 0x05,
+	0x49, 0xc4, 0x4e, 0x0c, 0xa5, 0x89, 0x5a, 0x4b, 0xed, 0xfb, 0x05, 0x7a, 0x3b, 0x8b, 0xcc, 0x92,
+	0x24, 0xd9, 0xd8, 0x05, 0x4d, 0x36, 0xc7, 0x16, 0xe8, 0xb2, 0xbd, 0x4b, 0x0d, 0xd4, 0x44, 0xad,
+	0xda, 0x96, 0x7a, 0xf6, 0xf3, 0x41, 0x85, 0xcc, 0x65, 0x6c, 0x82, 0x96, 0xb0, 0xd0, 0xf7, 0xfc,
+	0x81, 0xb1, 0xd0, 0x44, 0x2d, 0x5d, 0x12, 0xb9, 0x68, 0x7d, 0x43, 0xa0, 0xc9, 0x1e, 0xd8, 0x00,
+	0x75, 0x18, 0xb1, 0x89, 0x28, 0xb5, 0x2c, 0x41, 0xa1, 0xf0, 0xc8, 0xc0, 0x49, 0x1c, 0x51, 0x62,
+	0x16, 0xe1, 0x0a, 0x6e, 0x40, 0x35, 0xa6, 0x1f, 0x03, 0x26, 0x26, 0xc8, 0x43, 0x99, 0xc4, 0x63,
+	0xa2, 0x8d, 0xa1, 0x16, 0x3a, 0x67, 0x92, 0xf0, 0xee, 0x1f, 0x07, 0x4e, 0x92, 0x46, 0xd4, 0xa8,
+	0x16, 0x72, 0xe7, 0x32, 0x5e, 0x03, 0x65, 0x4c, 0xa7, 0xc6, 0x62, 0x21, 0xca, 0x05, 0xeb, 0x3b,
+	0x82, 0xd5, 0xf2, 0xf5, 0xe0, 0x67, 0x50, 0xf5, 0x47, 0xce, 0x29, 0x95, 0xeb, 0xba, 0x77, 0xfd,
+	0x22, 0x7b, 0x3b, 0xce, 0x29, 0x25, 0x19, 0x25, 0xf0, 0x4f, 0x4e, 0x90, 0xc8, 0x2d, 0xfd, 0x0d,
+	0x3f, 0x72, 0x82, 0x84, 0x64, 0x14, 0xc7, 0x8f, 0x23, 0x67, 0x98, 0x18, 0xca, 0x4d, 0xf8, 0x5b,
+	0x1e, 0x26, 0x19, 0xc5, 0xf1, 0x30, 0x4a, 0x03, 0x6a, 0xa8, 0x37, 0xe1, 0x7d, 0x1e, 0x26, 0x19,
+	0x65, 0xed, 0xc1, 0x72, 0xd1, 0xe3, 0x6c, 0x65, 0xbd, 0x8e, 0xd8, 0x44, 0x79, 0x65, 0xbd, 0x0e,
+	0x36, 0x01, 0x26, 0xd9, 0xd8, 0xbd, 0x4e, 0x2c, 0x26, 0xd0, 0x49, 0x41, 0xb1, 0xec, 0x79, 0x3d,
+	0x3e, 0xc4, 0x15, 0x1e, 0xdd, 0xc2, 0x8b, 0x29, 0xee, 0xea, 0x6f, 0x4d, 0x67, 0xbc, 0x18, 0xe3,
+	0x4e, 0xbf, 0x8f, 0xa1, 0x1a, 0x52, 0x1a, 0xc5, 0xf2, 0xb2, 0xff, 0x2f, 0x5c, 0x47, 0x9f, 0xd2,
+	0xa8, 0x17, 0x0c, 0x19, 0xc9, 0x08, 0x5e, 0xca, 0x75, 0xbc, 0x31, 0x1b, 0x0e, 0xc5, 0x7b, 0x52,
+	0xf3, 0x52, 0x52, 0xb4, 0x3e, 0x40, 0x2d, 0x4f, 0xc1, 0xeb, 0xb0, 0xc8, 0x93, 0x64, 0xd7, 0xfc,
+	0x81, 0x48, 0x0d, 0x3f, 0x87, 0x3a, 0x7f, 0x48, 0x74, 0xc0, 0x79, 0x42, 0x3d, 0x16, 0x0d, 0x4a,
+	0xaf, 0xf7, 0x5a, 0xd4, 0x3a, 0x53, 0xe0, 0xbf, 0x43, 0x6e, 0xb9, 0x43, 0xb3, 0x2f, 0x9a, 0x45,
+	0xfc, 0xdd, 0x07, 0xce, 0x84, 0x96, 0xe6, 0x12, 0x0a, 0x7e, 0x05, 0xaa, 0x93, 0x26, 0x23, 0x51,
+	0x73, 0xa9, 0xfd, 0xb0, 0x30, 0xd3, 0x95, 0x1a, 0xf6, 0x66, 0x9a, 0x8c, 0xc4, 0x7f, 0x85, 0x48,
+	0xc0, 0x2f, 0x41, 0xa1, 0x81, 0x27, 0x3f, 0x78, 0xeb, 0x96, 0xbc, 0x6e, 0xe0, 0x89, 0x34, 0x8e,
+	0x37, 0x3e, 0x23, 0xa8, 0xe5, 0x85, 0xf0, 0x1b, 0x50, 0x27, 0x6c, 0x90, 0xb9, 0x5a, 0x6d, 0x6f,
+	0xfc, 0x43, 0x6f, 0x71, 0xd8, 0x65, 0x03, 0x9a, 0xcf, 0xc0, 0xf3, 0x31, 0x06, 0x75, 0x4c, 0xa7,
+	0xd9, 0x5e, 0x96, 0x89, 0x38, 0x5b, 0x8f, 0xb2, 0x3e, 0x9c, 0xc5, 0x35, 0x50, 0xf7, 0xf6, 0xf7,
+	0xba, 0xf5, 0x0a, 0xd6, 0x40, 0x79, 0xd7, 0x7d, 0x5f, 0x47, 0xfc, 0x70, 0xb4, 0x7f, 0x58, 0x5f,
+	0x68, 0x7c, 0x45, 0xa0, 0x49, 0x87, 0xb8, 0x53, 0xf2, 0xf3, 0xe4, 0xee, 0x99, 0xf8, 0xef, 0x35,
+	0x37, 0xeb, 0xa0, 0x8f, 0xe9, 0x74, 0xc7, 0x89, 0x47, 0x34, 0xb7, 0x34, 0x17, 0xac, 0xa7, 0xa2,
+	0xdd, 0x15, 0x5b, 0x2b, 0xa0, 0x1f, 0xec, 0x6c, 0x92, 0x6e, 0xa7, 0x6c, 0x6e, 0xcb, 0x38, 0xbb,
+	0x30, 0xd1, 0xf9, 0x85, 0x89, 0x7e, 0x5d, 0x98, 0xe8, 0xcb, 0xa5, 0x59, 0x39, 0xbf, 0x34, 0x2b,
+	0x3f, 0x2e, 0xcd, 0xca, 0x9f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x6f, 0x68, 0x61, 0x87, 0xfd, 0x05,
+	0x00, 0x00,
 }
 
 func (m *RPC) Marshal() (dAtA []byte, err error) {
@@ -911,10 +877,6 @@ func (m *RPC) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.Control != nil {
 		{
 			size, err := m.Control.MarshalToSizedBuffer(dAtA[:i])
@@ -978,27 +940,19 @@ func (m *RPC_SubOpts) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
+	i -= len(m.Topicid)
+	copy(dAtA[i:], m.Topicid)
+	i = encodeVarintRpc(dAtA, i, uint64(len(m.Topicid)))
+	i--
+	dAtA[i] = 0x12
+	i--
+	if m.Subscribe {
+		dAtA[i] = 1
+	} else {
+		dAtA[i] = 0
 	}
-	if m.Topicid != nil {
-		i -= len(*m.Topicid)
-		copy(dAtA[i:], *m.Topicid)
-		i = encodeVarintRpc(dAtA, i, uint64(len(*m.Topicid)))
-		i--
-		dAtA[i] = 0x12
-	}
-	if m.Subscribe != nil {
-		i--
-		if *m.Subscribe {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x8
-	}
+	i--
+	dAtA[i] = 0x8
 	return len(dAtA) - i, nil
 }
 
@@ -1022,10 +976,6 @@ func (m *Message) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.Key != nil {
 		i -= len(m.Key)
 		copy(dAtA[i:], m.Key)
@@ -1040,13 +990,11 @@ func (m *Message) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x2a
 	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintRpc(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0x22
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintRpc(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0x22
 	if m.Seqno != nil {
 		i -= len(m.Seqno)
 		copy(dAtA[i:], m.Seqno)
@@ -1091,10 +1039,6 @@ func (m *ControlMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if len(m.Prune) > 0 {
 		for iNdEx := len(m.Prune) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -1174,10 +1118,6 @@ func (m *ControlIHave) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if len(m.MessageIDs) > 0 {
 		for iNdEx := len(m.MessageIDs) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.MessageIDs[iNdEx])
@@ -1187,13 +1127,11 @@ func (m *ControlIHave) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 			dAtA[i] = 0x12
 		}
 	}
-	if m.TopicID != nil {
-		i -= len(*m.TopicID)
-		copy(dAtA[i:], *m.TopicID)
-		i = encodeVarintRpc(dAtA, i, uint64(len(*m.TopicID)))
-		i--
-		dAtA[i] = 0xa
-	}
+	i -= len(m.TopicID)
+	copy(dAtA[i:], m.TopicID)
+	i = encodeVarintRpc(dAtA, i, uint64(len(m.TopicID)))
+	i--
+	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -1217,10 +1155,6 @@ func (m *ControlIWant) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if len(m.MessageIDs) > 0 {
 		for iNdEx := len(m.MessageIDs) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.MessageIDs[iNdEx])
@@ -1253,17 +1187,11 @@ func (m *ControlGraft) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.TopicID != nil {
-		i -= len(*m.TopicID)
-		copy(dAtA[i:], *m.TopicID)
-		i = encodeVarintRpc(dAtA, i, uint64(len(*m.TopicID)))
-		i--
-		dAtA[i] = 0xa
-	}
+	i -= len(m.TopicID)
+	copy(dAtA[i:], m.TopicID)
+	i = encodeVarintRpc(dAtA, i, uint64(len(m.TopicID)))
+	i--
+	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -1287,15 +1215,9 @@ func (m *ControlPrune) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Backoff != nil {
-		i = encodeVarintRpc(dAtA, i, uint64(*m.Backoff))
-		i--
-		dAtA[i] = 0x18
-	}
+	i = encodeVarintRpc(dAtA, i, uint64(m.Backoff))
+	i--
+	dAtA[i] = 0x18
 	if len(m.Peers) > 0 {
 		for iNdEx := len(m.Peers) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -1310,13 +1232,11 @@ func (m *ControlPrune) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 			dAtA[i] = 0x12
 		}
 	}
-	if m.TopicID != nil {
-		i -= len(*m.TopicID)
-		copy(dAtA[i:], *m.TopicID)
-		i = encodeVarintRpc(dAtA, i, uint64(len(*m.TopicID)))
-		i--
-		dAtA[i] = 0xa
-	}
+	i -= len(m.TopicID)
+	copy(dAtA[i:], m.TopicID)
+	i = encodeVarintRpc(dAtA, i, uint64(len(m.TopicID)))
+	i--
+	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -1340,10 +1260,6 @@ func (m *PeerInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.SignedPeerRecord != nil {
 		i -= len(m.SignedPeerRecord)
 		copy(dAtA[i:], m.SignedPeerRecord)
@@ -1381,10 +1297,6 @@ func (m *TopicDescriptor) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.Enc != nil {
 		{
 			size, err := m.Enc.MarshalToSizedBuffer(dAtA[:i])
@@ -1409,13 +1321,11 @@ func (m *TopicDescriptor) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x12
 	}
-	if m.Name != nil {
-		i -= len(*m.Name)
-		copy(dAtA[i:], *m.Name)
-		i = encodeVarintRpc(dAtA, i, uint64(len(*m.Name)))
-		i--
-		dAtA[i] = 0xa
-	}
+	i -= len(m.Name)
+	copy(dAtA[i:], m.Name)
+	i = encodeVarintRpc(dAtA, i, uint64(len(m.Name)))
+	i--
+	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -1439,10 +1349,6 @@ func (m *TopicDescriptor_AuthOpts) MarshalToSizedBuffer(dAtA []byte) (int, error
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if len(m.Keys) > 0 {
 		for iNdEx := len(m.Keys) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.Keys[iNdEx])
@@ -1452,11 +1358,9 @@ func (m *TopicDescriptor_AuthOpts) MarshalToSizedBuffer(dAtA []byte) (int, error
 			dAtA[i] = 0x12
 		}
 	}
-	if m.Mode != nil {
-		i = encodeVarintRpc(dAtA, i, uint64(*m.Mode))
-		i--
-		dAtA[i] = 0x8
-	}
+	i = encodeVarintRpc(dAtA, i, uint64(m.Mode))
+	i--
+	dAtA[i] = 0x8
 	return len(dAtA) - i, nil
 }
 
@@ -1480,10 +1384,6 @@ func (m *TopicDescriptor_EncOpts) MarshalToSizedBuffer(dAtA []byte) (int, error)
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if len(m.KeyHashes) > 0 {
 		for iNdEx := len(m.KeyHashes) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.KeyHashes[iNdEx])
@@ -1493,11 +1393,9 @@ func (m *TopicDescriptor_EncOpts) MarshalToSizedBuffer(dAtA []byte) (int, error)
 			dAtA[i] = 0x12
 		}
 	}
-	if m.Mode != nil {
-		i = encodeVarintRpc(dAtA, i, uint64(*m.Mode))
-		i--
-		dAtA[i] = 0x8
-	}
+	i = encodeVarintRpc(dAtA, i, uint64(m.Mode))
+	i--
+	dAtA[i] = 0x8
 	return len(dAtA) - i, nil
 }
 
@@ -1534,9 +1432,6 @@ func (m *RPC) Size() (n int) {
 		l = m.Control.Size()
 		n += 1 + l + sovRpc(uint64(l))
 	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
 	return n
 }
 
@@ -1546,16 +1441,9 @@ func (m *RPC_SubOpts) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Subscribe != nil {
-		n += 2
-	}
-	if m.Topicid != nil {
-		l = len(*m.Topicid)
-		n += 1 + l + sovRpc(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	n += 2
+	l = len(m.Topicid)
+	n += 1 + l + sovRpc(uint64(l))
 	return n
 }
 
@@ -1577,10 +1465,8 @@ func (m *Message) Size() (n int) {
 		l = len(m.Seqno)
 		n += 1 + l + sovRpc(uint64(l))
 	}
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovRpc(uint64(l))
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovRpc(uint64(l))
 	if m.Signature != nil {
 		l = len(m.Signature)
 		n += 1 + l + sovRpc(uint64(l))
@@ -1588,9 +1474,6 @@ func (m *Message) Size() (n int) {
 	if m.Key != nil {
 		l = len(m.Key)
 		n += 1 + l + sovRpc(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -1625,9 +1508,6 @@ func (m *ControlMessage) Size() (n int) {
 			n += 1 + l + sovRpc(uint64(l))
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
 	return n
 }
 
@@ -1637,18 +1517,13 @@ func (m *ControlIHave) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.TopicID != nil {
-		l = len(*m.TopicID)
-		n += 1 + l + sovRpc(uint64(l))
-	}
+	l = len(m.TopicID)
+	n += 1 + l + sovRpc(uint64(l))
 	if len(m.MessageIDs) > 0 {
 		for _, s := range m.MessageIDs {
 			l = len(s)
 			n += 1 + l + sovRpc(uint64(l))
 		}
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -1665,9 +1540,6 @@ func (m *ControlIWant) Size() (n int) {
 			n += 1 + l + sovRpc(uint64(l))
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
 	return n
 }
 
@@ -1677,13 +1549,8 @@ func (m *ControlGraft) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.TopicID != nil {
-		l = len(*m.TopicID)
-		n += 1 + l + sovRpc(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.TopicID)
+	n += 1 + l + sovRpc(uint64(l))
 	return n
 }
 
@@ -1693,22 +1560,15 @@ func (m *ControlPrune) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.TopicID != nil {
-		l = len(*m.TopicID)
-		n += 1 + l + sovRpc(uint64(l))
-	}
+	l = len(m.TopicID)
+	n += 1 + l + sovRpc(uint64(l))
 	if len(m.Peers) > 0 {
 		for _, e := range m.Peers {
 			l = e.Size()
 			n += 1 + l + sovRpc(uint64(l))
 		}
 	}
-	if m.Backoff != nil {
-		n += 1 + sovRpc(uint64(*m.Backoff))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	n += 1 + sovRpc(uint64(m.Backoff))
 	return n
 }
 
@@ -1726,9 +1586,6 @@ func (m *PeerInfo) Size() (n int) {
 		l = len(m.SignedPeerRecord)
 		n += 1 + l + sovRpc(uint64(l))
 	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
 	return n
 }
 
@@ -1738,10 +1595,8 @@ func (m *TopicDescriptor) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Name != nil {
-		l = len(*m.Name)
-		n += 1 + l + sovRpc(uint64(l))
-	}
+	l = len(m.Name)
+	n += 1 + l + sovRpc(uint64(l))
 	if m.Auth != nil {
 		l = m.Auth.Size()
 		n += 1 + l + sovRpc(uint64(l))
@@ -1749,9 +1604,6 @@ func (m *TopicDescriptor) Size() (n int) {
 	if m.Enc != nil {
 		l = m.Enc.Size()
 		n += 1 + l + sovRpc(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -1762,17 +1614,12 @@ func (m *TopicDescriptor_AuthOpts) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Mode != nil {
-		n += 1 + sovRpc(uint64(*m.Mode))
-	}
+	n += 1 + sovRpc(uint64(m.Mode))
 	if len(m.Keys) > 0 {
 		for _, b := range m.Keys {
 			l = len(b)
 			n += 1 + l + sovRpc(uint64(l))
 		}
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -1783,17 +1630,12 @@ func (m *TopicDescriptor_EncOpts) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Mode != nil {
-		n += 1 + sovRpc(uint64(*m.Mode))
-	}
+	n += 1 + sovRpc(uint64(m.Mode))
 	if len(m.KeyHashes) > 0 {
 		for _, b := range m.KeyHashes {
 			l = len(b)
 			n += 1 + l + sovRpc(uint64(l))
 		}
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -1943,16 +1785,12 @@ func (m *RPC) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -2010,8 +1848,7 @@ func (m *RPC_SubOpts) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-			b := bool(v != 0)
-			m.Subscribe = &b
+			m.Subscribe = bool(v != 0)
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Topicid", wireType)
@@ -2042,8 +1879,7 @@ func (m *RPC_SubOpts) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topicid = &s
+			m.Topicid = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -2051,16 +1887,12 @@ func (m *RPC_SubOpts) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -2231,8 +2063,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 5:
 			if wireType != 2 {
@@ -2308,16 +2139,12 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -2498,16 +2325,12 @@ func (m *ControlMessage) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -2576,8 +2399,7 @@ func (m *ControlIHave) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.TopicID = &s
+			m.TopicID = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
@@ -2617,16 +2439,12 @@ func (m *ControlIHave) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -2703,16 +2521,12 @@ func (m *ControlIWant) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -2781,8 +2595,7 @@ func (m *ControlGraft) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.TopicID = &s
+			m.TopicID = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -2790,16 +2603,12 @@ func (m *ControlGraft) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -2868,8 +2677,7 @@ func (m *ControlPrune) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.TopicID = &s
+			m.TopicID = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
@@ -2909,7 +2717,7 @@ func (m *ControlPrune) Unmarshal(dAtA []byte) error {
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Backoff", wireType)
 			}
-			var v uint64
+			m.Backoff = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowRpc
@@ -2919,28 +2727,23 @@ func (m *ControlPrune) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= uint64(b&0x7F) << shift
+				m.Backoff |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			m.Backoff = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := skipRpc(dAtA[iNdEx:])
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -3053,16 +2856,12 @@ func (m *PeerInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -3131,8 +2930,7 @@ func (m *TopicDescriptor) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Name = &s
+			m.Name = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
@@ -3212,16 +3010,12 @@ func (m *TopicDescriptor) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -3264,7 +3058,7 @@ func (m *TopicDescriptor_AuthOpts) Unmarshal(dAtA []byte) error {
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Mode", wireType)
 			}
-			var v TopicDescriptor_AuthOpts_AuthMode
+			m.Mode = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowRpc
@@ -3274,12 +3068,11 @@ func (m *TopicDescriptor_AuthOpts) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= TopicDescriptor_AuthOpts_AuthMode(b&0x7F) << shift
+				m.Mode |= TopicDescriptor_AuthOpts_AuthMode(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			m.Mode = &v
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Keys", wireType)
@@ -3318,16 +3111,12 @@ func (m *TopicDescriptor_AuthOpts) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -3370,7 +3159,7 @@ func (m *TopicDescriptor_EncOpts) Unmarshal(dAtA []byte) error {
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Mode", wireType)
 			}
-			var v TopicDescriptor_EncOpts_EncMode
+			m.Mode = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowRpc
@@ -3380,12 +3169,11 @@ func (m *TopicDescriptor_EncOpts) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= TopicDescriptor_EncOpts_EncMode(b&0x7F) << shift
+				m.Mode |= TopicDescriptor_EncOpts_EncMode(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			m.Mode = &v
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field KeyHashes", wireType)
@@ -3424,16 +3212,12 @@ func (m *TopicDescriptor_EncOpts) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}

--- a/pb/trace.pb.go
+++ b/pb/trace.pb.go
@@ -96,25 +96,22 @@ func (TraceEvent_Type) EnumDescriptor() ([]byte, []int) {
 }
 
 type TraceEvent struct {
-	Type                 *TraceEvent_Type             `protobuf:"varint,1,opt,name=type,enum=pubsub.pb.TraceEvent_Type" json:"type,omitempty"`
-	PeerID               []byte                       `protobuf:"bytes,2,opt,name=peerID" json:"peerID,omitempty"`
-	Timestamp            *int64                       `protobuf:"varint,3,opt,name=timestamp" json:"timestamp,omitempty"`
-	PublishMessage       *TraceEvent_PublishMessage   `protobuf:"bytes,4,opt,name=publishMessage" json:"publishMessage,omitempty"`
-	RejectMessage        *TraceEvent_RejectMessage    `protobuf:"bytes,5,opt,name=rejectMessage" json:"rejectMessage,omitempty"`
-	DuplicateMessage     *TraceEvent_DuplicateMessage `protobuf:"bytes,6,opt,name=duplicateMessage" json:"duplicateMessage,omitempty"`
-	DeliverMessage       *TraceEvent_DeliverMessage   `protobuf:"bytes,7,opt,name=deliverMessage" json:"deliverMessage,omitempty"`
-	AddPeer              *TraceEvent_AddPeer          `protobuf:"bytes,8,opt,name=addPeer" json:"addPeer,omitempty"`
-	RemovePeer           *TraceEvent_RemovePeer       `protobuf:"bytes,9,opt,name=removePeer" json:"removePeer,omitempty"`
-	RecvRPC              *TraceEvent_RecvRPC          `protobuf:"bytes,10,opt,name=recvRPC" json:"recvRPC,omitempty"`
-	SendRPC              *TraceEvent_SendRPC          `protobuf:"bytes,11,opt,name=sendRPC" json:"sendRPC,omitempty"`
-	DropRPC              *TraceEvent_DropRPC          `protobuf:"bytes,12,opt,name=dropRPC" json:"dropRPC,omitempty"`
-	Join                 *TraceEvent_Join             `protobuf:"bytes,13,opt,name=join" json:"join,omitempty"`
-	Leave                *TraceEvent_Leave            `protobuf:"bytes,14,opt,name=leave" json:"leave,omitempty"`
-	Graft                *TraceEvent_Graft            `protobuf:"bytes,15,opt,name=graft" json:"graft,omitempty"`
-	Prune                *TraceEvent_Prune            `protobuf:"bytes,16,opt,name=prune" json:"prune,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                     `json:"-"`
-	XXX_unrecognized     []byte                       `json:"-"`
-	XXX_sizecache        int32                        `json:"-"`
+	Type             TraceEvent_Type              `protobuf:"varint,1,opt,name=type,enum=pubsub.pb.TraceEvent_Type" json:"type"`
+	PeerID           []byte                       `protobuf:"bytes,2,opt,name=peerID" json:"peerID"`
+	Timestamp        int64                        `protobuf:"varint,3,opt,name=timestamp" json:"timestamp"`
+	PublishMessage   *TraceEvent_PublishMessage   `protobuf:"bytes,4,opt,name=publishMessage" json:"publishMessage,omitempty"`
+	RejectMessage    *TraceEvent_RejectMessage    `protobuf:"bytes,5,opt,name=rejectMessage" json:"rejectMessage,omitempty"`
+	DuplicateMessage *TraceEvent_DuplicateMessage `protobuf:"bytes,6,opt,name=duplicateMessage" json:"duplicateMessage,omitempty"`
+	DeliverMessage   *TraceEvent_DeliverMessage   `protobuf:"bytes,7,opt,name=deliverMessage" json:"deliverMessage,omitempty"`
+	AddPeer          *TraceEvent_AddPeer          `protobuf:"bytes,8,opt,name=addPeer" json:"addPeer,omitempty"`
+	RemovePeer       *TraceEvent_RemovePeer       `protobuf:"bytes,9,opt,name=removePeer" json:"removePeer,omitempty"`
+	RecvRPC          *TraceEvent_RecvRPC          `protobuf:"bytes,10,opt,name=recvRPC" json:"recvRPC,omitempty"`
+	SendRPC          *TraceEvent_SendRPC          `protobuf:"bytes,11,opt,name=sendRPC" json:"sendRPC,omitempty"`
+	DropRPC          *TraceEvent_DropRPC          `protobuf:"bytes,12,opt,name=dropRPC" json:"dropRPC,omitempty"`
+	Join             *TraceEvent_Join             `protobuf:"bytes,13,opt,name=join" json:"join,omitempty"`
+	Leave            *TraceEvent_Leave            `protobuf:"bytes,14,opt,name=leave" json:"leave,omitempty"`
+	Graft            *TraceEvent_Graft            `protobuf:"bytes,15,opt,name=graft" json:"graft,omitempty"`
+	Prune            *TraceEvent_Prune            `protobuf:"bytes,16,opt,name=prune" json:"prune,omitempty"`
 }
 
 func (m *TraceEvent) Reset()         { *m = TraceEvent{} }
@@ -151,8 +148,8 @@ func (m *TraceEvent) XXX_DiscardUnknown() {
 var xxx_messageInfo_TraceEvent proto.InternalMessageInfo
 
 func (m *TraceEvent) GetType() TraceEvent_Type {
-	if m != nil && m.Type != nil {
-		return *m.Type
+	if m != nil {
+		return m.Type
 	}
 	return TraceEvent_PUBLISH_MESSAGE
 }
@@ -165,8 +162,8 @@ func (m *TraceEvent) GetPeerID() []byte {
 }
 
 func (m *TraceEvent) GetTimestamp() int64 {
-	if m != nil && m.Timestamp != nil {
-		return *m.Timestamp
+	if m != nil {
+		return m.Timestamp
 	}
 	return 0
 }
@@ -263,11 +260,8 @@ func (m *TraceEvent) GetPrune() *TraceEvent_Prune {
 }
 
 type TraceEvent_PublishMessage struct {
-	MessageID            []byte   `protobuf:"bytes,1,opt,name=messageID" json:"messageID,omitempty"`
-	Topic                *string  `protobuf:"bytes,2,opt,name=topic" json:"topic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	MessageID []byte `protobuf:"bytes,1,opt,name=messageID" json:"messageID"`
+	Topic     string `protobuf:"bytes,2,opt,name=topic" json:"topic"`
 }
 
 func (m *TraceEvent_PublishMessage) Reset()         { *m = TraceEvent_PublishMessage{} }
@@ -311,20 +305,17 @@ func (m *TraceEvent_PublishMessage) GetMessageID() []byte {
 }
 
 func (m *TraceEvent_PublishMessage) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
 
 type TraceEvent_RejectMessage struct {
-	MessageID            []byte   `protobuf:"bytes,1,opt,name=messageID" json:"messageID,omitempty"`
-	ReceivedFrom         []byte   `protobuf:"bytes,2,opt,name=receivedFrom" json:"receivedFrom,omitempty"`
-	Reason               *string  `protobuf:"bytes,3,opt,name=reason" json:"reason,omitempty"`
-	Topic                *string  `protobuf:"bytes,4,opt,name=topic" json:"topic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	MessageID    []byte `protobuf:"bytes,1,opt,name=messageID" json:"messageID"`
+	ReceivedFrom []byte `protobuf:"bytes,2,opt,name=receivedFrom" json:"receivedFrom"`
+	Reason       string `protobuf:"bytes,3,opt,name=reason" json:"reason"`
+	Topic        string `protobuf:"bytes,4,opt,name=topic" json:"topic"`
 }
 
 func (m *TraceEvent_RejectMessage) Reset()         { *m = TraceEvent_RejectMessage{} }
@@ -375,26 +366,23 @@ func (m *TraceEvent_RejectMessage) GetReceivedFrom() []byte {
 }
 
 func (m *TraceEvent_RejectMessage) GetReason() string {
-	if m != nil && m.Reason != nil {
-		return *m.Reason
+	if m != nil {
+		return m.Reason
 	}
 	return ""
 }
 
 func (m *TraceEvent_RejectMessage) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
 
 type TraceEvent_DuplicateMessage struct {
-	MessageID            []byte   `protobuf:"bytes,1,opt,name=messageID" json:"messageID,omitempty"`
-	ReceivedFrom         []byte   `protobuf:"bytes,2,opt,name=receivedFrom" json:"receivedFrom,omitempty"`
-	Topic                *string  `protobuf:"bytes,3,opt,name=topic" json:"topic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	MessageID    []byte `protobuf:"bytes,1,opt,name=messageID" json:"messageID"`
+	ReceivedFrom []byte `protobuf:"bytes,2,opt,name=receivedFrom" json:"receivedFrom"`
+	Topic        string `protobuf:"bytes,3,opt,name=topic" json:"topic"`
 }
 
 func (m *TraceEvent_DuplicateMessage) Reset()         { *m = TraceEvent_DuplicateMessage{} }
@@ -445,19 +433,16 @@ func (m *TraceEvent_DuplicateMessage) GetReceivedFrom() []byte {
 }
 
 func (m *TraceEvent_DuplicateMessage) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
 
 type TraceEvent_DeliverMessage struct {
-	MessageID            []byte   `protobuf:"bytes,1,opt,name=messageID" json:"messageID,omitempty"`
-	Topic                *string  `protobuf:"bytes,2,opt,name=topic" json:"topic,omitempty"`
-	ReceivedFrom         []byte   `protobuf:"bytes,3,opt,name=receivedFrom" json:"receivedFrom,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	MessageID    []byte `protobuf:"bytes,1,opt,name=messageID" json:"messageID"`
+	Topic        string `protobuf:"bytes,2,opt,name=topic" json:"topic"`
+	ReceivedFrom []byte `protobuf:"bytes,3,opt,name=receivedFrom" json:"receivedFrom"`
 }
 
 func (m *TraceEvent_DeliverMessage) Reset()         { *m = TraceEvent_DeliverMessage{} }
@@ -501,8 +486,8 @@ func (m *TraceEvent_DeliverMessage) GetMessageID() []byte {
 }
 
 func (m *TraceEvent_DeliverMessage) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
@@ -515,11 +500,8 @@ func (m *TraceEvent_DeliverMessage) GetReceivedFrom() []byte {
 }
 
 type TraceEvent_AddPeer struct {
-	PeerID               []byte   `protobuf:"bytes,1,opt,name=peerID" json:"peerID,omitempty"`
-	Proto                *string  `protobuf:"bytes,2,opt,name=proto" json:"proto,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	PeerID []byte `protobuf:"bytes,1,opt,name=peerID" json:"peerID"`
+	Proto  string `protobuf:"bytes,2,opt,name=proto" json:"proto"`
 }
 
 func (m *TraceEvent_AddPeer) Reset()         { *m = TraceEvent_AddPeer{} }
@@ -563,17 +545,14 @@ func (m *TraceEvent_AddPeer) GetPeerID() []byte {
 }
 
 func (m *TraceEvent_AddPeer) GetProto() string {
-	if m != nil && m.Proto != nil {
-		return *m.Proto
+	if m != nil {
+		return m.Proto
 	}
 	return ""
 }
 
 type TraceEvent_RemovePeer struct {
-	PeerID               []byte   `protobuf:"bytes,1,opt,name=peerID" json:"peerID,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	PeerID []byte `protobuf:"bytes,1,opt,name=peerID" json:"peerID"`
 }
 
 func (m *TraceEvent_RemovePeer) Reset()         { *m = TraceEvent_RemovePeer{} }
@@ -617,11 +596,8 @@ func (m *TraceEvent_RemovePeer) GetPeerID() []byte {
 }
 
 type TraceEvent_RecvRPC struct {
-	ReceivedFrom         []byte              `protobuf:"bytes,1,opt,name=receivedFrom" json:"receivedFrom,omitempty"`
-	Meta                 *TraceEvent_RPCMeta `protobuf:"bytes,2,opt,name=meta" json:"meta,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
-	XXX_unrecognized     []byte              `json:"-"`
-	XXX_sizecache        int32               `json:"-"`
+	ReceivedFrom []byte              `protobuf:"bytes,1,opt,name=receivedFrom" json:"receivedFrom"`
+	Meta         *TraceEvent_RPCMeta `protobuf:"bytes,2,opt,name=meta" json:"meta,omitempty"`
 }
 
 func (m *TraceEvent_RecvRPC) Reset()         { *m = TraceEvent_RecvRPC{} }
@@ -672,11 +648,8 @@ func (m *TraceEvent_RecvRPC) GetMeta() *TraceEvent_RPCMeta {
 }
 
 type TraceEvent_SendRPC struct {
-	SendTo               []byte              `protobuf:"bytes,1,opt,name=sendTo" json:"sendTo,omitempty"`
-	Meta                 *TraceEvent_RPCMeta `protobuf:"bytes,2,opt,name=meta" json:"meta,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
-	XXX_unrecognized     []byte              `json:"-"`
-	XXX_sizecache        int32               `json:"-"`
+	SendTo []byte              `protobuf:"bytes,1,opt,name=sendTo" json:"sendTo"`
+	Meta   *TraceEvent_RPCMeta `protobuf:"bytes,2,opt,name=meta" json:"meta,omitempty"`
 }
 
 func (m *TraceEvent_SendRPC) Reset()         { *m = TraceEvent_SendRPC{} }
@@ -727,11 +700,8 @@ func (m *TraceEvent_SendRPC) GetMeta() *TraceEvent_RPCMeta {
 }
 
 type TraceEvent_DropRPC struct {
-	SendTo               []byte              `protobuf:"bytes,1,opt,name=sendTo" json:"sendTo,omitempty"`
-	Meta                 *TraceEvent_RPCMeta `protobuf:"bytes,2,opt,name=meta" json:"meta,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
-	XXX_unrecognized     []byte              `json:"-"`
-	XXX_sizecache        int32               `json:"-"`
+	SendTo []byte              `protobuf:"bytes,1,opt,name=sendTo" json:"sendTo"`
+	Meta   *TraceEvent_RPCMeta `protobuf:"bytes,2,opt,name=meta" json:"meta,omitempty"`
 }
 
 func (m *TraceEvent_DropRPC) Reset()         { *m = TraceEvent_DropRPC{} }
@@ -782,10 +752,7 @@ func (m *TraceEvent_DropRPC) GetMeta() *TraceEvent_RPCMeta {
 }
 
 type TraceEvent_Join struct {
-	Topic                *string  `protobuf:"bytes,1,opt,name=topic" json:"topic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Topic string `protobuf:"bytes,1,opt,name=topic" json:"topic"`
 }
 
 func (m *TraceEvent_Join) Reset()         { *m = TraceEvent_Join{} }
@@ -822,17 +789,14 @@ func (m *TraceEvent_Join) XXX_DiscardUnknown() {
 var xxx_messageInfo_TraceEvent_Join proto.InternalMessageInfo
 
 func (m *TraceEvent_Join) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
 
 type TraceEvent_Leave struct {
-	Topic                *string  `protobuf:"bytes,2,opt,name=topic" json:"topic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Topic string `protobuf:"bytes,2,opt,name=topic" json:"topic"`
 }
 
 func (m *TraceEvent_Leave) Reset()         { *m = TraceEvent_Leave{} }
@@ -869,18 +833,15 @@ func (m *TraceEvent_Leave) XXX_DiscardUnknown() {
 var xxx_messageInfo_TraceEvent_Leave proto.InternalMessageInfo
 
 func (m *TraceEvent_Leave) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
 
 type TraceEvent_Graft struct {
-	PeerID               []byte   `protobuf:"bytes,1,opt,name=peerID" json:"peerID,omitempty"`
-	Topic                *string  `protobuf:"bytes,2,opt,name=topic" json:"topic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	PeerID []byte `protobuf:"bytes,1,opt,name=peerID" json:"peerID"`
+	Topic  string `protobuf:"bytes,2,opt,name=topic" json:"topic"`
 }
 
 func (m *TraceEvent_Graft) Reset()         { *m = TraceEvent_Graft{} }
@@ -924,18 +885,15 @@ func (m *TraceEvent_Graft) GetPeerID() []byte {
 }
 
 func (m *TraceEvent_Graft) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
 
 type TraceEvent_Prune struct {
-	PeerID               []byte   `protobuf:"bytes,1,opt,name=peerID" json:"peerID,omitempty"`
-	Topic                *string  `protobuf:"bytes,2,opt,name=topic" json:"topic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	PeerID []byte `protobuf:"bytes,1,opt,name=peerID" json:"peerID"`
+	Topic  string `protobuf:"bytes,2,opt,name=topic" json:"topic"`
 }
 
 func (m *TraceEvent_Prune) Reset()         { *m = TraceEvent_Prune{} }
@@ -979,19 +937,16 @@ func (m *TraceEvent_Prune) GetPeerID() []byte {
 }
 
 func (m *TraceEvent_Prune) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
 
 type TraceEvent_RPCMeta struct {
-	Messages             []*TraceEvent_MessageMeta `protobuf:"bytes,1,rep,name=messages" json:"messages,omitempty"`
-	Subscription         []*TraceEvent_SubMeta     `protobuf:"bytes,2,rep,name=subscription" json:"subscription,omitempty"`
-	Control              *TraceEvent_ControlMeta   `protobuf:"bytes,3,opt,name=control" json:"control,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
-	XXX_unrecognized     []byte                    `json:"-"`
-	XXX_sizecache        int32                     `json:"-"`
+	Messages     []*TraceEvent_MessageMeta `protobuf:"bytes,1,rep,name=messages" json:"messages,omitempty"`
+	Subscription []*TraceEvent_SubMeta     `protobuf:"bytes,2,rep,name=subscription" json:"subscription,omitempty"`
+	Control      *TraceEvent_ControlMeta   `protobuf:"bytes,3,opt,name=control" json:"control,omitempty"`
 }
 
 func (m *TraceEvent_RPCMeta) Reset()         { *m = TraceEvent_RPCMeta{} }
@@ -1049,11 +1004,8 @@ func (m *TraceEvent_RPCMeta) GetControl() *TraceEvent_ControlMeta {
 }
 
 type TraceEvent_MessageMeta struct {
-	MessageID            []byte   `protobuf:"bytes,1,opt,name=messageID" json:"messageID,omitempty"`
-	Topic                *string  `protobuf:"bytes,2,opt,name=topic" json:"topic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	MessageID []byte `protobuf:"bytes,1,opt,name=messageID" json:"messageID"`
+	Topic     string `protobuf:"bytes,2,opt,name=topic" json:"topic"`
 }
 
 func (m *TraceEvent_MessageMeta) Reset()         { *m = TraceEvent_MessageMeta{} }
@@ -1097,18 +1049,15 @@ func (m *TraceEvent_MessageMeta) GetMessageID() []byte {
 }
 
 func (m *TraceEvent_MessageMeta) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
 
 type TraceEvent_SubMeta struct {
-	Subscribe            *bool    `protobuf:"varint,1,opt,name=subscribe" json:"subscribe,omitempty"`
-	Topic                *string  `protobuf:"bytes,2,opt,name=topic" json:"topic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Subscribe bool   `protobuf:"varint,1,opt,name=subscribe" json:"subscribe"`
+	Topic     string `protobuf:"bytes,2,opt,name=topic" json:"topic"`
 }
 
 func (m *TraceEvent_SubMeta) Reset()         { *m = TraceEvent_SubMeta{} }
@@ -1145,27 +1094,24 @@ func (m *TraceEvent_SubMeta) XXX_DiscardUnknown() {
 var xxx_messageInfo_TraceEvent_SubMeta proto.InternalMessageInfo
 
 func (m *TraceEvent_SubMeta) GetSubscribe() bool {
-	if m != nil && m.Subscribe != nil {
-		return *m.Subscribe
+	if m != nil {
+		return m.Subscribe
 	}
 	return false
 }
 
 func (m *TraceEvent_SubMeta) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
 
 type TraceEvent_ControlMeta struct {
-	Ihave                []*TraceEvent_ControlIHaveMeta `protobuf:"bytes,1,rep,name=ihave" json:"ihave,omitempty"`
-	Iwant                []*TraceEvent_ControlIWantMeta `protobuf:"bytes,2,rep,name=iwant" json:"iwant,omitempty"`
-	Graft                []*TraceEvent_ControlGraftMeta `protobuf:"bytes,3,rep,name=graft" json:"graft,omitempty"`
-	Prune                []*TraceEvent_ControlPruneMeta `protobuf:"bytes,4,rep,name=prune" json:"prune,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                       `json:"-"`
-	XXX_unrecognized     []byte                         `json:"-"`
-	XXX_sizecache        int32                          `json:"-"`
+	Ihave []*TraceEvent_ControlIHaveMeta `protobuf:"bytes,1,rep,name=ihave" json:"ihave,omitempty"`
+	Iwant []*TraceEvent_ControlIWantMeta `protobuf:"bytes,2,rep,name=iwant" json:"iwant,omitempty"`
+	Graft []*TraceEvent_ControlGraftMeta `protobuf:"bytes,3,rep,name=graft" json:"graft,omitempty"`
+	Prune []*TraceEvent_ControlPruneMeta `protobuf:"bytes,4,rep,name=prune" json:"prune,omitempty"`
 }
 
 func (m *TraceEvent_ControlMeta) Reset()         { *m = TraceEvent_ControlMeta{} }
@@ -1230,11 +1176,8 @@ func (m *TraceEvent_ControlMeta) GetPrune() []*TraceEvent_ControlPruneMeta {
 }
 
 type TraceEvent_ControlIHaveMeta struct {
-	Topic                *string  `protobuf:"bytes,1,opt,name=topic" json:"topic,omitempty"`
-	MessageIDs           [][]byte `protobuf:"bytes,2,rep,name=messageIDs" json:"messageIDs,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Topic      string   `protobuf:"bytes,1,opt,name=topic" json:"topic"`
+	MessageIDs [][]byte `protobuf:"bytes,2,rep,name=messageIDs" json:"messageIDs,omitempty"`
 }
 
 func (m *TraceEvent_ControlIHaveMeta) Reset()         { *m = TraceEvent_ControlIHaveMeta{} }
@@ -1271,8 +1214,8 @@ func (m *TraceEvent_ControlIHaveMeta) XXX_DiscardUnknown() {
 var xxx_messageInfo_TraceEvent_ControlIHaveMeta proto.InternalMessageInfo
 
 func (m *TraceEvent_ControlIHaveMeta) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
@@ -1285,10 +1228,7 @@ func (m *TraceEvent_ControlIHaveMeta) GetMessageIDs() [][]byte {
 }
 
 type TraceEvent_ControlIWantMeta struct {
-	MessageIDs           [][]byte `protobuf:"bytes,1,rep,name=messageIDs" json:"messageIDs,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	MessageIDs [][]byte `protobuf:"bytes,1,rep,name=messageIDs" json:"messageIDs,omitempty"`
 }
 
 func (m *TraceEvent_ControlIWantMeta) Reset()         { *m = TraceEvent_ControlIWantMeta{} }
@@ -1332,10 +1272,7 @@ func (m *TraceEvent_ControlIWantMeta) GetMessageIDs() [][]byte {
 }
 
 type TraceEvent_ControlGraftMeta struct {
-	Topic                *string  `protobuf:"bytes,1,opt,name=topic" json:"topic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Topic string `protobuf:"bytes,1,opt,name=topic" json:"topic"`
 }
 
 func (m *TraceEvent_ControlGraftMeta) Reset()         { *m = TraceEvent_ControlGraftMeta{} }
@@ -1372,18 +1309,15 @@ func (m *TraceEvent_ControlGraftMeta) XXX_DiscardUnknown() {
 var xxx_messageInfo_TraceEvent_ControlGraftMeta proto.InternalMessageInfo
 
 func (m *TraceEvent_ControlGraftMeta) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
 
 type TraceEvent_ControlPruneMeta struct {
-	Topic                *string  `protobuf:"bytes,1,opt,name=topic" json:"topic,omitempty"`
-	Peers                [][]byte `protobuf:"bytes,2,rep,name=peers" json:"peers,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Topic string   `protobuf:"bytes,1,opt,name=topic" json:"topic"`
+	Peers [][]byte `protobuf:"bytes,2,rep,name=peers" json:"peers,omitempty"`
 }
 
 func (m *TraceEvent_ControlPruneMeta) Reset()         { *m = TraceEvent_ControlPruneMeta{} }
@@ -1420,8 +1354,8 @@ func (m *TraceEvent_ControlPruneMeta) XXX_DiscardUnknown() {
 var xxx_messageInfo_TraceEvent_ControlPruneMeta proto.InternalMessageInfo
 
 func (m *TraceEvent_ControlPruneMeta) GetTopic() string {
-	if m != nil && m.Topic != nil {
-		return *m.Topic
+	if m != nil {
+		return m.Topic
 	}
 	return ""
 }
@@ -1434,10 +1368,7 @@ func (m *TraceEvent_ControlPruneMeta) GetPeers() [][]byte {
 }
 
 type TraceEventBatch struct {
-	Batch                []*TraceEvent `protobuf:"bytes,1,rep,name=batch" json:"batch,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
+	Batch []*TraceEvent `protobuf:"bytes,1,rep,name=batch" json:"batch,omitempty"`
 }
 
 func (m *TraceEventBatch) Reset()         { *m = TraceEventBatch{} }
@@ -1510,70 +1441,72 @@ func init() {
 func init() { proto.RegisterFile("trace.proto", fileDescriptor_0571941a1d628a80) }
 
 var fileDescriptor_0571941a1d628a80 = []byte{
-	// 999 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x96, 0x51, 0x6f, 0xda, 0x56,
-	0x14, 0xc7, 0xe7, 0x00, 0x01, 0x0e, 0x84, 0x78, 0x77, 0x6d, 0x65, 0xb1, 0x36, 0x62, 0x59, 0x55,
-	0x21, 0x4d, 0x42, 0x6a, 0xa4, 0xa9, 0x0f, 0x6b, 0xab, 0x11, 0xec, 0x26, 0x44, 0x24, 0xb1, 0x0e,
-	0x24, 0x7b, 0xcc, 0x0c, 0xdc, 0x35, 0x8e, 0xc0, 0xb6, 0xec, 0x0b, 0x53, 0x9f, 0xf6, 0xb4, 0xef,
-	0xd6, 0xb7, 0xed, 0x23, 0x54, 0xf9, 0x24, 0xd3, 0xbd, 0xd7, 0x36, 0x36, 0xd8, 0xb4, 0x8b, 0xfa,
-	0xe6, 0x73, 0xf3, 0xff, 0x9d, 0x7b, 0xce, 0xbd, 0xe7, 0x7f, 0x03, 0xd4, 0x98, 0x6f, 0x4d, 0x68,
-	0xc7, 0xf3, 0x5d, 0xe6, 0x92, 0xaa, 0xb7, 0x18, 0x07, 0x8b, 0x71, 0xc7, 0x1b, 0x1f, 0x7e, 0x7a,
-	0x02, 0x30, 0xe2, 0x7f, 0x32, 0x96, 0xd4, 0x61, 0xa4, 0x03, 0x45, 0xf6, 0xc1, 0xa3, 0x9a, 0xd2,
-	0x52, 0xda, 0x8d, 0xa3, 0x66, 0x27, 0x16, 0x76, 0x56, 0xa2, 0xce, 0xe8, 0x83, 0x47, 0x51, 0xe8,
-	0xc8, 0x13, 0xd8, 0xf5, 0x28, 0xf5, 0xfb, 0xba, 0xb6, 0xd3, 0x52, 0xda, 0x75, 0x0c, 0x23, 0xf2,
-	0x14, 0xaa, 0xcc, 0x9e, 0xd3, 0x80, 0x59, 0x73, 0x4f, 0x2b, 0xb4, 0x94, 0x76, 0x01, 0x57, 0x0b,
-	0x64, 0x00, 0x0d, 0x6f, 0x31, 0x9e, 0xd9, 0xc1, 0xed, 0x39, 0x0d, 0x02, 0xeb, 0x3d, 0xd5, 0x8a,
-	0x2d, 0xa5, 0x5d, 0x3b, 0x7a, 0x9e, 0xbd, 0x9f, 0x99, 0xd2, 0xe2, 0x1a, 0x4b, 0xfa, 0xb0, 0xe7,
-	0xd3, 0x3b, 0x3a, 0x61, 0x51, 0xb2, 0x92, 0x48, 0xf6, 0x63, 0x76, 0x32, 0x4c, 0x4a, 0x31, 0x4d,
-	0x12, 0x04, 0x75, 0xba, 0xf0, 0x66, 0xf6, 0xc4, 0x62, 0x34, 0xca, 0xb6, 0x2b, 0xb2, 0xbd, 0xc8,
-	0xce, 0xa6, 0xaf, 0xa9, 0x71, 0x83, 0xe7, 0xcd, 0x4e, 0xe9, 0xcc, 0x5e, 0x52, 0x3f, 0xca, 0x58,
-	0xde, 0xd6, 0xac, 0x9e, 0xd2, 0xe2, 0x1a, 0x4b, 0x5e, 0x41, 0xd9, 0x9a, 0x4e, 0x4d, 0x4a, 0x7d,
-	0xad, 0x22, 0xd2, 0x3c, 0xcb, 0x4e, 0xd3, 0x95, 0x22, 0x8c, 0xd4, 0xe4, 0x57, 0x00, 0x9f, 0xce,
-	0xdd, 0x25, 0x15, 0x6c, 0x55, 0xb0, 0xad, 0xbc, 0x23, 0x8a, 0x74, 0x98, 0x60, 0xf8, 0xd6, 0x3e,
-	0x9d, 0x2c, 0xd1, 0xec, 0x69, 0xb0, 0x6d, 0x6b, 0x94, 0x22, 0x8c, 0xd4, 0x1c, 0x0c, 0xa8, 0x33,
-	0xe5, 0x60, 0x6d, 0x1b, 0x38, 0x94, 0x22, 0x8c, 0xd4, 0x1c, 0x9c, 0xfa, 0xae, 0xc7, 0xc1, 0xfa,
-	0x36, 0x50, 0x97, 0x22, 0x8c, 0xd4, 0x7c, 0x8c, 0xef, 0x5c, 0xdb, 0xd1, 0xf6, 0x04, 0x95, 0x33,
-	0xc6, 0x67, 0xae, 0xed, 0xa0, 0xd0, 0x91, 0x97, 0x50, 0x9a, 0x51, 0x6b, 0x49, 0xb5, 0x86, 0x00,
-	0xbe, 0xcf, 0x06, 0x06, 0x5c, 0x82, 0x52, 0xc9, 0x91, 0xf7, 0xbe, 0xf5, 0x07, 0xd3, 0xf6, 0xb7,
-	0x21, 0x27, 0x5c, 0x82, 0x52, 0xc9, 0x11, 0xcf, 0x5f, 0x38, 0x54, 0x53, 0xb7, 0x21, 0x26, 0x97,
-	0xa0, 0x54, 0x36, 0x75, 0x68, 0xa4, 0xa7, 0x9f, 0x3b, 0x6b, 0x2e, 0x3f, 0xfb, 0xba, 0xb0, 0x69,
-	0x1d, 0x57, 0x0b, 0xe4, 0x11, 0x94, 0x98, 0xeb, 0xd9, 0x13, 0x61, 0xc7, 0x2a, 0xca, 0xa0, 0xf9,
-	0x17, 0xec, 0xa5, 0xc6, 0xfe, 0x33, 0x49, 0x0e, 0xa1, 0xee, 0xd3, 0x09, 0xb5, 0x97, 0x74, 0xfa,
-	0xce, 0x77, 0xe7, 0xa1, 0xb5, 0x53, 0x6b, 0xdc, 0xf8, 0x3e, 0xb5, 0x02, 0xd7, 0x11, 0xee, 0xae,
-	0x62, 0x18, 0xad, 0x0a, 0x28, 0x26, 0x0b, 0xb8, 0x03, 0x75, 0xdd, 0x29, 0x5f, 0xa1, 0x86, 0x78,
-	0xaf, 0x42, 0x72, 0xaf, 0x5b, 0x68, 0xa4, 0x3d, 0xf4, 0x90, 0x23, 0xdb, 0xd8, 0xbf, 0xb0, 0xb9,
-	0x7f, 0xf3, 0x15, 0x94, 0x43, 0x9b, 0x25, 0xde, 0x41, 0x25, 0xf5, 0x0e, 0x3e, 0xe2, 0x57, 0xee,
-	0x32, 0x37, 0x4a, 0x2e, 0x82, 0xe6, 0x73, 0x80, 0x95, 0xc7, 0xf2, 0xd8, 0xe6, 0xef, 0x50, 0x0e,
-	0xad, 0xb4, 0x51, 0x8d, 0x92, 0x71, 0x1a, 0x2f, 0xa1, 0x38, 0xa7, 0xcc, 0x12, 0x3b, 0xe5, 0x7b,
-	0xd3, 0xec, 0x9d, 0x53, 0x66, 0xa1, 0x90, 0x36, 0x47, 0x50, 0x0e, 0x3d, 0xc7, 0x8b, 0xe0, 0xae,
-	0x1b, 0xb9, 0x51, 0x11, 0x32, 0x7a, 0x60, 0xd6, 0xd0, 0x90, 0x5f, 0x33, 0xeb, 0x53, 0x28, 0x72,
-	0xc3, 0xae, 0xae, 0x4b, 0x49, 0x5e, 0xfa, 0x33, 0x28, 0x09, 0x77, 0xe6, 0x18, 0xe0, 0x67, 0x28,
-	0x09, 0x27, 0x6e, 0xbb, 0xa7, 0x6c, 0x4c, 0xb8, 0xf1, 0x7f, 0x62, 0x1f, 0x15, 0x28, 0x87, 0xc5,
-	0x93, 0x37, 0x50, 0x09, 0x47, 0x2d, 0xd0, 0x94, 0x56, 0xa1, 0x5d, 0x3b, 0xfa, 0x21, 0xbb, 0xdb,
-	0x70, 0x58, 0x45, 0xc7, 0x31, 0x42, 0xba, 0x50, 0x0f, 0x16, 0xe3, 0x60, 0xe2, 0xdb, 0x1e, 0xb3,
-	0x5d, 0x47, 0xdb, 0x11, 0x29, 0xf2, 0xde, 0xcf, 0xc5, 0x58, 0xe0, 0x29, 0x84, 0xfc, 0x02, 0xe5,
-	0x89, 0xeb, 0x30, 0xdf, 0x9d, 0x89, 0x21, 0xce, 0x2d, 0xa0, 0x27, 0x45, 0x22, 0x43, 0x44, 0x34,
-	0xbb, 0x50, 0x4b, 0x14, 0xf6, 0xa0, 0xc7, 0xe7, 0x0d, 0x94, 0xc3, 0xc2, 0x38, 0x1e, 0x96, 0x36,
-	0x96, 0x3f, 0x31, 0x2a, 0xb8, 0x5a, 0xc8, 0xc1, 0xff, 0xde, 0x81, 0x5a, 0xa2, 0x34, 0xf2, 0x1a,
-	0x4a, 0xf6, 0x2d, 0x7f, 0xaa, 0xe5, 0x69, 0xbe, 0xd8, 0xda, 0x4c, 0xff, 0xd4, 0x5a, 0xca, 0x23,
-	0x95, 0x90, 0xa0, 0xff, 0xb4, 0x1c, 0x16, 0x1e, 0xe4, 0x67, 0xe8, 0xdf, 0x2c, 0x87, 0x85, 0x34,
-	0x87, 0x38, 0x2d, 0xdf, 0xfc, 0xc2, 0x17, 0xd0, 0x62, 0xe0, 0x24, 0x2d, 0x9f, 0xff, 0xd7, 0xd1,
-	0xf3, 0x5f, 0xfc, 0x02, 0x5a, 0xcc, 0x9d, 0xa4, 0xe5, 0x7f, 0x82, 0x53, 0x50, 0xd7, 0x9b, 0xca,
-	0xf6, 0x02, 0x39, 0x00, 0x88, 0xef, 0x24, 0x10, 0x8d, 0xd6, 0x31, 0xb1, 0xd2, 0x3c, 0x5a, 0x65,
-	0x8a, 0x1a, 0x5c, 0x63, 0x94, 0x0d, 0xa6, 0x1d, 0x33, 0x71, 0x5b, 0x39, 0x4e, 0x7c, 0x1b, 0x2b,
-	0xe3, 0x16, 0x72, 0xea, 0xe4, 0x6f, 0x23, 0xa5, 0x7e, 0x54, 0xa2, 0x0c, 0x0e, 0xff, 0x51, 0xa0,
-	0xc8, 0x7f, 0x60, 0x92, 0xef, 0x60, 0xdf, 0xbc, 0x3a, 0x1e, 0xf4, 0x87, 0xa7, 0x37, 0xe7, 0xc6,
-	0x70, 0xd8, 0x3d, 0x31, 0xd4, 0x6f, 0x08, 0x81, 0x06, 0x1a, 0x67, 0x46, 0x6f, 0x14, 0xaf, 0x29,
-	0xe4, 0x31, 0x7c, 0xab, 0x5f, 0x99, 0x83, 0x7e, 0xaf, 0x3b, 0x32, 0xe2, 0xe5, 0x1d, 0xce, 0xeb,
-	0xc6, 0xa0, 0x7f, 0x6d, 0x60, 0xbc, 0x58, 0x20, 0x75, 0xa8, 0x74, 0x75, 0xfd, 0xc6, 0x34, 0x0c,
-	0x54, 0x8b, 0x64, 0x1f, 0x6a, 0x68, 0x9c, 0x5f, 0x5e, 0x1b, 0x72, 0xa1, 0xc4, 0xff, 0x8c, 0x46,
-	0xef, 0xfa, 0x06, 0xcd, 0x9e, 0xba, 0xcb, 0xa3, 0xa1, 0x71, 0xa1, 0x8b, 0xa8, 0xcc, 0x23, 0x1d,
-	0x2f, 0x4d, 0x11, 0x55, 0x48, 0x05, 0x8a, 0x67, 0x97, 0xfd, 0x0b, 0xb5, 0x4a, 0xaa, 0x50, 0x1a,
-	0x18, 0xdd, 0x6b, 0x43, 0x05, 0xfe, 0x79, 0x82, 0xdd, 0x77, 0x23, 0xb5, 0xc6, 0x3f, 0x4d, 0xbc,
-	0xba, 0x30, 0xd4, 0xfa, 0xe1, 0x5b, 0xd8, 0x5f, 0xdd, 0xef, 0xb1, 0xc5, 0x26, 0xb7, 0xe4, 0x27,
-	0x28, 0x8d, 0xf9, 0x47, 0x38, 0xc4, 0x8f, 0x33, 0x47, 0x01, 0xa5, 0xe6, 0xb8, 0xfe, 0xf1, 0xfe,
-	0x40, 0xf9, 0xf7, 0xfe, 0x40, 0xf9, 0x74, 0x7f, 0xa0, 0xfc, 0x17, 0x00, 0x00, 0xff, 0xff, 0xdb,
-	0x3a, 0x1c, 0xe4, 0xc9, 0x0b, 0x00, 0x00,
+	// 1036 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x96, 0x4f, 0x6f, 0xe3, 0x44,
+	0x18, 0xc6, 0xe3, 0xc6, 0x6e, 0x92, 0x37, 0x69, 0x6a, 0x06, 0x56, 0xb2, 0x0c, 0x84, 0x90, 0x45,
+	0xab, 0x08, 0xa4, 0x48, 0x5b, 0x21, 0x71, 0x60, 0x41, 0xa4, 0xb1, 0xb7, 0x9b, 0x2a, 0x69, 0xad,
+	0x49, 0x5a, 0x24, 0x2e, 0x95, 0x93, 0xcc, 0x6e, 0xbd, 0x4a, 0x6c, 0xcb, 0x9e, 0x04, 0x2d, 0xe2,
+	0xca, 0x9d, 0x1b, 0x9f, 0x82, 0xef, 0xd1, 0x1b, 0x7b, 0xe4, 0x84, 0x50, 0xfb, 0x45, 0xd0, 0xcc,
+	0xd8, 0x4e, 0x9c, 0x3f, 0xde, 0x8a, 0xee, 0xcd, 0x7e, 0xfd, 0xfc, 0x9e, 0x79, 0x67, 0x3c, 0xcf,
+	0xd8, 0x50, 0xa6, 0x81, 0x3d, 0x26, 0x2d, 0x3f, 0xf0, 0xa8, 0x87, 0x4a, 0xfe, 0x7c, 0x14, 0xce,
+	0x47, 0x2d, 0x7f, 0xd4, 0xf8, 0x53, 0x03, 0x18, 0xb2, 0x47, 0xe6, 0x82, 0xb8, 0x14, 0x7d, 0x0d,
+	0x32, 0x7d, 0xe3, 0x13, 0x4d, 0xaa, 0x4b, 0xcd, 0xea, 0x91, 0xde, 0x4a, 0x84, 0xad, 0xa5, 0xa8,
+	0x35, 0x7c, 0xe3, 0x93, 0x63, 0xf9, 0xe6, 0x9f, 0xcf, 0x72, 0x98, 0xab, 0xd1, 0x27, 0xb0, 0xef,
+	0x13, 0x12, 0x74, 0x0d, 0x6d, 0xaf, 0x2e, 0x35, 0x2b, 0xd1, 0xb3, 0xa8, 0x86, 0x1a, 0x50, 0xa2,
+	0xce, 0x8c, 0x84, 0xd4, 0x9e, 0xf9, 0x5a, 0xbe, 0x2e, 0x35, 0xf3, 0x91, 0x60, 0x59, 0x46, 0x3d,
+	0xa8, 0xfa, 0xf3, 0xd1, 0xd4, 0x09, 0xaf, 0xfb, 0x24, 0x0c, 0xed, 0x57, 0x44, 0x93, 0xeb, 0x52,
+	0xb3, 0x7c, 0xf4, 0xc5, 0xf6, 0x0e, 0xac, 0x94, 0x16, 0xaf, 0xb1, 0xa8, 0x0b, 0x07, 0x01, 0x79,
+	0x4d, 0xc6, 0x34, 0x36, 0x53, 0xb8, 0xd9, 0xe3, 0xed, 0x66, 0x78, 0x55, 0x8a, 0xd3, 0x24, 0xc2,
+	0xa0, 0x4e, 0xe6, 0xfe, 0xd4, 0x19, 0xdb, 0x94, 0xc4, 0x6e, 0xfb, 0xdc, 0xed, 0xc9, 0x76, 0x37,
+	0x63, 0x4d, 0x8d, 0x37, 0x78, 0x36, 0xd9, 0x09, 0x99, 0x3a, 0x0b, 0x12, 0xc4, 0x8e, 0x85, 0xac,
+	0xc9, 0x1a, 0x29, 0x2d, 0x5e, 0x63, 0xd1, 0x37, 0x50, 0xb0, 0x27, 0x13, 0x8b, 0x90, 0x40, 0x2b,
+	0x72, 0x9b, 0x4f, 0xb7, 0xdb, 0xb4, 0x85, 0x08, 0xc7, 0x6a, 0xf4, 0x03, 0x40, 0x40, 0x66, 0xde,
+	0x82, 0x70, 0xb6, 0xc4, 0xd9, 0xfa, 0xae, 0x25, 0x8a, 0x75, 0x78, 0x85, 0x61, 0x43, 0x07, 0x64,
+	0xbc, 0xc0, 0x56, 0x47, 0x83, 0xac, 0xa1, 0xb1, 0x10, 0xe1, 0x58, 0xcd, 0xc0, 0x90, 0xb8, 0x13,
+	0x06, 0x96, 0xb3, 0xc0, 0x81, 0x10, 0xe1, 0x58, 0xcd, 0xc0, 0x49, 0xe0, 0xf9, 0x0c, 0xac, 0x64,
+	0x81, 0x86, 0x10, 0xe1, 0x58, 0x8d, 0x5a, 0x20, 0xbf, 0xf6, 0x1c, 0x57, 0x3b, 0xe0, 0xd4, 0x8e,
+	0x8d, 0x7d, 0xea, 0x39, 0x2e, 0xe6, 0x3a, 0xf4, 0x14, 0x94, 0x29, 0xb1, 0x17, 0x44, 0xab, 0x72,
+	0xe0, 0xe3, 0xed, 0x40, 0x8f, 0x49, 0xb0, 0x50, 0x32, 0xe4, 0x55, 0x60, 0xbf, 0xa4, 0xda, 0x61,
+	0x16, 0x72, 0xc2, 0x24, 0x58, 0x28, 0x19, 0xe2, 0x07, 0x73, 0x97, 0x68, 0x6a, 0x16, 0x62, 0x31,
+	0x09, 0x16, 0x4a, 0xdd, 0x82, 0x6a, 0x7a, 0xf7, 0xb3, 0x7c, 0xcd, 0xc4, 0x65, 0xd7, 0xe0, 0xc1,
+	0x8d, 0x03, 0xb8, 0x2c, 0x23, 0x1d, 0x14, 0xea, 0xf9, 0xce, 0x98, 0x07, 0xb4, 0x14, 0x3d, 0x17,
+	0x25, 0xfd, 0x0f, 0x09, 0x0e, 0x52, 0x19, 0xb8, 0x97, 0x63, 0x13, 0x2a, 0x01, 0x19, 0x13, 0x67,
+	0x41, 0x26, 0xcf, 0x03, 0x6f, 0x96, 0x4a, 0x7e, 0xea, 0x09, 0x3b, 0x1d, 0x02, 0x62, 0x87, 0x9e,
+	0xcb, 0xc3, 0x1f, 0x0f, 0x1e, 0xd5, 0x96, 0x9d, 0xc9, 0x9b, 0x9d, 0xfd, 0x0a, 0xea, 0x7a, 0x9c,
+	0xde, 0x73, 0x6f, 0xc9, 0xe8, 0xf9, 0xcd, 0xd1, 0x7f, 0x81, 0x6a, 0x3a, 0x7a, 0x0f, 0x5d, 0xe9,
+	0x8d, 0xbe, 0xf2, 0xbb, 0xfa, 0xd2, 0x3b, 0x50, 0x88, 0xf2, 0xba, 0x72, 0xb8, 0x4a, 0x5b, 0x0e,
+	0x57, 0x9d, 0xed, 0x20, 0x8f, 0x7a, 0xe9, 0xe1, 0x78, 0x49, 0xff, 0x12, 0x60, 0x19, 0xdc, 0x6c,
+	0x1f, 0xfd, 0x25, 0x14, 0xa2, 0x94, 0x6e, 0x74, 0x29, 0xed, 0x5c, 0xbd, 0xa7, 0x20, 0xcf, 0x08,
+	0xb5, 0xf9, 0xd8, 0xbb, 0xc3, 0x6f, 0x75, 0xfa, 0x84, 0xda, 0x98, 0x4b, 0xf5, 0x9f, 0xa0, 0x10,
+	0x85, 0x9a, 0x35, 0xc4, 0x62, 0x3d, 0xf4, 0xd2, 0x0d, 0x89, 0xda, 0xff, 0xf4, 0x8e, 0x72, 0xff,
+	0xfe, 0xbd, 0x1b, 0x20, 0xb3, 0xd3, 0x61, 0xf9, 0x7a, 0xa5, 0xcd, 0x0d, 0xf3, 0x18, 0x14, 0x7e,
+	0x20, 0x64, 0xa6, 0xad, 0x0d, 0x0a, 0x3f, 0x02, 0xde, 0xfd, 0x5e, 0xb3, 0x2c, 0xf8, 0x91, 0xf0,
+	0x00, 0x8b, 0x1b, 0x09, 0x0a, 0xd1, 0x04, 0xd1, 0x77, 0x50, 0x8c, 0xb6, 0x6f, 0xa8, 0x49, 0xf5,
+	0x7c, 0xb3, 0x7c, 0xf4, 0xf9, 0xf6, 0x15, 0x89, 0x62, 0xc0, 0x57, 0x25, 0x41, 0x50, 0x1b, 0x2a,
+	0xe1, 0x7c, 0x14, 0x8e, 0x03, 0xc7, 0xa7, 0x8e, 0xe7, 0x6a, 0x7b, 0xdc, 0x62, 0xd7, 0x81, 0x3e,
+	0x1f, 0x71, 0x3c, 0x85, 0xa0, 0x6f, 0xa1, 0x30, 0xf6, 0x5c, 0x1a, 0x78, 0x53, 0x1e, 0x89, 0x9d,
+	0x0d, 0x74, 0x84, 0x88, 0x3b, 0xc4, 0x84, 0xde, 0x87, 0xf2, 0x4a, 0x63, 0x0f, 0x3e, 0x0d, 0xbb,
+	0x50, 0x88, 0x9a, 0x64, 0x56, 0x51, 0x9b, 0x23, 0xf1, 0x47, 0x54, 0x8c, 0xad, 0x92, 0x72, 0xa6,
+	0xd5, 0x6f, 0x7b, 0x50, 0x5e, 0x69, 0x19, 0x3d, 0x03, 0xc5, 0xb9, 0x66, 0xdf, 0x14, 0xb1, 0xca,
+	0x4f, 0x32, 0x27, 0xd9, 0x7d, 0x61, 0x2f, 0xc4, 0x52, 0x0b, 0x88, 0xd3, 0x3f, 0xdb, 0x2e, 0x8d,
+	0x16, 0xf8, 0x1d, 0xf4, 0x8f, 0xb6, 0x4b, 0x23, 0x9a, 0x41, 0x8c, 0x16, 0x1f, 0xa7, 0xfc, 0x3d,
+	0x68, 0xbe, 0x41, 0x05, 0x2d, 0xbe, 0x53, 0xcf, 0xe2, 0xef, 0x94, 0x7c, 0x0f, 0x9a, 0xef, 0x4d,
+	0x41, 0x8b, 0x4f, 0xd6, 0x19, 0xa8, 0xeb, 0x93, 0xca, 0xca, 0x11, 0xaa, 0x01, 0x24, 0xef, 0x2a,
+	0xe4, 0xd3, 0xad, 0xe0, 0x95, 0x8a, 0x7e, 0xb4, 0xf4, 0x8b, 0xa7, 0xb9, 0xc6, 0x48, 0x1b, 0x4c,
+	0x2b, 0x61, 0x92, 0xc9, 0x65, 0x66, 0xd9, 0x48, 0xf4, 0xc9, 0x74, 0x32, 0x7b, 0xfe, 0x08, 0x14,
+	0x16, 0xbb, 0xb8, 0x5d, 0x71, 0xd3, 0xf8, 0x4b, 0x02, 0x99, 0xfd, 0x2d, 0xa3, 0x0f, 0xe1, 0xd0,
+	0xba, 0x38, 0xee, 0x75, 0x07, 0x2f, 0xae, 0xfa, 0xe6, 0x60, 0xd0, 0x3e, 0x31, 0xd5, 0x1c, 0x42,
+	0x50, 0xc5, 0xe6, 0xa9, 0xd9, 0x19, 0x26, 0x35, 0x09, 0x3d, 0x82, 0x0f, 0x8c, 0x0b, 0xab, 0xd7,
+	0xed, 0xb4, 0x87, 0x66, 0x52, 0xde, 0x63, 0xbc, 0x61, 0xf6, 0xba, 0x97, 0x26, 0x4e, 0x8a, 0x79,
+	0x54, 0x81, 0x62, 0xdb, 0x30, 0xae, 0x2c, 0xd3, 0xc4, 0xaa, 0x8c, 0x0e, 0xa1, 0x8c, 0xcd, 0xfe,
+	0xf9, 0xa5, 0x29, 0x0a, 0x0a, 0x7b, 0x8c, 0xcd, 0xce, 0xe5, 0x15, 0xb6, 0x3a, 0xea, 0x3e, 0xbb,
+	0x1b, 0x98, 0x67, 0x06, 0xbf, 0x2b, 0xb0, 0x3b, 0x03, 0x9f, 0x5b, 0xfc, 0xae, 0x88, 0x8a, 0x20,
+	0x9f, 0x9e, 0x77, 0xcf, 0xd4, 0x12, 0x2a, 0x81, 0xd2, 0x33, 0xdb, 0x97, 0xa6, 0x0a, 0xec, 0xf2,
+	0x04, 0xb7, 0x9f, 0x0f, 0xd5, 0x32, 0xbb, 0xb4, 0xf0, 0xc5, 0x99, 0xa9, 0x56, 0x1a, 0xdf, 0xc3,
+	0xe1, 0xf2, 0x8d, 0x1f, 0xdb, 0x74, 0x7c, 0x8d, 0xbe, 0x02, 0x65, 0xc4, 0x2e, 0xa2, 0x6d, 0xfd,
+	0x68, 0xeb, 0xe6, 0xc0, 0x42, 0x73, 0xac, 0xdd, 0xdc, 0xd6, 0xa4, 0xb7, 0xb7, 0x35, 0xe9, 0xdf,
+	0xdb, 0x9a, 0xf4, 0xfb, 0x5d, 0x2d, 0xf7, 0xf6, 0xae, 0x96, 0xfb, 0xfb, 0xae, 0x96, 0xfb, 0x2f,
+	0x00, 0x00, 0xff, 0xff, 0x47, 0x99, 0x96, 0xf0, 0xa2, 0x0c, 0x00, 0x00,
 }
 
 func (m *TraceEvent) Marshal() (dAtA []byte, err error) {
@@ -1596,10 +1529,6 @@ func (m *TraceEvent) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.Prune != nil {
 		{
 			size, err := m.Prune.MarshalToSizedBuffer(dAtA[:i])
@@ -1758,11 +1687,9 @@ func (m *TraceEvent) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x22
 	}
-	if m.Timestamp != nil {
-		i = encodeVarintTrace(dAtA, i, uint64(*m.Timestamp))
-		i--
-		dAtA[i] = 0x18
-	}
+	i = encodeVarintTrace(dAtA, i, uint64(m.Timestamp))
+	i--
+	dAtA[i] = 0x18
 	if m.PeerID != nil {
 		i -= len(m.PeerID)
 		copy(dAtA[i:], m.PeerID)
@@ -1770,11 +1697,9 @@ func (m *TraceEvent) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x12
 	}
-	if m.Type != nil {
-		i = encodeVarintTrace(dAtA, i, uint64(*m.Type))
-		i--
-		dAtA[i] = 0x8
-	}
+	i = encodeVarintTrace(dAtA, i, uint64(m.Type))
+	i--
+	dAtA[i] = 0x8
 	return len(dAtA) - i, nil
 }
 
@@ -1798,17 +1723,11 @@ func (m *TraceEvent_PublishMessage) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0x12
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0x12
 	if m.MessageID != nil {
 		i -= len(m.MessageID)
 		copy(dAtA[i:], m.MessageID)
@@ -1839,24 +1758,16 @@ func (m *TraceEvent_RejectMessage) MarshalToSizedBuffer(dAtA []byte) (int, error
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0x22
-	}
-	if m.Reason != nil {
-		i -= len(*m.Reason)
-		copy(dAtA[i:], *m.Reason)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Reason)))
-		i--
-		dAtA[i] = 0x1a
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0x22
+	i -= len(m.Reason)
+	copy(dAtA[i:], m.Reason)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Reason)))
+	i--
+	dAtA[i] = 0x1a
 	if m.ReceivedFrom != nil {
 		i -= len(m.ReceivedFrom)
 		copy(dAtA[i:], m.ReceivedFrom)
@@ -1894,17 +1805,11 @@ func (m *TraceEvent_DuplicateMessage) MarshalToSizedBuffer(dAtA []byte) (int, er
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0x1a
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0x1a
 	if m.ReceivedFrom != nil {
 		i -= len(m.ReceivedFrom)
 		copy(dAtA[i:], m.ReceivedFrom)
@@ -1942,10 +1847,6 @@ func (m *TraceEvent_DeliverMessage) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.ReceivedFrom != nil {
 		i -= len(m.ReceivedFrom)
 		copy(dAtA[i:], m.ReceivedFrom)
@@ -1953,13 +1854,11 @@ func (m *TraceEvent_DeliverMessage) MarshalToSizedBuffer(dAtA []byte) (int, erro
 		i--
 		dAtA[i] = 0x1a
 	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0x12
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0x12
 	if m.MessageID != nil {
 		i -= len(m.MessageID)
 		copy(dAtA[i:], m.MessageID)
@@ -1990,17 +1889,11 @@ func (m *TraceEvent_AddPeer) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Proto != nil {
-		i -= len(*m.Proto)
-		copy(dAtA[i:], *m.Proto)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Proto)))
-		i--
-		dAtA[i] = 0x12
-	}
+	i -= len(m.Proto)
+	copy(dAtA[i:], m.Proto)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Proto)))
+	i--
+	dAtA[i] = 0x12
 	if m.PeerID != nil {
 		i -= len(m.PeerID)
 		copy(dAtA[i:], m.PeerID)
@@ -2031,10 +1924,6 @@ func (m *TraceEvent_RemovePeer) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.PeerID != nil {
 		i -= len(m.PeerID)
 		copy(dAtA[i:], m.PeerID)
@@ -2065,10 +1954,6 @@ func (m *TraceEvent_RecvRPC) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.Meta != nil {
 		{
 			size, err := m.Meta.MarshalToSizedBuffer(dAtA[:i])
@@ -2111,10 +1996,6 @@ func (m *TraceEvent_SendRPC) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.Meta != nil {
 		{
 			size, err := m.Meta.MarshalToSizedBuffer(dAtA[:i])
@@ -2157,10 +2038,6 @@ func (m *TraceEvent_DropRPC) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.Meta != nil {
 		{
 			size, err := m.Meta.MarshalToSizedBuffer(dAtA[:i])
@@ -2203,17 +2080,11 @@ func (m *TraceEvent_Join) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0xa
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -2237,17 +2108,11 @@ func (m *TraceEvent_Leave) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0x12
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0x12
 	return len(dAtA) - i, nil
 }
 
@@ -2271,17 +2136,11 @@ func (m *TraceEvent_Graft) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0x12
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0x12
 	if m.PeerID != nil {
 		i -= len(m.PeerID)
 		copy(dAtA[i:], m.PeerID)
@@ -2312,17 +2171,11 @@ func (m *TraceEvent_Prune) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0x12
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0x12
 	if m.PeerID != nil {
 		i -= len(m.PeerID)
 		copy(dAtA[i:], m.PeerID)
@@ -2353,10 +2206,6 @@ func (m *TraceEvent_RPCMeta) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if m.Control != nil {
 		{
 			size, err := m.Control.MarshalToSizedBuffer(dAtA[:i])
@@ -2420,17 +2269,11 @@ func (m *TraceEvent_MessageMeta) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0x12
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0x12
 	if m.MessageID != nil {
 		i -= len(m.MessageID)
 		copy(dAtA[i:], m.MessageID)
@@ -2461,27 +2304,19 @@ func (m *TraceEvent_SubMeta) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0x12
+	i--
+	if m.Subscribe {
+		dAtA[i] = 1
+	} else {
+		dAtA[i] = 0
 	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0x12
-	}
-	if m.Subscribe != nil {
-		i--
-		if *m.Subscribe {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x8
-	}
+	i--
+	dAtA[i] = 0x8
 	return len(dAtA) - i, nil
 }
 
@@ -2505,10 +2340,6 @@ func (m *TraceEvent_ControlMeta) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if len(m.Prune) > 0 {
 		for iNdEx := len(m.Prune) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -2588,10 +2419,6 @@ func (m *TraceEvent_ControlIHaveMeta) MarshalToSizedBuffer(dAtA []byte) (int, er
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if len(m.MessageIDs) > 0 {
 		for iNdEx := len(m.MessageIDs) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.MessageIDs[iNdEx])
@@ -2601,13 +2428,11 @@ func (m *TraceEvent_ControlIHaveMeta) MarshalToSizedBuffer(dAtA []byte) (int, er
 			dAtA[i] = 0x12
 		}
 	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0xa
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -2631,10 +2456,6 @@ func (m *TraceEvent_ControlIWantMeta) MarshalToSizedBuffer(dAtA []byte) (int, er
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if len(m.MessageIDs) > 0 {
 		for iNdEx := len(m.MessageIDs) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.MessageIDs[iNdEx])
@@ -2667,17 +2488,11 @@ func (m *TraceEvent_ControlGraftMeta) MarshalToSizedBuffer(dAtA []byte) (int, er
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0xa
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -2701,10 +2516,6 @@ func (m *TraceEvent_ControlPruneMeta) MarshalToSizedBuffer(dAtA []byte) (int, er
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if len(m.Peers) > 0 {
 		for iNdEx := len(m.Peers) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.Peers[iNdEx])
@@ -2714,13 +2525,11 @@ func (m *TraceEvent_ControlPruneMeta) MarshalToSizedBuffer(dAtA []byte) (int, er
 			dAtA[i] = 0x12
 		}
 	}
-	if m.Topic != nil {
-		i -= len(*m.Topic)
-		copy(dAtA[i:], *m.Topic)
-		i = encodeVarintTrace(dAtA, i, uint64(len(*m.Topic)))
-		i--
-		dAtA[i] = 0xa
-	}
+	i -= len(m.Topic)
+	copy(dAtA[i:], m.Topic)
+	i = encodeVarintTrace(dAtA, i, uint64(len(m.Topic)))
+	i--
+	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -2744,10 +2553,6 @@ func (m *TraceEventBatch) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
 	if len(m.Batch) > 0 {
 		for iNdEx := len(m.Batch) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -2782,16 +2587,12 @@ func (m *TraceEvent) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Type != nil {
-		n += 1 + sovTrace(uint64(*m.Type))
-	}
+	n += 1 + sovTrace(uint64(m.Type))
 	if m.PeerID != nil {
 		l = len(m.PeerID)
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.Timestamp != nil {
-		n += 1 + sovTrace(uint64(*m.Timestamp))
-	}
+	n += 1 + sovTrace(uint64(m.Timestamp))
 	if m.PublishMessage != nil {
 		l = m.PublishMessage.Size()
 		n += 1 + l + sovTrace(uint64(l))
@@ -2844,9 +2645,6 @@ func (m *TraceEvent) Size() (n int) {
 		l = m.Prune.Size()
 		n += 2 + l + sovTrace(uint64(l))
 	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
 	return n
 }
 
@@ -2860,13 +2658,8 @@ func (m *TraceEvent_PublishMessage) Size() (n int) {
 		l = len(m.MessageID)
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -2884,17 +2677,10 @@ func (m *TraceEvent_RejectMessage) Size() (n int) {
 		l = len(m.ReceivedFrom)
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.Reason != nil {
-		l = len(*m.Reason)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.Reason)
+	n += 1 + l + sovTrace(uint64(l))
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -2912,13 +2698,8 @@ func (m *TraceEvent_DuplicateMessage) Size() (n int) {
 		l = len(m.ReceivedFrom)
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -2932,16 +2713,11 @@ func (m *TraceEvent_DeliverMessage) Size() (n int) {
 		l = len(m.MessageID)
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	if m.ReceivedFrom != nil {
 		l = len(m.ReceivedFrom)
 		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -2956,13 +2732,8 @@ func (m *TraceEvent_AddPeer) Size() (n int) {
 		l = len(m.PeerID)
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.Proto != nil {
-		l = len(*m.Proto)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.Proto)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -2975,9 +2746,6 @@ func (m *TraceEvent_RemovePeer) Size() (n int) {
 	if m.PeerID != nil {
 		l = len(m.PeerID)
 		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -2996,9 +2764,6 @@ func (m *TraceEvent_RecvRPC) Size() (n int) {
 		l = m.Meta.Size()
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
 	return n
 }
 
@@ -3015,9 +2780,6 @@ func (m *TraceEvent_SendRPC) Size() (n int) {
 	if m.Meta != nil {
 		l = m.Meta.Size()
 		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -3036,9 +2798,6 @@ func (m *TraceEvent_DropRPC) Size() (n int) {
 		l = m.Meta.Size()
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
 	return n
 }
 
@@ -3048,13 +2807,8 @@ func (m *TraceEvent_Join) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -3064,13 +2818,8 @@ func (m *TraceEvent_Leave) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -3084,13 +2833,8 @@ func (m *TraceEvent_Graft) Size() (n int) {
 		l = len(m.PeerID)
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -3104,13 +2848,8 @@ func (m *TraceEvent_Prune) Size() (n int) {
 		l = len(m.PeerID)
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -3136,9 +2875,6 @@ func (m *TraceEvent_RPCMeta) Size() (n int) {
 		l = m.Control.Size()
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
 	return n
 }
 
@@ -3152,13 +2888,8 @@ func (m *TraceEvent_MessageMeta) Size() (n int) {
 		l = len(m.MessageID)
 		n += 1 + l + sovTrace(uint64(l))
 	}
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -3168,16 +2899,9 @@ func (m *TraceEvent_SubMeta) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Subscribe != nil {
-		n += 2
-	}
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	n += 2
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -3211,9 +2935,6 @@ func (m *TraceEvent_ControlMeta) Size() (n int) {
 			n += 1 + l + sovTrace(uint64(l))
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
 	return n
 }
 
@@ -3223,18 +2944,13 @@ func (m *TraceEvent_ControlIHaveMeta) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	if len(m.MessageIDs) > 0 {
 		for _, b := range m.MessageIDs {
 			l = len(b)
 			n += 1 + l + sovTrace(uint64(l))
 		}
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -3251,9 +2967,6 @@ func (m *TraceEvent_ControlIWantMeta) Size() (n int) {
 			n += 1 + l + sovTrace(uint64(l))
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
 	return n
 }
 
@@ -3263,13 +2976,8 @@ func (m *TraceEvent_ControlGraftMeta) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	return n
 }
 
@@ -3279,18 +2987,13 @@ func (m *TraceEvent_ControlPruneMeta) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Topic != nil {
-		l = len(*m.Topic)
-		n += 1 + l + sovTrace(uint64(l))
-	}
+	l = len(m.Topic)
+	n += 1 + l + sovTrace(uint64(l))
 	if len(m.Peers) > 0 {
 		for _, b := range m.Peers {
 			l = len(b)
 			n += 1 + l + sovTrace(uint64(l))
 		}
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -3306,9 +3009,6 @@ func (m *TraceEventBatch) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovTrace(uint64(l))
 		}
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
 	}
 	return n
 }
@@ -3352,7 +3052,7 @@ func (m *TraceEvent) Unmarshal(dAtA []byte) error {
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
 			}
-			var v TraceEvent_Type
+			m.Type = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowTrace
@@ -3362,12 +3062,11 @@ func (m *TraceEvent) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= TraceEvent_Type(b&0x7F) << shift
+				m.Type |= TraceEvent_Type(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			m.Type = &v
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field PeerID", wireType)
@@ -3406,7 +3105,7 @@ func (m *TraceEvent) Unmarshal(dAtA []byte) error {
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
 			}
-			var v int64
+			m.Timestamp = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowTrace
@@ -3416,12 +3115,11 @@ func (m *TraceEvent) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= int64(b&0x7F) << shift
+				m.Timestamp |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			m.Timestamp = &v
 		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field PublishMessage", wireType)
@@ -3896,16 +3594,12 @@ func (m *TraceEvent) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -4008,8 +3702,7 @@ func (m *TraceEvent_PublishMessage) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -4017,16 +3710,12 @@ func (m *TraceEvent_PublishMessage) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -4163,8 +3852,7 @@ func (m *TraceEvent_RejectMessage) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Reason = &s
+			m.Reason = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
@@ -4196,8 +3884,7 @@ func (m *TraceEvent_RejectMessage) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -4205,16 +3892,12 @@ func (m *TraceEvent_RejectMessage) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -4351,8 +4034,7 @@ func (m *TraceEvent_DuplicateMessage) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -4360,16 +4042,12 @@ func (m *TraceEvent_DuplicateMessage) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -4472,8 +4150,7 @@ func (m *TraceEvent_DeliverMessage) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
@@ -4515,16 +4192,12 @@ func (m *TraceEvent_DeliverMessage) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -4627,8 +4300,7 @@ func (m *TraceEvent_AddPeer) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Proto = &s
+			m.Proto = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -4636,16 +4308,12 @@ func (m *TraceEvent_AddPeer) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -4724,16 +4392,12 @@ func (m *TraceEvent_RemovePeer) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -4848,16 +4512,12 @@ func (m *TraceEvent_RecvRPC) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -4972,16 +4632,12 @@ func (m *TraceEvent_SendRPC) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -5096,16 +4752,12 @@ func (m *TraceEvent_DropRPC) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -5174,8 +4826,7 @@ func (m *TraceEvent_Join) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5183,16 +4834,12 @@ func (m *TraceEvent_Join) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -5261,8 +4908,7 @@ func (m *TraceEvent_Leave) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5270,16 +4916,12 @@ func (m *TraceEvent_Leave) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -5382,8 +5024,7 @@ func (m *TraceEvent_Graft) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5391,16 +5032,12 @@ func (m *TraceEvent_Graft) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -5503,8 +5140,7 @@ func (m *TraceEvent_Prune) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5512,16 +5148,12 @@ func (m *TraceEvent_Prune) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -5670,16 +5302,12 @@ func (m *TraceEvent_RPCMeta) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -5782,8 +5410,7 @@ func (m *TraceEvent_MessageMeta) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5791,16 +5418,12 @@ func (m *TraceEvent_MessageMeta) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -5858,8 +5481,7 @@ func (m *TraceEvent_SubMeta) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-			b := bool(v != 0)
-			m.Subscribe = &b
+			m.Subscribe = bool(v != 0)
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Topic", wireType)
@@ -5890,8 +5512,7 @@ func (m *TraceEvent_SubMeta) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5899,16 +5520,12 @@ func (m *TraceEvent_SubMeta) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -6089,16 +5706,12 @@ func (m *TraceEvent_ControlMeta) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -6167,8 +5780,7 @@ func (m *TraceEvent_ControlIHaveMeta) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
@@ -6208,16 +5820,12 @@ func (m *TraceEvent_ControlIHaveMeta) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -6294,16 +5902,12 @@ func (m *TraceEvent_ControlIWantMeta) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -6372,8 +5976,7 @@ func (m *TraceEvent_ControlGraftMeta) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -6381,16 +5984,12 @@ func (m *TraceEvent_ControlGraftMeta) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -6459,8 +6058,7 @@ func (m *TraceEvent_ControlPruneMeta) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			s := string(dAtA[iNdEx:postIndex])
-			m.Topic = &s
+			m.Topic = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
@@ -6500,16 +6098,12 @@ func (m *TraceEvent_ControlPruneMeta) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}
@@ -6588,16 +6182,12 @@ func (m *TraceEventBatch) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTrace
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTrace
 			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
 			iNdEx += skippy
 		}
 	}

--- a/pubsub.go
+++ b/pubsub.go
@@ -774,8 +774,8 @@ func (p *PubSub) handleRemoveRelay(topic string) {
 // Only called from processLoop.
 func (p *PubSub) announce(topic string, sub bool) {
 	subopt := &pb.RPC_SubOpts{
-		Topicid:   &topic,
-		Subscribe: &sub,
+		Topicid:   topic,
+		Subscribe: sub,
 	}
 
 	out := rpcWithSubs(subopt)
@@ -818,8 +818,8 @@ func (p *PubSub) doAnnounceRetry(pid peer.ID, topic string, sub bool) {
 	}
 
 	subopt := &pb.RPC_SubOpts{
-		Topicid:   &topic,
-		Subscribe: &sub,
+		Topicid:   topic,
+		Subscribe: sub,
 	}
 
 	out := rpcWithSubs(subopt)
@@ -1141,7 +1141,7 @@ type SubOpt func(sub *Subscription) error
 //
 // Deprecated: use pubsub.Join() and topic.Subscribe() instead
 func (p *PubSub) Subscribe(topic string, opts ...SubOpt) (*Subscription, error) {
-	td := pb.TopicDescriptor{Name: &topic}
+	td := pb.TopicDescriptor{Name: topic}
 
 	return p.SubscribeByTopicDescriptor(&td, opts...)
 }

--- a/score_test.go
+++ b/score_test.go
@@ -109,7 +109,7 @@ func TestScoreFirstMessageDeliveries(t *testing.T) {
 	nMessages := 100
 	for i := 0; i < nMessages; i++ {
 		pbMsg := makeTestMessage(i)
-		pbMsg.Topic = &mytopic
+		pbMsg.Topic = mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 		ps.ValidateMessage(&msg)
 		ps.DeliverMessage(&msg)
@@ -149,7 +149,7 @@ func TestScoreFirstMessageDeliveriesCap(t *testing.T) {
 	nMessages := 100
 	for i := 0; i < nMessages; i++ {
 		pbMsg := makeTestMessage(i)
-		pbMsg.Topic = &mytopic
+		pbMsg.Topic = mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 		ps.ValidateMessage(&msg)
 		ps.DeliverMessage(&msg)
@@ -189,7 +189,7 @@ func TestScoreFirstMessageDeliveriesDecay(t *testing.T) {
 	nMessages := 100
 	for i := 0; i < nMessages; i++ {
 		pbMsg := makeTestMessage(i)
-		pbMsg.Topic = &mytopic
+		pbMsg.Topic = mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 		ps.ValidateMessage(&msg)
 		ps.DeliverMessage(&msg)
@@ -269,7 +269,7 @@ func TestScoreMeshMessageDeliveries(t *testing.T) {
 	wg := sync.WaitGroup{}
 	for i := 0; i < nMessages; i++ {
 		pbMsg := makeTestMessage(i)
-		pbMsg.Topic = &mytopic
+		pbMsg.Topic = mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 		ps.ValidateMessage(&msg)
 		ps.DeliverMessage(&msg)
@@ -339,7 +339,7 @@ func TestScoreMeshMessageDeliveriesDecay(t *testing.T) {
 	nMessages := 40
 	for i := 0; i < nMessages; i++ {
 		pbMsg := makeTestMessage(i)
-		pbMsg.Topic = &mytopic
+		pbMsg.Topic = mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 		ps.ValidateMessage(&msg)
 		ps.DeliverMessage(&msg)
@@ -413,7 +413,7 @@ func TestScoreMeshFailurePenalty(t *testing.T) {
 	nMessages := 100
 	for i := 0; i < nMessages; i++ {
 		pbMsg := makeTestMessage(i)
-		pbMsg.Topic = &mytopic
+		pbMsg.Topic = mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 		ps.ValidateMessage(&msg)
 		ps.DeliverMessage(&msg)
@@ -473,7 +473,7 @@ func TestScoreInvalidMessageDeliveries(t *testing.T) {
 	nMessages := 100
 	for i := 0; i < nMessages; i++ {
 		pbMsg := makeTestMessage(i)
-		pbMsg.Topic = &mytopic
+		pbMsg.Topic = mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 		ps.RejectMessage(&msg, RejectInvalidSignature)
 	}
@@ -510,7 +510,7 @@ func TestScoreInvalidMessageDeliveriesDecay(t *testing.T) {
 	nMessages := 100
 	for i := 0; i < nMessages; i++ {
 		pbMsg := makeTestMessage(i)
-		pbMsg.Topic = &mytopic
+		pbMsg.Topic = mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 		ps.RejectMessage(&msg, RejectInvalidSignature)
 	}
@@ -556,7 +556,7 @@ func TestScoreRejectMessageDeliveries(t *testing.T) {
 	ps.AddPeer(peerB, "myproto")
 
 	pbMsg := makeTestMessage(0)
-	pbMsg.Topic = &mytopic
+	pbMsg.Topic = mytopic
 	msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 	msg2 := Message{ReceivedFrom: peerB, Message: pbMsg}
 
@@ -947,7 +947,7 @@ func TestScoreRecapTopicParams(t *testing.T) {
 	nMessages := 100
 	for i := 0; i < nMessages; i++ {
 		pbMsg := makeTestMessage(i)
-		pbMsg.Topic = &mytopic
+		pbMsg.Topic = mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 		ps.ValidateMessage(&msg)
 		ps.DeliverMessage(&msg)
@@ -1029,7 +1029,7 @@ func TestScoreResetTopicParams(t *testing.T) {
 	nMessages := 100
 	for i := 0; i < nMessages; i++ {
 		pbMsg := makeTestMessage(i)
-		pbMsg.Topic = &mytopic
+		pbMsg.Topic = mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
 		ps.ValidateMessage(&msg)
 		ps.RejectMessage(&msg, RejectValidationFailed)

--- a/sign_test.go
+++ b/sign_test.go
@@ -31,7 +31,7 @@ func testSignVerify(t *testing.T, privk crypto.PrivKey) {
 	topic := "foo"
 	m := pb.Message{
 		Data:  []byte("abc"),
-		Topic: &topic,
+		Topic: topic,
 		From:  []byte(id),
 		Seqno: []byte("123"),
 	}

--- a/subscription_filter_test.go
+++ b/subscription_filter_test.go
@@ -20,16 +20,16 @@ func TestBasicSubscriptionFilter(t *testing.T) {
 	yes := true
 	subs := []*pb.RPC_SubOpts{
 		&pb.RPC_SubOpts{
-			Topicid:   &topic1,
-			Subscribe: &yes,
+			Topicid:   topic1,
+			Subscribe: yes,
 		},
 		&pb.RPC_SubOpts{
-			Topicid:   &topic2,
-			Subscribe: &yes,
+			Topicid:   topic2,
+			Subscribe: yes,
 		},
 		&pb.RPC_SubOpts{
-			Topicid:   &topic3,
-			Subscribe: &yes,
+			Topicid:   topic3,
+			Subscribe: yes,
 		},
 	}
 
@@ -109,25 +109,25 @@ func TestSubscriptionFilterDeduplication(t *testing.T) {
 	no := false
 	subs := []*pb.RPC_SubOpts{
 		&pb.RPC_SubOpts{
-			Topicid:   &topic1,
-			Subscribe: &yes,
+			Topicid:   topic1,
+			Subscribe: yes,
 		},
 		&pb.RPC_SubOpts{
-			Topicid:   &topic1,
-			Subscribe: &yes,
+			Topicid:   topic1,
+			Subscribe: yes,
 		},
 
 		&pb.RPC_SubOpts{
-			Topicid:   &topic2,
-			Subscribe: &yes,
+			Topicid:   topic2,
+			Subscribe: yes,
 		},
 		&pb.RPC_SubOpts{
-			Topicid:   &topic2,
-			Subscribe: &no,
+			Topicid:   topic2,
+			Subscribe: no,
 		},
 		&pb.RPC_SubOpts{
-			Topicid:   &topic3,
-			Subscribe: &yes,
+			Topicid:   topic3,
+			Subscribe: yes,
 		},
 	}
 

--- a/tag_tracer_test.go
+++ b/tag_tracer_test.go
@@ -89,9 +89,9 @@ func TestTagTracerDeliveryTags(t *testing.T) {
 
 	for i := 0; i < 20; i++ {
 		// deliver only 5 messages to topic 2 (less than the cap)
-		topic := &topic1
+		topic := topic1
 		if i < 5 {
-			topic = &topic2
+			topic = topic2
 		}
 		msg := &Message{
 			ReceivedFrom: p,
@@ -181,7 +181,7 @@ func TestTagTracerDeliveryTagsNearFirst(t *testing.T) {
 			Message: &pb.Message{
 				From:  []byte(p),
 				Data:  []byte(fmt.Sprintf("msg-%d", i)),
-				Topic: &topic,
+				Topic: topic,
 				Seqno: []byte(fmt.Sprintf("%d", i)),
 			},
 		}

--- a/topic.go
+++ b/topic.go
@@ -213,7 +213,7 @@ func (t *Topic) Publish(ctx context.Context, data []byte, opts ...PubOpt) error 
 
 	m := &pb.Message{
 		Data:  data,
-		Topic: &t.topic,
+		Topic: t.topic,
 		From:  nil,
 		Seqno: nil,
 	}

--- a/trace.go
+++ b/trace.go
@@ -67,11 +67,10 @@ func (t *pubsubTracer) PublishMessage(msg *Message) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_PUBLISH_MESSAGE.Enum(),
+		Type:      pb.TraceEvent_PUBLISH_MESSAGE,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		PublishMessage: &pb.TraceEvent_PublishMessage{
 			MessageID: []byte(t.msgID(msg.Message)),
 			Topic:     msg.Message.Topic,
@@ -108,15 +107,14 @@ func (t *pubsubTracer) RejectMessage(msg *Message, reason string) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_REJECT_MESSAGE.Enum(),
+		Type:      pb.TraceEvent_REJECT_MESSAGE,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		RejectMessage: &pb.TraceEvent_RejectMessage{
 			MessageID:    []byte(t.msgID(msg.Message)),
 			ReceivedFrom: []byte(msg.ReceivedFrom),
-			Reason:       &reason,
+			Reason:       reason,
 			Topic:        msg.Topic,
 		},
 	}
@@ -139,11 +137,10 @@ func (t *pubsubTracer) DuplicateMessage(msg *Message) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_DUPLICATE_MESSAGE.Enum(),
+		Type:      pb.TraceEvent_DUPLICATE_MESSAGE,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		DuplicateMessage: &pb.TraceEvent_DuplicateMessage{
 			MessageID:    []byte(t.msgID(msg.Message)),
 			ReceivedFrom: []byte(msg.ReceivedFrom),
@@ -169,11 +166,10 @@ func (t *pubsubTracer) DeliverMessage(msg *Message) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_DELIVER_MESSAGE.Enum(),
+		Type:      pb.TraceEvent_DELIVER_MESSAGE,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		DeliverMessage: &pb.TraceEvent_DeliverMessage{
 			MessageID:    []byte(t.msgID(msg.Message)),
 			Topic:        msg.Topic,
@@ -198,14 +194,13 @@ func (t *pubsubTracer) AddPeer(p peer.ID, proto protocol.ID) {
 	}
 
 	protoStr := string(proto)
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_ADD_PEER.Enum(),
+		Type:      pb.TraceEvent_ADD_PEER,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		AddPeer: &pb.TraceEvent_AddPeer{
 			PeerID: []byte(p),
-			Proto:  &protoStr,
+			Proto:  protoStr,
 		},
 	}
 
@@ -225,11 +220,10 @@ func (t *pubsubTracer) RemovePeer(p peer.ID) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_REMOVE_PEER.Enum(),
+		Type:      pb.TraceEvent_REMOVE_PEER,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		RemovePeer: &pb.TraceEvent_RemovePeer{
 			PeerID: []byte(p),
 		},
@@ -247,11 +241,10 @@ func (t *pubsubTracer) RecvRPC(rpc *RPC) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_RECV_RPC.Enum(),
+		Type:      pb.TraceEvent_RECV_RPC,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		RecvRPC: &pb.TraceEvent_RecvRPC{
 			ReceivedFrom: []byte(rpc.from),
 			Meta:         t.traceRPCMeta(rpc),
@@ -270,11 +263,10 @@ func (t *pubsubTracer) SendRPC(rpc *RPC, p peer.ID) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_SEND_RPC.Enum(),
+		Type:      pb.TraceEvent_SEND_RPC,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		SendRPC: &pb.TraceEvent_SendRPC{
 			SendTo: []byte(p),
 			Meta:   t.traceRPCMeta(rpc),
@@ -293,11 +285,10 @@ func (t *pubsubTracer) DropRPC(rpc *RPC, p peer.ID) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_DROP_RPC.Enum(),
+		Type:      pb.TraceEvent_DROP_RPC,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		DropRPC: &pb.TraceEvent_DropRPC{
 			SendTo: []byte(p),
 			Meta:   t.traceRPCMeta(rpc),
@@ -395,13 +386,12 @@ func (t *pubsubTracer) Join(topic string) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_JOIN.Enum(),
+		Type:      pb.TraceEvent_JOIN,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		Join: &pb.TraceEvent_Join{
-			Topic: &topic,
+			Topic: topic,
 		},
 	}
 
@@ -421,13 +411,12 @@ func (t *pubsubTracer) Leave(topic string) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_LEAVE.Enum(),
+		Type:      pb.TraceEvent_LEAVE,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		Leave: &pb.TraceEvent_Leave{
-			Topic: &topic,
+			Topic: topic,
 		},
 	}
 
@@ -447,14 +436,13 @@ func (t *pubsubTracer) Graft(p peer.ID, topic string) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_GRAFT.Enum(),
+		Type:      pb.TraceEvent_GRAFT,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		Graft: &pb.TraceEvent_Graft{
 			PeerID: []byte(p),
-			Topic:  &topic,
+			Topic:  topic,
 		},
 	}
 
@@ -474,14 +462,13 @@ func (t *pubsubTracer) Prune(p peer.ID, topic string) {
 		return
 	}
 
-	now := time.Now().UnixNano()
 	evt := &pb.TraceEvent{
-		Type:      pb.TraceEvent_PRUNE.Enum(),
+		Type:      pb.TraceEvent_PRUNE,
 		PeerID:    []byte(t.pid),
-		Timestamp: &now,
+		Timestamp: time.Now().UnixNano(),
 		Prune: &pb.TraceEvent_Prune{
 			PeerID: []byte(p),
-			Topic:  &topic,
+			Topic:  topic,
 		},
 	}
 


### PR DESCRIPTION
This removes the pointer indirection from all values and saves us an allocation. We never actually try to distinguish between a field being missing and the "zero" value anyways.