### PR TITLE
discovery.go: Include topic size information in `MinTopicSize` godoc.

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -75,7 +75,7 @@ type discover struct {
 
 // MinTopicSize returns a function that checks if a router is ready for publishing based on the topic size.
 // The router ultimately decides the whether it is ready or not, the given size is just a suggestion. Note
-// that the topic size does not include the host in the count.
+// that the topic size does not include the router in the count.
 func MinTopicSize(size int) RouterReady {
 	return func(rt PubSubRouter, topic string) (bool, error) {
 		return rt.EnoughPeers(topic, size), nil

--- a/discovery.go
+++ b/discovery.go
@@ -74,7 +74,8 @@ type discover struct {
 }
 
 // MinTopicSize returns a function that checks if a router is ready for publishing based on the topic size.
-// The router ultimately decides the whether it is ready or not, the given size is just a suggestion.
+// The router ultimately decides the whether it is ready or not, the given size is just a suggestion. Note
+// that the topic size does not include the host in the count.
 func MinTopicSize(size int) RouterReady {
 	return func(rt PubSubRouter, topic string) (bool, error) {
 		return rt.EnoughPeers(topic, size), nil


### PR DESCRIPTION
This PR resolves #462 . 