### PR TITLE
More tracing, option to configure the Subscribe output queue length

### DIFF
--- a/gossip_tracer.go
+++ b/gossip_tracer.go
@@ -162,7 +162,7 @@ func (gt *gossipTracer) DuplicateMessage(msg *Message)        {}
 func (gt *gossipTracer) RecvRPC(rpc *RPC)                     {}
 func (gt *gossipTracer) SendRPC(rpc *RPC, p peer.ID)          {}
 func (gt *gossipTracer) DropRPC(rpc *RPC, p peer.ID)          {}
-func (gt *gossipTracer) DroppedInSubscribe(msg *Message)      {}
+func (gt *gossipTracer) UndeliverableMessage(msg *Message)    {}
 
 func (gt *gossipTracer) ThrottlePeer(p peer.ID) {
 	gt.Lock()

--- a/gossip_tracer.go
+++ b/gossip_tracer.go
@@ -159,6 +159,9 @@ func (gt *gossipTracer) Leave(topic string)                   {}
 func (gt *gossipTracer) Graft(p peer.ID, topic string)        {}
 func (gt *gossipTracer) Prune(p peer.ID, topic string)        {}
 func (gt *gossipTracer) DuplicateMessage(msg *Message)        {}
+func (gt *gossipTracer) RecvRPC(rpc *RPC)                     {}
+func (gt *gossipTracer) SendRPC(rpc *RPC, p peer.ID)          {}
+func (gt *gossipTracer) DropRPC(rpc *RPC, p peer.ID)          {}
 
 func (gt *gossipTracer) ThrottlePeer(p peer.ID) {
 	gt.Lock()

--- a/gossip_tracer.go
+++ b/gossip_tracer.go
@@ -162,6 +162,7 @@ func (gt *gossipTracer) DuplicateMessage(msg *Message)        {}
 func (gt *gossipTracer) RecvRPC(rpc *RPC)                     {}
 func (gt *gossipTracer) SendRPC(rpc *RPC, p peer.ID)          {}
 func (gt *gossipTracer) DropRPC(rpc *RPC, p peer.ID)          {}
+func (gt *gossipTracer) DroppedInSubscribe(msg *Message)      {}
 
 func (gt *gossipTracer) ThrottlePeer(p peer.ID) {
 	gt.Lock()

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -450,4 +450,4 @@ func (pg *peerGater) SendRPC(rpc *RPC, p peer.ID) {}
 
 func (pg *peerGater) DropRPC(rpc *RPC, p peer.ID) {}
 
-func (pg *peerGater) DroppedInSubscribe(msg *Message) {}
+func (pg *peerGater) UndeliverableMessage(msg *Message) {}

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -449,3 +449,5 @@ func (pg *peerGater) RecvRPC(rpc *RPC) {}
 func (pg *peerGater) SendRPC(rpc *RPC, p peer.ID) {}
 
 func (pg *peerGater) DropRPC(rpc *RPC, p peer.ID) {}
+
+func (pg *peerGater) DroppedInSubscribe(msg *Message) {}

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -362,6 +362,9 @@ func (pg *peerGater) AcceptFrom(p peer.ID) AcceptStatus {
 	return AcceptControl
 }
 
+// -- RawTracer interface methods
+var _ RawTracer = (*peerGater)(nil)
+
 // tracer interface
 func (pg *peerGater) AddPeer(p peer.ID, proto protocol.ID) {
 	pg.Lock()
@@ -440,3 +443,9 @@ func (pg *peerGater) DuplicateMessage(msg *Message) {
 }
 
 func (pg *peerGater) ThrottlePeer(p peer.ID) {}
+
+func (pg *peerGater) RecvRPC(rpc *RPC) {}
+
+func (pg *peerGater) SendRPC(rpc *RPC, p peer.ID) {}
+
+func (pg *peerGater) DropRPC(rpc *RPC, p peer.ID) {}

--- a/pubsub.go
+++ b/pubsub.go
@@ -842,6 +842,7 @@ func (p *PubSub) notifySubs(msg *Message) {
 		select {
 		case f.ch <- msg:
 		default:
+			p.tracer.DroppedInSubscribe(msg)
 			log.Infof("Can't deliver message to subscription for topic %s; subscriber too slow", topic)
 		}
 	}

--- a/pubsub.go
+++ b/pubsub.go
@@ -842,7 +842,7 @@ func (p *PubSub) notifySubs(msg *Message) {
 		select {
 		case f.ch <- msg:
 		default:
-			p.tracer.DroppedInSubscribe(msg)
+			p.tracer.UndeliverableMessage(msg)
 			log.Infof("Can't deliver message to subscription for topic %s; subscriber too slow", topic)
 		}
 	}

--- a/pubsub.go
+++ b/pubsub.go
@@ -189,12 +189,12 @@ type PubSubRouter interface {
 type AcceptStatus int
 
 const (
-	// AcceptAll signals to accept the incoming RPC for full processing
+	// AcceptNone signals to drop the incoming RPC
 	AcceptNone AcceptStatus = iota
 	// AcceptControl signals to accept the incoming RPC only for control message processing by
 	// the router. Included payload messages will _not_ be pushed to the validation queue.
 	AcceptControl
-	// AcceptNone signals to drop the incoming RPC
+	// AcceptAll signals to accept the incoming RPC for full processing
 	AcceptAll
 )
 
@@ -1136,7 +1136,7 @@ type addSubReq struct {
 type SubOpt func(sub *Subscription) error
 
 // Subscribe returns a new Subscription for the given topic.
-// Note that subscription is not an instanteneous operation. It may take some time
+// Note that subscription is not an instantaneous operation. It may take some time
 // before the subscription is processed by the pubsub main loop and propagated to our peers.
 //
 // Deprecated: use pubsub.Join() and topic.Subscribe() instead

--- a/pubsub.go
+++ b/pubsub.go
@@ -1150,6 +1150,16 @@ func (p *PubSub) Subscribe(topic string, opts ...SubOpt) (*Subscription, error) 
 	return topicHandle.Subscribe(opts...)
 }
 
+// WithBufferSize is a Subscribe option to customize the size of the subscribe output buffer.
+// The default length is 32 but it can be configured to avoid dropping messages if the consumer is not reading fast
+// enough.
+func WithBufferSize(size int) SubOpt {
+	return func(sub *Subscription) error {
+		sub.ch = make(chan *Message, size)
+		return nil
+	}
+}
+
 type topicReq struct {
 	resp chan []string
 }

--- a/score.go
+++ b/score.go
@@ -825,6 +825,8 @@ func (ps *peerScore) SendRPC(rpc *RPC, p peer.ID) {}
 
 func (ps *peerScore) DropRPC(rpc *RPC, p peer.ID) {}
 
+func (ps *peerScore) DroppedInSubscribe(msg *Message) {}
+
 // message delivery records
 func (d *messageDeliveries) getRecord(id string) *deliveryRecord {
 	rec, ok := d.records[id]

--- a/score.go
+++ b/score.go
@@ -819,6 +819,12 @@ func (ps *peerScore) DuplicateMessage(msg *Message) {
 
 func (ps *peerScore) ThrottlePeer(p peer.ID) {}
 
+func (ps *peerScore) RecvRPC(rpc *RPC) {}
+
+func (ps *peerScore) SendRPC(rpc *RPC, p peer.ID) {}
+
+func (ps *peerScore) DropRPC(rpc *RPC, p peer.ID) {}
+
 // message delivery records
 func (d *messageDeliveries) getRecord(id string) *deliveryRecord {
 	rec, ok := d.records[id]

--- a/score.go
+++ b/score.go
@@ -825,7 +825,7 @@ func (ps *peerScore) SendRPC(rpc *RPC, p peer.ID) {}
 
 func (ps *peerScore) DropRPC(rpc *RPC, p peer.ID) {}
 
-func (ps *peerScore) DroppedInSubscribe(msg *Message) {}
+func (ps *peerScore) UndeliverableMessage(msg *Message) {}
 
 // message delivery records
 func (d *messageDeliveries) getRecord(id string) *deliveryRecord {

--- a/tag_tracer.go
+++ b/tag_tracer.go
@@ -251,5 +251,8 @@ func (t *tagTracer) RejectMessage(msg *Message, reason string) {
 	}
 }
 
-func (t *tagTracer) RemovePeer(peer.ID)      {}
-func (gt *tagTracer) ThrottlePeer(p peer.ID) {}
+func (t *tagTracer) RemovePeer(peer.ID)          {}
+func (t *tagTracer) ThrottlePeer(p peer.ID)      {}
+func (t *tagTracer) RecvRPC(rpc *RPC)            {}
+func (t *tagTracer) SendRPC(rpc *RPC, p peer.ID) {}
+func (t *tagTracer) DropRPC(rpc *RPC, p peer.ID) {}

--- a/tag_tracer.go
+++ b/tag_tracer.go
@@ -251,9 +251,9 @@ func (t *tagTracer) RejectMessage(msg *Message, reason string) {
 	}
 }
 
-func (t *tagTracer) RemovePeer(peer.ID)              {}
-func (t *tagTracer) ThrottlePeer(p peer.ID)          {}
-func (t *tagTracer) RecvRPC(rpc *RPC)                {}
-func (t *tagTracer) SendRPC(rpc *RPC, p peer.ID)     {}
-func (t *tagTracer) DropRPC(rpc *RPC, p peer.ID)     {}
-func (t *tagTracer) DroppedInSubscribe(msg *Message) {}
+func (t *tagTracer) RemovePeer(peer.ID)                {}
+func (t *tagTracer) ThrottlePeer(p peer.ID)            {}
+func (t *tagTracer) RecvRPC(rpc *RPC)                  {}
+func (t *tagTracer) SendRPC(rpc *RPC, p peer.ID)       {}
+func (t *tagTracer) DropRPC(rpc *RPC, p peer.ID)       {}
+func (t *tagTracer) UndeliverableMessage(msg *Message) {}

--- a/tag_tracer.go
+++ b/tag_tracer.go
@@ -251,8 +251,9 @@ func (t *tagTracer) RejectMessage(msg *Message, reason string) {
 	}
 }
 
-func (t *tagTracer) RemovePeer(peer.ID)          {}
-func (t *tagTracer) ThrottlePeer(p peer.ID)      {}
-func (t *tagTracer) RecvRPC(rpc *RPC)            {}
-func (t *tagTracer) SendRPC(rpc *RPC, p peer.ID) {}
-func (t *tagTracer) DropRPC(rpc *RPC, p peer.ID) {}
+func (t *tagTracer) RemovePeer(peer.ID)              {}
+func (t *tagTracer) ThrottlePeer(p peer.ID)          {}
+func (t *tagTracer) RecvRPC(rpc *RPC)                {}
+func (t *tagTracer) SendRPC(rpc *RPC, p peer.ID)     {}
+func (t *tagTracer) DropRPC(rpc *RPC, p peer.ID)     {}
+func (t *tagTracer) DroppedInSubscribe(msg *Message) {}

--- a/topic.go
+++ b/topic.go
@@ -130,7 +130,7 @@ func (t *Topic) sendNotification(evt PeerEvent) {
 }
 
 // Subscribe returns a new Subscription for the topic.
-// Note that subscription is not an instanteneous operation. It may take some time
+// Note that subscription is not an instantaneous operation. It may take some time
 // before the subscription is processed by the pubsub main loop and propagated to our peers.
 func (t *Topic) Subscribe(opts ...SubOpt) (*Subscription, error) {
 	t.mux.RLock()

--- a/topic.go
+++ b/topic.go
@@ -141,7 +141,6 @@ func (t *Topic) Subscribe(opts ...SubOpt) (*Subscription, error) {
 
 	sub := &Subscription{
 		topic: t.topic,
-		ch:    make(chan *Message, 32),
 		ctx:   t.p.ctx,
 	}
 
@@ -150,6 +149,11 @@ func (t *Topic) Subscribe(opts ...SubOpt) (*Subscription, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if sub.ch == nil {
+		// apply the default size
+		sub.ch = make(chan *Message, 32)
 	}
 
 	out := make(chan *Subscription, 1)

--- a/trace.go
+++ b/trace.go
@@ -48,6 +48,12 @@ type RawTracer interface {
 	DuplicateMessage(msg *Message)
 	// ThrottlePeer is invoked when a peer is throttled by the peer gater.
 	ThrottlePeer(p peer.ID)
+	// RecvRPC is invoked when an incoming RPC is received.
+	RecvRPC(rpc *RPC)
+	// SendRPC is invoked when a RPC is sent.
+	SendRPC(rpc *RPC, p peer.ID)
+	// DropRPC is invoked when an outbound RPC is dropped, typically because of a queue full.
+	DropRPC(rpc *RPC, p peer.ID)
 }
 
 // pubsub tracer details
@@ -243,6 +249,10 @@ func (t *pubsubTracer) RecvRPC(rpc *RPC) {
 		return
 	}
 
+	for _, tr := range t.raw {
+		tr.RecvRPC(rpc)
+	}
+
 	if t.tracer == nil {
 		return
 	}
@@ -266,6 +276,10 @@ func (t *pubsubTracer) SendRPC(rpc *RPC, p peer.ID) {
 		return
 	}
 
+	for _, tr := range t.raw {
+		tr.SendRPC(rpc, p)
+	}
+
 	if t.tracer == nil {
 		return
 	}
@@ -287,6 +301,10 @@ func (t *pubsubTracer) SendRPC(rpc *RPC, p peer.ID) {
 func (t *pubsubTracer) DropRPC(rpc *RPC, p peer.ID) {
 	if t == nil {
 		return
+	}
+
+	for _, tr := range t.raw {
+		tr.DropRPC(rpc, p)
 	}
 
 	if t.tracer == nil {

--- a/trace.go
+++ b/trace.go
@@ -54,9 +54,9 @@ type RawTracer interface {
 	SendRPC(rpc *RPC, p peer.ID)
 	// DropRPC is invoked when an outbound RPC is dropped, typically because of a queue full.
 	DropRPC(rpc *RPC, p peer.ID)
-	// DroppedInSubscribe is invoked when the consumer of Subscribe is not reading messages fast enough and
+	// UndeliverableMessage is invoked when the consumer of Subscribe is not reading messages fast enough and
 	// the pressure release mechanism trigger, dropping messages.
-	DroppedInSubscribe(msg *Message)
+	UndeliverableMessage(msg *Message)
 }
 
 // pubsub tracer details
@@ -328,13 +328,13 @@ func (t *pubsubTracer) DropRPC(rpc *RPC, p peer.ID) {
 	t.tracer.Trace(evt)
 }
 
-func (t *pubsubTracer) DroppedInSubscribe(msg *Message) {
+func (t *pubsubTracer) UndeliverableMessage(msg *Message) {
 	if t == nil {
 		return
 	}
 
 	for _, tr := range t.raw {
-		tr.DroppedInSubscribe(msg)
+		tr.UndeliverableMessage(msg)
 	}
 }
 


### PR DESCRIPTION
Replace https://github.com/libp2p/go-libp2p-pubsub/pull/429 in an attempt to properly trigger the CI.