### PR TITLE
reduce log spam from empty heartbeat messages

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1296,7 +1296,12 @@ func (gs *GossipSubRouter) heartbeatTimer() {
 }
 
 func (gs *GossipSubRouter) heartbeat() {
-	defer log.Infow("heartbeat")
+	start := time.Now()
+	defer func() {
+		if dt := time.Since(start); dt > time.Millisecond {
+			log.Infow("heartbeat done", "took", dt)
+		}
+	}()
 
 	gs.heartbeatTicks++
 


### PR DESCRIPTION
the spam was introduced in https://github.com/libp2p/go-libp2p-pubsub/pull/435
this makes it go away, unless it took enough time to be informative.