### PR TITLE
Remove peer filter check from subscriptions

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -1001,10 +1001,6 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 	for _, subopt := range subs {
 		t := subopt.GetTopicid()
 
-		if !p.peerFilter(rpc.from, t) {
-			continue
-		}
-
 		if subopt.GetSubscribe() {
 			tmap, ok := p.topics[t]
 			if !ok {


### PR DESCRIPTION
Remove the filter check when we are processing subscriptions. It is redundant and it also makes it impossible to dynamically change the filter value.