### PR TITLE
feat: WithLocalPublication option to enable local only publishing on a topic

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -221,6 +221,7 @@ type Message struct {
 	ID            string
 	ReceivedFrom  peer.ID
 	ValidatorData interface{}
+	Local bool
 }
 
 func (m *Message) GetFrom() peer.ID {
@@ -1066,7 +1067,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 				continue
 			}
 
-			p.pushMsg(&Message{pmsg, "", rpc.from, nil})
+			p.pushMsg(&Message{pmsg, "", rpc.from, nil, false})
 		}
 	}
 
@@ -1165,7 +1166,9 @@ func (p *PubSub) checkSigningPolicy(msg *Message) error {
 func (p *PubSub) publishMessage(msg *Message) {
 	p.tracer.DeliverMessage(msg)
 	p.notifySubs(msg)
-	p.rt.Publish(msg)
+	if !msg.Local {
+		p.rt.Publish(msg)
+	}
 }
 
 type addTopicReq struct {

--- a/topic.go
+++ b/topic.go
@@ -320,8 +320,11 @@ func WithReadiness(ready RouterReady) PubOpt {
 	}
 }
 
-// WithLocalPublication option tells Publish to *only* notify local subscribers about a message.
-// This option prevents messages publication to peers.
+// WithLocalPublication returns a publishing option to notify in-process subscribers only.
+// It prevents message publication to mesh peers.
+// Useful in edge cases where the msg needs to be only delivered to the in-process subscribers,
+// e.g. not to spam the network with outdated msgs.
+// Should not be used specifically for in-process pubsubing.
 func WithLocalPublication(local bool) PubOpt {
 	return func(pub *PublishOptions) error {
 		pub.local = local

--- a/topic.go
+++ b/topic.go
@@ -215,6 +215,7 @@ type ProvideKey func() (crypto.PrivKey, peer.ID)
 type PublishOptions struct {
 	ready     RouterReady
 	customKey ProvideKey
+	local bool
 }
 
 type PubOpt func(pub *PublishOptions) error
@@ -307,7 +308,7 @@ func (t *Topic) Publish(ctx context.Context, data []byte, opts ...PubOpt) error 
 		}
 	}
 
-	return t.p.val.PushLocal(&Message{m, "", t.p.host.ID(), nil})
+	return t.p.val.PushLocal(&Message{m, "", t.p.host.ID(), nil, pub.local})
 }
 
 // WithReadiness returns a publishing option for only publishing when the router is ready.
@@ -315,6 +316,15 @@ func (t *Topic) Publish(ctx context.Context, data []byte, opts ...PubOpt) error 
 func WithReadiness(ready RouterReady) PubOpt {
 	return func(pub *PublishOptions) error {
 		pub.ready = ready
+		return nil
+	}
+}
+
+// WithLocalPublication option tells Publish to *only* notify local subscribers about a message.
+// This option prevents messages publication to peers.
+func WithLocalPublication(local bool) PubOpt {
+	return func(pub *PublishOptions) error {
+		pub.local = local
 		return nil
 	}
 }


### PR DESCRIPTION
An attempt to close https://github.com/libp2p/go-libp2p-pubsub/issues/480

> I know that it is better to discuss the solution first, but waiting is not fun while coding is and I am ok to redo that if we find a better solution.

We can also sneak here similar cases like an option to publish to the mesh only, so doing something like the code below during validation is not needed anymore:
```go
if self == peer {
	return 
}
```
