### PR TITLE
Add Backoff For Pruned Peers

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1093,7 +1093,7 @@ func (gs *GossipSubRouter) Leave(topic string) {
 		gs.sendPrune(p, topic)
 		// Add a backoff to this peer to prevent us from eagerly
 		// re-grafting this peer into our mesh if we rejoin this
-		// topic before the backoff period.
+		// topic before the backoff period ends.
 		gs.addBackoff(p, topic)
 	}
 }

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1091,6 +1091,10 @@ func (gs *GossipSubRouter) Leave(topic string) {
 		log.Debugf("LEAVE: Remove mesh link to %s in %s", p, topic)
 		gs.tracer.Prune(p, topic)
 		gs.sendPrune(p, topic)
+		// Add a backoff to this peer to prevent us from eagerly
+		// re-grafting this peer into our mesh if we rejoin this
+		// topic before the backoff period.
+		gs.addBackoff(p, topic)
 	}
 }
 


### PR DESCRIPTION
This PR resolves the issue described in #367. 
- [x] To prevent unnecessary penalties due to eager re-grafting of peers, we now add a backoff when leaving a topic and pruning the respective peers from our topic mesh.  
- [x] Adds in a regression test for this case. 