### PR TITLE
feat: msgIdGenerator

### DIFF
--- a/gossip_tracer.go
+++ b/gossip_tracer.go
@@ -15,7 +15,7 @@ import (
 type gossipTracer struct {
 	sync.Mutex
 
-	msgID MsgIdFunction
+	idGen *msgIDGenerator
 
 	followUpTime time.Duration
 
@@ -29,7 +29,7 @@ type gossipTracer struct {
 
 func newGossipTracer() *gossipTracer {
 	return &gossipTracer{
-		msgID:        DefaultMsgIdFn,
+		idGen:        newMsgIdGenerator(),
 		promises:     make(map[string]map[peer.ID]time.Time),
 		peerPromises: make(map[peer.ID]map[string]struct{}),
 	}
@@ -40,7 +40,7 @@ func (gt *gossipTracer) Start(gs *GossipSubRouter) {
 		return
 	}
 
-	gt.msgID = gs.p.msgID
+	gt.idGen = gs.p.idGen
 	gt.followUpTime = gs.params.IWantFollowupTime
 }
 
@@ -117,7 +117,7 @@ func (gt *gossipTracer) GetBrokenPromises() map[peer.ID]int {
 var _ RawTracer = (*gossipTracer)(nil)
 
 func (gt *gossipTracer) fulfillPromise(msg *Message) {
-	mid := gt.msgID(msg.Message)
+	mid := gt.idGen.ID(msg)
 
 	gt.Lock()
 	defer gt.Unlock()

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -295,7 +295,7 @@ func WithPeerScore(params *PeerScoreParams, thresholds *PeerScoreThresholds) Opt
 			ps.tracer = &pubsubTracer{
 				raw:   []RawTracer{gs.score, gs.gossipTracer},
 				pid:   ps.host.ID(),
-				msgID: ps.msgID,
+				idGen: ps.idGen,
 			}
 		}
 
@@ -484,7 +484,7 @@ func (gs *GossipSubRouter) Attach(p *PubSub) {
 	gs.tagTracer.Start(gs)
 
 	// start using the same msg ID function as PubSub for caching messages.
-	gs.mcache.SetMsgIdFn(p.msgID)
+	gs.mcache.SetMsgIdFn(p.idGen.ID)
 
 	// start the heartbeat
 	go gs.heartbeatTimer()
@@ -705,7 +705,7 @@ func (gs *GossipSubRouter) handleIWant(p peer.ID, ctl *pb.ControlMessage) []*pb.
 				continue
 			}
 
-			ihave[mid] = msg
+			ihave[mid] = msg.Message
 		}
 	}
 
@@ -954,7 +954,7 @@ func (gs *GossipSubRouter) connector() {
 }
 
 func (gs *GossipSubRouter) Publish(msg *Message) {
-	gs.mcache.Put(msg.Message)
+	gs.mcache.Put(msg)
 
 	from := msg.ReceivedFrom
 	topic := msg.GetTopic()

--- a/mcache.go
+++ b/mcache.go
@@ -3,8 +3,6 @@ package pubsub
 import (
 	"fmt"
 
-	pb "github.com/libp2p/go-libp2p-pubsub/pb"
-
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -27,23 +25,25 @@ func NewMessageCache(gossip, history int) *MessageCache {
 		panic(err)
 	}
 	return &MessageCache{
-		msgs:    make(map[string]*pb.Message),
+		msgs:    make(map[string]*Message),
 		peertx:  make(map[string]map[peer.ID]int),
 		history: make([][]CacheEntry, history),
 		gossip:  gossip,
-		msgID:   DefaultMsgIdFn,
+		msgID: func(msg *Message) string {
+			return DefaultMsgIdFn(msg.Message)
+		},
 	}
 }
 
 type MessageCache struct {
-	msgs    map[string]*pb.Message
+	msgs    map[string]*Message
 	peertx  map[string]map[peer.ID]int
 	history [][]CacheEntry
 	gossip  int
-	msgID   MsgIdFunction
+	msgID   func(*Message) string
 }
 
-func (mc *MessageCache) SetMsgIdFn(msgID MsgIdFunction) {
+func (mc *MessageCache) SetMsgIdFn(msgID func(*Message) string) {
 	mc.msgID = msgID
 }
 
@@ -52,18 +52,18 @@ type CacheEntry struct {
 	topic string
 }
 
-func (mc *MessageCache) Put(msg *pb.Message) {
+func (mc *MessageCache) Put(msg *Message) {
 	mid := mc.msgID(msg)
 	mc.msgs[mid] = msg
 	mc.history[0] = append(mc.history[0], CacheEntry{mid: mid, topic: msg.GetTopic()})
 }
 
-func (mc *MessageCache) Get(mid string) (*pb.Message, bool) {
+func (mc *MessageCache) Get(mid string) (*Message, bool) {
 	m, ok := mc.msgs[mid]
 	return m, ok
 }
 
-func (mc *MessageCache) GetForPeer(mid string, p peer.ID) (*pb.Message, int, bool) {
+func (mc *MessageCache) GetForPeer(mid string, p peer.ID) (*Message, int, bool) {
 	m, ok := mc.msgs[mid]
 	if !ok {
 		return nil, 0, false

--- a/mcache_test.go
+++ b/mcache_test.go
@@ -18,7 +18,7 @@ func TestMessageCache(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		mcache.Put(msgs[i])
+		mcache.Put(&Message{Message: msgs[i]})
 	}
 
 	for i := 0; i < 10; i++ {
@@ -28,7 +28,7 @@ func TestMessageCache(t *testing.T) {
 			t.Fatalf("Message %d not in cache", i)
 		}
 
-		if m != msgs[i] {
+		if m.Message != msgs[i] {
 			t.Fatalf("Message %d does not match cache", i)
 		}
 	}
@@ -47,7 +47,7 @@ func TestMessageCache(t *testing.T) {
 
 	mcache.Shift()
 	for i := 10; i < 20; i++ {
-		mcache.Put(msgs[i])
+		mcache.Put(&Message{Message: msgs[i]})
 	}
 
 	for i := 0; i < 20; i++ {
@@ -57,7 +57,7 @@ func TestMessageCache(t *testing.T) {
 			t.Fatalf("Message %d not in cache", i)
 		}
 
-		if m != msgs[i] {
+		if m.Message != msgs[i] {
 			t.Fatalf("Message %d does not match cache", i)
 		}
 	}
@@ -83,22 +83,22 @@ func TestMessageCache(t *testing.T) {
 
 	mcache.Shift()
 	for i := 20; i < 30; i++ {
-		mcache.Put(msgs[i])
+		mcache.Put(&Message{Message: msgs[i]})
 	}
 
 	mcache.Shift()
 	for i := 30; i < 40; i++ {
-		mcache.Put(msgs[i])
+		mcache.Put(&Message{Message: msgs[i]})
 	}
 
 	mcache.Shift()
 	for i := 40; i < 50; i++ {
-		mcache.Put(msgs[i])
+		mcache.Put(&Message{Message: msgs[i]})
 	}
 
 	mcache.Shift()
 	for i := 50; i < 60; i++ {
-		mcache.Put(msgs[i])
+		mcache.Put(&Message{Message: msgs[i]})
 	}
 
 	if len(mcache.msgs) != 50 {
@@ -120,7 +120,7 @@ func TestMessageCache(t *testing.T) {
 			t.Fatalf("Message %d not in cache", i)
 		}
 
-		if m != msgs[i] {
+		if m.Message != msgs[i] {
 			t.Fatalf("Message %d does not match cache", i)
 		}
 	}

--- a/midgen.go
+++ b/midgen.go
@@ -2,6 +2,8 @@ package pubsub
 
 import (
 	"sync"
+
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 )
 
 // msgIDGenerator handles computing IDs for msgs
@@ -33,6 +35,12 @@ func (m *msgIDGenerator) ID(msg *Message) string {
 		return msg.ID
 	}
 
+	msg.ID = m.RawID(msg.Message)
+	return msg.ID
+}
+
+// RawID computes ID for the proto 'msg'.
+func (m *msgIDGenerator) RawID(msg *pb.Message) string {
 	m.topicGensLk.RLock()
 	gen, ok := m.topicGens[msg.GetTopic()]
 	m.topicGensLk.RUnlock()
@@ -40,6 +48,5 @@ func (m *msgIDGenerator) ID(msg *Message) string {
 		gen = m.Default
 	}
 
-	msg.ID = gen(msg.Message)
-	return msg.ID
+	return gen(msg)
 }

--- a/midgen.go
+++ b/midgen.go
@@ -1,0 +1,32 @@
+package pubsub
+
+import "sync"
+
+type msgIDGenerator struct {
+	defGen MsgIdFunction
+
+	topicGens    map[string]MsgIdFunction
+	topicGensLk sync.RWMutex
+}
+
+func (m *msgIDGenerator) Add(topic string, gen MsgIdFunction) {
+	m.topicGensLk.Lock()
+	m.topicGens[topic] = gen
+	m.topicGensLk.Unlock()
+}
+
+func (m *msgIDGenerator) GenID(msg *Message) string {
+	if msg.ID != "" {
+		return msg.ID
+	}
+
+	m.topicGensLk.RLock()
+	gen, ok := m.topicGens[msg.GetTopic()]
+	m.topicGensLk.RUnlock()
+	if !ok {
+		gen = m.defGen
+	}
+
+	msg.ID = gen(msg.Message)
+	return msg.ID
+}

--- a/midgen.go
+++ b/midgen.go
@@ -9,8 +9,8 @@ import (
 type msgIDGenerator struct {
 	Default MsgIdFunction
 
-	topicGens   map[string]MsgIdFunction
 	topicGensLk sync.RWMutex
+	topicGens   map[string]MsgIdFunction
 }
 
 func newMsgIdGenerator() *msgIDGenerator {

--- a/midgen.go
+++ b/midgen.go
@@ -9,11 +9,11 @@ import (
 type msgIDGenerator struct {
 	Default MsgIdFunction
 
-	topicGens    map[string]MsgIdFunction
+	topicGens   map[string]MsgIdFunction
 	topicGensLk sync.RWMutex
 }
 
-func newMsgIdGenerator() *msgIDGenerator{
+func newMsgIdGenerator() *msgIDGenerator {
 	return &msgIDGenerator{
 		Default:   DefaultMsgIdFn,
 		topicGens: make(map[string]MsgIdFunction),

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -182,7 +182,7 @@ func WithPeerGater(params *PeerGaterParams) Option {
 			ps.tracer = &pubsubTracer{
 				raw:   []RawTracer{gs.gate},
 				pid:   ps.host.ID(),
-				msgID: ps.msgID,
+				idGen: ps.idGen,
 			}
 		}
 

--- a/pubsub.go
+++ b/pubsub.go
@@ -213,6 +213,7 @@ const (
 
 type Message struct {
 	*pb.Message
+	ID string
 	ReceivedFrom  peer.ID
 	ValidatorData interface{}
 }
@@ -1047,8 +1048,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 				continue
 			}
 
-			msg := &Message{pmsg, rpc.from, nil}
-			p.pushMsg(msg)
+			p.pushMsg(&Message{pmsg, "", rpc.from, nil})
 		}
 	}
 

--- a/pubsub.go
+++ b/pubsub.go
@@ -20,7 +20,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/protocol"
 
 	logging "github.com/ipfs/go-log"
-	timecache "github.com/whyrusleeping/timecache"
+	"github.com/whyrusleeping/timecache"
 )
 
 // DefaultMaximumMessageSize is 1mb.
@@ -1161,7 +1161,7 @@ type TopicOptions struct{}
 type TopicOpt func(t *Topic) error
 
 // WithMsgIdFunction sets custom MsgIdFunction for a Topic, enabling topics to have own msg id generation rules.
-func (p *PubSub) WithMsgIdFunction(msgId MsgIdFunction) TopicOpt {
+func WithMsgIdFunction(msgId MsgIdFunction) TopicOpt {
 	return func(t *Topic) error {
 		t.p.idGen.Set(t.topic, msgId)
 		return nil

--- a/pubsub.go
+++ b/pubsub.go
@@ -1160,8 +1160,8 @@ type TopicOptions struct{}
 
 type TopicOpt func(t *Topic) error
 
-// WithMsgIdFunction sets custom MsgIdFunction for a Topic, enabling topics to have own msg id generation rules.
-func WithMsgIdFunction(msgId MsgIdFunction) TopicOpt {
+// WithTopicMessageIdFn sets custom MsgIdFunction for a Topic, enabling topics to have own msg id generation rules.
+func WithTopicMessageIdFn(msgId MsgIdFunction) TopicOpt {
 	return func(t *Topic) error {
 		t.p.idGen.Set(t.topic, msgId)
 		return nil

--- a/pubsub.go
+++ b/pubsub.go
@@ -1160,6 +1160,14 @@ type TopicOptions struct{}
 
 type TopicOpt func(t *Topic) error
 
+// WithMsgIdFunction sets custom MsgIdFunction for a Topic, enabling topics to have own msg id generation rules.
+func (p *PubSub) WithMsgIdFunction(msgId MsgIdFunction) TopicOpt {
+	return func(t *Topic) error {
+		t.p.idGen.Set(t.topic, msgId)
+		return nil
+	}
+}
+
 // Join joins the topic and returns a Topic handle. Only one Topic handle should exist per topic, and Join will error if
 // the Topic handle already exists.
 func (p *PubSub) Join(topic string, opts ...TopicOpt) (*Topic, error) {

--- a/pubsub.go
+++ b/pubsub.go
@@ -20,7 +20,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/protocol"
 
 	logging "github.com/ipfs/go-log"
-	"github.com/whyrusleeping/timecache"
+	timecache "github.com/whyrusleeping/timecache"
 )
 
 // DefaultMaximumMessageSize is 1mb.
@@ -213,7 +213,7 @@ const (
 
 type Message struct {
 	*pb.Message
-	ID string
+	ID            string
 	ReceivedFrom  peer.ID
 	ValidatorData interface{}
 }

--- a/tag_tracer.go
+++ b/tag_tracer.go
@@ -44,9 +44,9 @@ var (
 type tagTracer struct {
 	sync.RWMutex
 
-	cmgr     connmgr.ConnManager
-	msgID    MsgIdFunction
-	decayer  connmgr.Decayer
+	cmgr    connmgr.ConnManager
+	idGen   *msgIDGenerator
+	decayer connmgr.Decayer
 	decaying map[string]connmgr.DecayingTag
 	direct   map[peer.ID]struct{}
 
@@ -62,7 +62,7 @@ func newTagTracer(cmgr connmgr.ConnManager) *tagTracer {
 	}
 	return &tagTracer{
 		cmgr:      cmgr,
-		msgID:     DefaultMsgIdFn,
+		idGen:     newMsgIdGenerator(),
 		decayer:   decayer,
 		decaying:  make(map[string]connmgr.DecayingTag),
 		nearFirst: make(map[string]map[peer.ID]struct{}),
@@ -74,7 +74,7 @@ func (t *tagTracer) Start(gs *GossipSubRouter) {
 		return
 	}
 
-	t.msgID = gs.p.msgID
+	t.idGen = gs.p.idGen
 	t.direct = gs.direct
 }
 
@@ -162,7 +162,7 @@ func (t *tagTracer) bumpTagsForMessage(p peer.ID, msg *Message) {
 func (t *tagTracer) nearFirstPeers(msg *Message) []peer.ID {
 	t.Lock()
 	defer t.Unlock()
-	peersMap, ok := t.nearFirst[t.msgID(msg.Message)]
+	peersMap, ok := t.nearFirst[t.idGen.ID(msg)]
 	if !ok {
 		return nil
 	}
@@ -194,7 +194,7 @@ func (t *tagTracer) DeliverMessage(msg *Message) {
 
 	// delete the delivery state for this message
 	t.Lock()
-	delete(t.nearFirst, t.msgID(msg.Message))
+	delete(t.nearFirst, t.idGen.ID(msg))
 	t.Unlock()
 }
 
@@ -215,7 +215,7 @@ func (t *tagTracer) ValidateMessage(msg *Message) {
 	defer t.Unlock()
 
 	// create map to start tracking the peers who deliver while we're validating
-	id := t.msgID(msg.Message)
+	id := t.idGen.ID(msg)
 	if _, exists := t.nearFirst[id]; exists {
 		return
 	}
@@ -226,7 +226,7 @@ func (t *tagTracer) DuplicateMessage(msg *Message) {
 	t.Lock()
 	defer t.Unlock()
 
-	id := t.msgID(msg.Message)
+	id := t.idGen.ID(msg)
 	peers, ok := t.nearFirst[id]
 	if !ok {
 		return
@@ -247,7 +247,7 @@ func (t *tagTracer) RejectMessage(msg *Message, reason string) {
 	case RejectValidationIgnored:
 		fallthrough
 	case RejectValidationFailed:
-		delete(t.nearFirst, t.msgID(msg.Message))
+		delete(t.nearFirst, t.idGen.ID(msg))
 	}
 }
 

--- a/tag_tracer.go
+++ b/tag_tracer.go
@@ -44,9 +44,9 @@ var (
 type tagTracer struct {
 	sync.RWMutex
 
-	cmgr    connmgr.ConnManager
-	idGen   *msgIDGenerator
-	decayer connmgr.Decayer
+	cmgr     connmgr.ConnManager
+	idGen    *msgIDGenerator
+	decayer  connmgr.Decayer
 	decaying map[string]connmgr.DecayingTag
 	direct   map[peer.ID]struct{}
 

--- a/topic.go
+++ b/topic.go
@@ -283,7 +283,7 @@ func (t *Topic) Publish(ctx context.Context, data []byte, opts ...PubOpt) error 
 		}
 	}
 
-	return t.p.val.PushLocal(&Message{m, t.p.host.ID(), nil})
+	return t.p.val.PushLocal(&Message{m, "", t.p.host.ID(), nil})
 }
 
 // WithReadiness returns a publishing option for only publishing when the router is ready.

--- a/trace.go
+++ b/trace.go
@@ -64,7 +64,7 @@ type pubsubTracer struct {
 	tracer EventTracer
 	raw    []RawTracer
 	pid    peer.ID
-	msgID  MsgIdFunction
+	idGen  *msgIDGenerator
 }
 
 func (t *pubsubTracer) PublishMessage(msg *Message) {
@@ -82,7 +82,7 @@ func (t *pubsubTracer) PublishMessage(msg *Message) {
 		PeerID:    []byte(t.pid),
 		Timestamp: &now,
 		PublishMessage: &pb.TraceEvent_PublishMessage{
-			MessageID: []byte(t.msgID(msg.Message)),
+			MessageID: []byte(t.idGen.ID(msg)),
 			Topic:     msg.Message.Topic,
 		},
 	}
@@ -123,7 +123,7 @@ func (t *pubsubTracer) RejectMessage(msg *Message, reason string) {
 		PeerID:    []byte(t.pid),
 		Timestamp: &now,
 		RejectMessage: &pb.TraceEvent_RejectMessage{
-			MessageID:    []byte(t.msgID(msg.Message)),
+			MessageID:    []byte(t.idGen.ID(msg)),
 			ReceivedFrom: []byte(msg.ReceivedFrom),
 			Reason:       &reason,
 			Topic:        msg.Topic,
@@ -154,7 +154,7 @@ func (t *pubsubTracer) DuplicateMessage(msg *Message) {
 		PeerID:    []byte(t.pid),
 		Timestamp: &now,
 		DuplicateMessage: &pb.TraceEvent_DuplicateMessage{
-			MessageID:    []byte(t.msgID(msg.Message)),
+			MessageID:    []byte(t.idGen.ID(msg)),
 			ReceivedFrom: []byte(msg.ReceivedFrom),
 			Topic:        msg.Topic,
 		},
@@ -184,7 +184,7 @@ func (t *pubsubTracer) DeliverMessage(msg *Message) {
 		PeerID:    []byte(t.pid),
 		Timestamp: &now,
 		DeliverMessage: &pb.TraceEvent_DeliverMessage{
-			MessageID:    []byte(t.msgID(msg.Message)),
+			MessageID:    []byte(t.idGen.ID(msg)),
 			Topic:        msg.Topic,
 			ReceivedFrom: []byte(msg.ReceivedFrom),
 		},
@@ -344,7 +344,7 @@ func (t *pubsubTracer) traceRPCMeta(rpc *RPC) *pb.TraceEvent_RPCMeta {
 	var msgs []*pb.TraceEvent_MessageMeta
 	for _, m := range rpc.Publish {
 		msgs = append(msgs, &pb.TraceEvent_MessageMeta{
-			MessageID: []byte(t.msgID(m)),
+			MessageID: []byte(t.idGen.ID(&Message{Message: m})),
 			Topic:     m.Topic,
 		})
 	}

--- a/trace.go
+++ b/trace.go
@@ -344,7 +344,7 @@ func (t *pubsubTracer) traceRPCMeta(rpc *RPC) *pb.TraceEvent_RPCMeta {
 	var msgs []*pb.TraceEvent_MessageMeta
 	for _, m := range rpc.Publish {
 		msgs = append(msgs, &pb.TraceEvent_MessageMeta{
-			MessageID: []byte(t.idGen.ID(&Message{Message: m})),
+			MessageID: []byte(t.idGen.RawID(m)),
 			Topic:     m.Topic,
 		})
 	}

--- a/validation.go
+++ b/validation.go
@@ -284,7 +284,7 @@ func (v *validation) validate(vals []*topicVal, src peer.ID, msg *Message, synch
 
 	// we can mark the message as seen now that we have verified the signature
 	// and avoid invoking user validators more than once
-	id := v.p.msgID(msg.Message)
+	id := v.p.idGen.ID(msg)
 	if !v.p.markSeen(id) {
 		v.tracer.DuplicateMessage(msg)
 		return nil


### PR DESCRIPTION
* Introduces `msgIdGenerator` 
* Ensures msg id is generated once only
	* Besides `Tracer `methods rcving `*RPC`
* Allows setting per-topic `MsgIDFunction`

Closes #464

> Personally, I still prefer the solution, where we compute and set Message.ID once in the pipeline and then assume it is set everywhere, instead of calling generator everywhere, but I might be missing something