### PR TITLE
fix goroutine build up from connected notifications

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -13,7 +13,6 @@ import (
 	"github.com/libp2p/go-msgio/protoio"
 
 	"github.com/gogo/protobuf/proto"
-	ms "github.com/multiformats/go-multistream"
 )
 
 // get the initial RPC containing all of our subscriptions to send to new peers
@@ -106,14 +105,11 @@ func (p *PubSub) handleNewPeer(ctx context.Context, pid peer.ID, outgoing <-chan
 	if err != nil {
 		log.Debug("opening new stream to peer: ", err, pid)
 
-		if err == ms.ErrNotSupported {
-			select {
-			case p.newPeerError <- pid:
-			case <-ctx.Done():
-			}
-		} else {
-			p.notifyPeerDead(pid)
+		select {
+		case p.newPeerError <- pid:
+		case <-ctx.Done():
 		}
+
 		return
 	}
 

--- a/notify.go
+++ b/notify.go
@@ -24,15 +24,13 @@ func (p *PubSubNotif) Connected(n network.Network, c network.Conn) {
 
 	select {
 	case <-p.newPeersSema:
-		defer func() {
-			p.newPeersSema <- struct{}{}
-		}()
-
 	case <-p.ctx.Done():
 		return
 	}
 
 	p.newPeersPend[c.RemotePeer()] = struct{}{}
+	p.newPeersSema <- struct{}{}
+
 	select {
 	case p.newPeers <- struct{}{}:
 	default:
@@ -61,10 +59,6 @@ func (p *PubSubNotif) Initialize() {
 
 	select {
 	case <-p.newPeersSema:
-		defer func() {
-			p.newPeersSema <- struct{}{}
-		}()
-
 	case <-p.ctx.Done():
 		return
 	}
@@ -75,6 +69,8 @@ func (p *PubSubNotif) Initialize() {
 		}
 		p.newPeersPend[pid] = struct{}{}
 	}
+
+	p.newPeersSema <- struct{}{}
 
 	select {
 	case p.newPeers <- struct{}{}:

--- a/notify.go
+++ b/notify.go
@@ -22,19 +22,21 @@ func (p *PubSubNotif) Connected(n network.Network, c network.Conn) {
 		return
 	}
 
-	select {
-	case <-p.newPeersSema:
-	case <-p.ctx.Done():
-		return
-	}
+	go func() {
+		select {
+		case <-p.newPeersSema:
+		case <-p.ctx.Done():
+			return
+		}
 
-	p.newPeersPend[c.RemotePeer()] = struct{}{}
-	p.newPeersSema <- struct{}{}
+		p.newPeersPend[c.RemotePeer()] = struct{}{}
+		p.newPeersSema <- struct{}{}
 
-	select {
-	case p.newPeers <- struct{}{}:
-	default:
-	}
+		select {
+		case p.newPeers <- struct{}{}:
+		default:
+		}
+	}()
 }
 
 func (p *PubSubNotif) Disconnected(n network.Network, c network.Conn) {

--- a/pubsub.go
+++ b/pubsub.go
@@ -592,14 +592,15 @@ func (p *PubSub) processLoop(ctx context.Context) {
 
 func (p *PubSub) handlePendingPeers() {
 	p.newPeersPrioLk.Lock()
-	defer p.newPeersPrioLk.Unlock()
 
 	if len(p.newPeersPend) == 0 {
+		p.newPeersPrioLk.Unlock()
 		return
 	}
 
 	newPeers := p.newPeersPend
 	p.newPeersPend = make(map[peer.ID]struct{})
+	p.newPeersPrioLk.Unlock()
 
 	for pid := range newPeers {
 		if p.host.Network().Connectedness(pid) != network.Connected {
@@ -625,14 +626,15 @@ func (p *PubSub) handlePendingPeers() {
 
 func (p *PubSub) handleDeadPeers() {
 	p.peerDeadPrioLk.Lock()
-	defer p.peerDeadPrioLk.Unlock()
 
 	if len(p.peerDeadPend) == 0 {
+		p.peerDeadPrioLk.Unlock()
 		return
 	}
 
 	deadPeers := p.peerDeadPend
 	p.peerDeadPend = make(map[peer.ID]struct{})
+	p.peerDeadPrioLk.Unlock()
 
 	for pid := range deadPeers {
 		ch, ok := p.peers[pid]

--- a/pubsub.go
+++ b/pubsub.go
@@ -89,8 +89,10 @@ type PubSub struct {
 	// removeTopic is a topic cancellation channel
 	rmTopic chan *rmTopicReq
 
-	// a notification channel for new peer connections
-	newPeers chan peer.ID
+	// a notification channel for new peer connections accumulated
+	newPeers     chan struct{}
+	newPeersMx   sync.Mutex
+	newPeersPend map[peer.ID]struct{}
 
 	// a notification channel for new outoging peer streams
 	newPeerStream chan network.Stream
@@ -231,7 +233,8 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		signKey:               nil,
 		signPolicy:            StrictSign,
 		incoming:              make(chan *RPC, 32),
-		newPeers:              make(chan peer.ID),
+		newPeers:              make(chan struct{}, 1),
+		newPeersPend:          make(map[peer.ID]struct{}),
 		newPeerStream:         make(chan network.Stream),
 		newPeerError:          make(chan peer.ID),
 		peerDead:              make(chan peer.ID),
@@ -480,21 +483,8 @@ func (p *PubSub) processLoop(ctx context.Context) {
 
 	for {
 		select {
-		case pid := <-p.newPeers:
-			if _, ok := p.peers[pid]; ok {
-				log.Debug("already have connection to peer: ", pid)
-				continue
-			}
-
-			if p.blacklist.Contains(pid) {
-				log.Warn("ignoring connection from blacklisted peer: ", pid)
-				continue
-			}
-
-			messages := make(chan *RPC, p.peerOutboundQueueSize)
-			messages <- p.getHelloPacket()
-			go p.handleNewPeer(ctx, pid, messages)
-			p.peers[pid] = messages
+		case <-p.newPeers:
+			p.handlePendingPeers()
 
 		case s := <-p.newPeerStream:
 			pid := s.Conn().RemotePeer()
@@ -618,6 +608,35 @@ func (p *PubSub) processLoop(ctx context.Context) {
 			log.Info("pubsub processloop shutting down")
 			return
 		}
+	}
+}
+
+func (p *PubSub) handlePendingPeers() {
+	p.newPeersMx.Lock()
+	defer p.newPeersMx.Unlock()
+
+	if len(p.newPeersPend) == 0 {
+		return
+	}
+
+	newPeers := p.newPeersPend
+	p.newPeersPend = make(map[peer.ID]struct{})
+
+	for pid := range newPeers {
+		if _, ok := p.peers[pid]; ok {
+			log.Debug("already have connection to peer: ", pid)
+			continue
+		}
+
+		if p.blacklist.Contains(pid) {
+			log.Warn("ignoring connection from blacklisted peer: ", pid)
+			continue
+		}
+
+		messages := make(chan *RPC, p.peerOutboundQueueSize)
+		messages <- p.getHelloPacket()
+		go p.handleNewPeer(p.ctx, pid, messages)
+		p.peers[pid] = messages
 	}
 }
 


### PR DESCRIPTION
As observed in the gateway.

Aggregates notifications and batch processes, while being careful not to block the event loop.