### PR TITLE
Adds exponential backoff to re-spawing new streams for supposedly dead peers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 cover.out
 prof.out
 go-floodsub.test
+
+.idea/

--- a/backoff.go
+++ b/backoff.go
@@ -15,7 +15,7 @@ const (
 	TimeToLive             = 10 * time.Minute
 	BackoffCleanupInterval = 1 * time.Minute
 	BackoffMultiplier      = 2
-	MaxBackoffJitterCoff   = 1000
+	MaxBackoffJitterCoff   = 100
 )
 
 type backoffHistory struct {

--- a/backoff.go
+++ b/backoff.go
@@ -53,15 +53,18 @@ func (b *backoff) updateAndGet(id peer.ID) time.Duration {
 	defer b.mu.Unlock()
 
 	h, ok := b.info[id]
-	if !ok || time.Since(h.lastTried) > TimeToLive {
+	switch {
+	case !ok || time.Since(h.lastTried) > TimeToLive:
 		// first request goes immediately.
 		h = &backoffHistory{
 			duration: time.Duration(0),
 			attempts: 0,
 		}
-	} else if h.duration < MinBackoffDelay {
+
+	case h.duration < MinBackoffDelay:
 		h.duration = MinBackoffDelay
-	} else if h.duration < MaxBackoffDelay {
+
+	case h.duration < MaxBackoffDelay:
 		jitter := rand.Intn(MaxBackoffJitterCoff)
 		h.duration = (BackoffMultiplier * h.duration) + time.Duration(jitter)*time.Millisecond
 		if h.duration > MaxBackoffDelay || h.duration < 0 {

--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,59 @@
+package pubsub
+
+import (
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+const (
+	MinBackoffDelay   = 100 * time.Millisecond
+	MaxBackoffDelay   = 10 * time.Second
+	BackoffMultiplier = 2
+)
+
+type backoff struct {
+	mu sync.Mutex
+	info map[peer.ID]time.Duration
+}
+
+func newBackoff() *backoff{
+	return &backoff{
+		mu: sync.Mutex{},
+		info: make(map[peer.ID]time.Duration),
+	}
+}
+
+func (b *backoff) get(id peer.ID) time.Duration {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	h, ok := b.info[id]
+	if !ok {
+		h = time.Duration(0)
+		b.info[id] = h
+	}
+
+	return h
+}
+
+func (b *backoff) update(id peer.ID) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	h := b.info[id]
+
+	if h < MinBackoffDelay {
+		h = MinBackoffDelay
+	} else if h == MaxBackoffDelay {
+		h = MaxBackoffDelay
+	} else {
+		h = time.Duration(BackoffMultiplier * h)
+		if h > MaxBackoffDelay || h < 0 {
+			h = MaxBackoffDelay
+		}
+	}
+
+	b.info[id] = h
+}

--- a/backoff.go
+++ b/backoff.go
@@ -93,11 +93,14 @@ func (b *backoff) cleanup() {
 }
 
 func (b *backoff) cleanupLoop(ctx context.Context) {
+	ticker := time.NewTicker(b.ci)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return // pubsub shutting down
-		case <-time.Tick(b.ci):
+		case <-ticker.C:
 			b.cleanup()
 		}
 	}

--- a/backoff.go
+++ b/backoff.go
@@ -33,8 +33,6 @@ func (b *backoff) updateAndGet(id peer.ID) time.Duration{
 	if !ok {
 		// first request goes immediately.
 		h = time.Duration(0)
-		b.info[id] = h
-
 	} else if h < MinBackoffDelay {
 		h = MinBackoffDelay
 	} else if h < MaxBackoffDelay {
@@ -45,6 +43,6 @@ func (b *backoff) updateAndGet(id peer.ID) time.Duration{
 	}
 
 	b.info[id] = h
-	
+
 	return h
 }

--- a/backoff.go
+++ b/backoff.go
@@ -61,7 +61,7 @@ func (b *backoff) updateAndGet(id peer.ID) (time.Duration, error) {
 			duration: time.Duration(0),
 			attempts: 0,
 		}
-	case h.attempts > b.maxAttempts:
+	case h.attempts >= b.maxAttempts:
 		return 0, fmt.Errorf("peer %s has reached its maximum backoff attempts", id)
 
 	case h.duration < MinBackoffDelay:

--- a/backoff.go
+++ b/backoff.go
@@ -10,39 +10,64 @@ import (
 const (
 	MinBackoffDelay   = 100 * time.Millisecond
 	MaxBackoffDelay   = 10 * time.Second
+	TimeToLive        = 10 * time.Minute
 	BackoffMultiplier = 2
 )
 
-type backoff struct {
-	mu sync.Mutex
-	info map[peer.ID]time.Duration
+type backoffHistory struct {
+	duration  time.Duration
+	lastTried time.Time
 }
 
-func newBackoff() *backoff{
+type backoff struct {
+	mu   sync.Mutex
+	info map[peer.ID]*backoffHistory
+	ct   int // size threshold that kicks off the cleaner
+}
+
+func newBackoff(sizeThreshold int) *backoff {
 	return &backoff{
-		mu: sync.Mutex{},
-		info: make(map[peer.ID]time.Duration),
+		mu:   sync.Mutex{},
+		ct:   sizeThreshold,
+		info: make(map[peer.ID]*backoffHistory),
 	}
 }
 
-func (b *backoff) updateAndGet(id peer.ID) time.Duration{
+func (b *backoff) updateAndGet(id peer.ID) time.Duration {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	h, ok := b.info[id]
-	if !ok {
+	if !ok || time.Since(h.lastTried) > TimeToLive {
 		// first request goes immediately.
-		h = time.Duration(0)
-	} else if h < MinBackoffDelay {
-		h = MinBackoffDelay
-	} else if h < MaxBackoffDelay {
-		h = time.Duration(BackoffMultiplier * h)
-		if h > MaxBackoffDelay || h < 0 {
-			h = MaxBackoffDelay
+		h = &backoffHistory{
+			duration: time.Duration(0),
+		}
+	} else if time.Since(h.lastTried) > TimeToLive {
+		h.duration = time.Duration(0)
+	} else if h.duration < MinBackoffDelay {
+		h.duration = MinBackoffDelay
+	} else if h.duration < MaxBackoffDelay {
+		h.duration = time.Duration(BackoffMultiplier * h.duration)
+		if h.duration > MaxBackoffDelay || h.duration < 0 {
+			h.duration = MaxBackoffDelay
 		}
 	}
 
+	h.lastTried = time.Now()
 	b.info[id] = h
 
-	return h
+	if len(b.info) > b.ct {
+		b.cleanup()
+	}
+
+	return h.duration
+}
+
+func (b *backoff) cleanup() {
+	for id, h := range b.info {
+		if time.Since(h.lastTried) > TimeToLive {
+			delete(b.info, id)
+		}
+	}
 }

--- a/backoff.go
+++ b/backoff.go
@@ -43,8 +43,6 @@ func (b *backoff) updateAndGet(id peer.ID) time.Duration {
 		h = &backoffHistory{
 			duration: time.Duration(0),
 		}
-	} else if time.Since(h.lastTried) > TimeToLive {
-		h.duration = time.Duration(0)
 	} else if h.duration < MinBackoffDelay {
 		h.duration = MinBackoffDelay
 	} else if h.duration < MaxBackoffDelay {

--- a/backoff.go
+++ b/backoff.go
@@ -25,30 +25,19 @@ func newBackoff() *backoff{
 	}
 }
 
-func (b *backoff) get(id peer.ID) time.Duration {
+func (b *backoff) updateAndGet(id peer.ID) time.Duration{
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	h, ok := b.info[id]
 	if !ok {
+		// first request goes immediately.
 		h = time.Duration(0)
 		b.info[id] = h
-	}
 
-	return h
-}
-
-func (b *backoff) update(id peer.ID) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	h := b.info[id]
-
-	if h < MinBackoffDelay {
+	} else if h < MinBackoffDelay {
 		h = MinBackoffDelay
-	} else if h == MaxBackoffDelay {
-		h = MaxBackoffDelay
-	} else {
+	} else if h < MaxBackoffDelay {
 		h = time.Duration(BackoffMultiplier * h)
 		if h > MaxBackoffDelay || h < 0 {
 			h = MaxBackoffDelay
@@ -56,4 +45,6 @@ func (b *backoff) update(id peer.ID) {
 	}
 
 	b.info[id] = h
+	
+	return h
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-func TestBackoff_Update(t *testing.T){
+func TestBackoff_Update(t *testing.T) {
 	id1 := peer.ID("peer-1")
 	id2 := peer.ID("peer-2")
 
@@ -19,25 +19,30 @@ func TestBackoff_Update(t *testing.T){
 
 	size := 10
 	cleanupInterval := 5 * time.Second
+	maxBackoffAttempts := 10
 
-	b := newBackoff(ctx, size, cleanupInterval)
+	b := newBackoff(ctx, size, cleanupInterval, maxBackoffAttempts)
 
 	if len(b.info) > 0 {
 		t.Fatal("non-empty info map for backoff")
 	}
 
-	if d := b.updateAndGet(id1); d != time.Duration(0) {
+	if d, valid := b.updateAndGet(id1); d != time.Duration(0) || !valid {
 		t.Fatalf("invalid initialization: %v", d)
 	}
-	if d := b.updateAndGet(id2); d != time.Duration(0) {
+	if d, valid := b.updateAndGet(id2); d != time.Duration(0) || !valid {
 		t.Fatalf("invalid initialization: %v", d)
 	}
 
-	for i := 0; i < 10; i++{
-		got := b.updateAndGet(id1)
+	for i := 0; i < maxBackoffAttempts-1; i++ {
+		got, valid := b.updateAndGet(id1)
+
+		if !valid {
+			t.Fatalf("update attempt invalidated")
+		}
 
 		expected := time.Duration(math.Pow(BackoffMultiplier, float64(i)) *
-			float64(MinBackoffDelay + MaxBackoffJitterCoff * time.Millisecond))
+			float64(MinBackoffDelay+MaxBackoffJitterCoff*time.Millisecond))
 		if expected > MaxBackoffDelay {
 			expected = MaxBackoffDelay
 		}
@@ -47,32 +52,50 @@ func TestBackoff_Update(t *testing.T){
 		}
 	}
 
-	got := b.updateAndGet(id2)
+	if len(b.info) != 2 {
+		t.Fatalf("pre-invalidation attempt, info map size mismatch, expected: %d, got: %d", 2, len(b.info))
+	}
+
+	// trying once more beyond the threshold, hence expecting an invalidation
+	if _, valid := b.updateAndGet(id1); valid {
+		t.Fatal("update beyond max attempts did not invalidate")
+	}
+
+	// invalidated entry must be removed
+	if len(b.info) != 1 {
+		t.Fatalf("post-invalidation attempt, info map size mismatch, expected: %d, got: %d", 1, len(b.info))
+	}
+
+	got, valid := b.updateAndGet(id2)
+	if !valid {
+		t.Fatalf("update attempt invalidated")
+	}
 	if got != MinBackoffDelay {
 		t.Fatalf("invalid backoff result, expected: %v, got: %v", MinBackoffDelay, got)
 	}
 
 	// sets last tried of id2 to long ago that it resets back upon next try.
 	b.info[id2].lastTried = time.Now().Add(-TimeToLive)
-	got = b.updateAndGet(id2)
+	got, valid = b.updateAndGet(id2)
+	if !valid {
+		t.Fatalf("update attempt invalidated")
+	}
 	if got != time.Duration(0) {
 		t.Fatalf("invalid ttl expiration, expected: %v, got: %v", time.Duration(0), got)
 	}
 
-	if len(b.info) != 2 {
-		t.Fatalf("info map size mismatch, expected: %d, got: %d", 2, len(b.info))
-	}
 }
 
-func TestBackoff_Clean(t *testing.T){
+func TestBackoff_Clean(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	size := 10
 	cleanupInterval := 2 * time.Second
-	b := newBackoff(ctx, size, cleanupInterval)
+	maxBackoffAttempts := 100 // setting attempts to a high number hence testing cleanup logic.
+	b := newBackoff(ctx, size, cleanupInterval, maxBackoffAttempts)
 
-	for i := 0; i < size; i++{
+	for i := 0; i < size; i++ {
 		id := peer.ID(fmt.Sprintf("peer-%d", i))
 		b.updateAndGet(id)
 		b.info[id].lastTried = time.Now().Add(-TimeToLive) // enforces expiry
@@ -86,7 +109,10 @@ func TestBackoff_Clean(t *testing.T){
 	time.Sleep(2 * cleanupInterval)
 
 	// next update should trigger cleanup
-	got := b.updateAndGet(peer.ID("some-new-peer"))
+	got, valid := b.updateAndGet(peer.ID("some-new-peer"))
+	if !valid {
+		t.Fatalf("update attempt invalidated")
+	}
 	if got != time.Duration(0) {
 		t.Fatalf("invalid backoff result, expected: %v, got: %v", time.Duration(0), got)
 	}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -53,7 +53,7 @@ func TestBackoff_Update(t *testing.T) {
 
 	// trying once more beyond the threshold, hence expecting exceeding threshold
 	if _, err := b.updateAndGet(id1); err == nil {
-		t.Fatalf("expected an error for going beyond threshold but got a nil: %s", err)
+		t.Fatalf("expected an error for going beyond threshold but got nil")
 	}
 
 	got, err := b.updateAndGet(id2)

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -52,8 +52,8 @@ func TestBackoff_Update(t *testing.T) {
 	}
 
 	// trying once more beyond the threshold, hence expecting exceeding threshold
-	if _, err := b.updateAndGet(id1); err != nil {
-		t.Fatalf("invalid exceeding threshold status: %s", err)
+	if _, err := b.updateAndGet(id1); err == nil {
+		t.Fatalf("expected an error for going beyond threshold but got a nil: %s", err)
 	}
 
 	got, err := b.updateAndGet(id2)

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -41,4 +41,8 @@ func TestBackoff(t *testing.T){
 	if got != MinBackoffDelay {
 		t.Fatalf("invalid backoff result, expected: %v, got: %v", MinBackoffDelay, got)
 	}
+
+	if len(b.info) != 2 {
+		t.Fatalf("info map size mismatch, expected: %d, got: %d", 2, len(b.info))
+	}
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -68,7 +68,7 @@ func TestBackoff_Clean(t *testing.T){
 	defer cancel()
 
 	size := 10
-	cleanupInterval := 5 * time.Second
+	cleanupInterval := 2 * time.Second
 	b := newBackoff(ctx, size, cleanupInterval)
 
 	for i := 0; i < size; i++{
@@ -82,7 +82,7 @@ func TestBackoff_Clean(t *testing.T){
 	}
 
 	// waits for a cleanup loop to kick-in
-	time.Sleep(cleanupInterval)
+	time.Sleep(2 * cleanupInterval)
 
 	// next update should trigger cleanup
 	got := b.updateAndGet(peer.ID("some-new-peer"))

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -17,30 +17,28 @@ func TestBackoff(t *testing.T){
 		t.Fatal("non-empty info map for backoff")
 	}
 
-	if d := b.get(id1); d != time.Duration(0) {
-		t.Fatalf("invalid initialization: %d", d)
+	if d := b.updateAndGet(id1); d != time.Duration(0) {
+		t.Fatalf("invalid initialization: %v", d)
 	}
-	if d := b.get(id2); d != time.Duration(0) {
-		t.Fatalf("invalid initialization: %d", d)
+	if d := b.updateAndGet(id2); d != time.Duration(0) {
+		t.Fatalf("invalid initialization: %v", d)
 	}
 
 	for i := 0; i < 10; i++{
-		b.update(id1)
+		got := b.updateAndGet(id1)
 
-		got := b.get(id1)
 		expected := time.Duration(math.Pow(BackoffMultiplier, float64(i)) * float64(MinBackoffDelay))
 		if expected > MaxBackoffDelay {
 			expected = MaxBackoffDelay
 		}
 
 		if expected != got {
-			t.Fatalf("invalid backoff result, expected: %d, got: %d", expected, got)
+			t.Fatalf("invalid backoff result, expected: %v, got: %v", expected, got)
 		}
 	}
 
-	b.update(id2)
-	got := b.get(id2)
+	got := b.updateAndGet(id2)
 	if got != MinBackoffDelay {
-		t.Fatalf("invalid backoff result, expected: %d, got: %d", MinBackoffDelay, got)
+		t.Fatalf("invalid backoff result, expected: %v, got: %v", MinBackoffDelay, got)
 	}
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -36,12 +36,13 @@ func TestBackoff_Update(t *testing.T){
 	for i := 0; i < 10; i++{
 		got := b.updateAndGet(id1)
 
-		expected := time.Duration(math.Pow(BackoffMultiplier, float64(i)) * float64(MinBackoffDelay))
+		expected := time.Duration(math.Pow(BackoffMultiplier, float64(i)) *
+			float64(MinBackoffDelay + MaxBackoffJitterCoff * time.Millisecond))
 		if expected > MaxBackoffDelay {
 			expected = MaxBackoffDelay
 		}
 
-		if expected != got {
+		if expected < got { // considering jitter, expected backoff must always be greater than or equal to actual.
 			t.Fatalf("invalid backoff result, expected: %v, got: %v", expected, got)
 		}
 	}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,46 @@
+package pubsub
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+func TestBackoff(t *testing.T){
+	id1 := peer.ID("peer-1")
+	id2 := peer.ID("peer-2")
+	b := newBackoff()
+
+	if len(b.info) > 0 {
+		t.Fatal("non-empty info map for backoff")
+	}
+
+	if d := b.get(id1); d != time.Duration(0) {
+		t.Fatalf("invalid initialization: %d", d)
+	}
+	if d := b.get(id2); d != time.Duration(0) {
+		t.Fatalf("invalid initialization: %d", d)
+	}
+
+	for i := 0; i < 10; i++{
+		b.update(id1)
+
+		got := b.get(id1)
+		expected := time.Duration(math.Pow(BackoffMultiplier, float64(i)) * float64(MinBackoffDelay))
+		if expected > MaxBackoffDelay {
+			expected = MaxBackoffDelay
+		}
+
+		if expected != got {
+			t.Fatalf("invalid backoff result, expected: %d, got: %d", expected, got)
+		}
+	}
+
+	b.update(id2)
+	got := b.get(id2)
+	if got != MinBackoffDelay {
+		t.Fatalf("invalid backoff result, expected: %d, got: %d", MinBackoffDelay, got)
+	}
+}

--- a/comm.go
+++ b/comm.go
@@ -123,7 +123,12 @@ func (p *PubSub) handleNewPeer(ctx context.Context, pid peer.ID, outgoing <-chan
 }
 
 func (p *PubSub) handleNewPeerWithBackoff(ctx context.Context, pid peer.ID, outgoing <-chan *RPC) {
-	delay := p.deadPeerBackoff.updateAndGet(pid)
+	delay, valid := p.deadPeerBackoff.updateAndGet(pid)
+	if !valid {
+		log.Warnf("backoff attempts to %s expired after reaching maximum allowed", pid)
+		return
+	}
+
 	select {
 	case <-time.After(delay):
 		p.handleNewPeer(ctx, pid, outgoing)

--- a/comm.go
+++ b/comm.go
@@ -123,7 +123,7 @@ func (p *PubSub) handleNewPeer(ctx context.Context, pid peer.ID, outgoing <-chan
 }
 
 func (p *PubSub) handleNewPeerWithBackoff(ctx context.Context, pid peer.ID, outgoing <-chan *RPC) {
-	delay := p.deadPeerBackoff.get(pid)
+	delay := p.deadPeerBackoff.updateAndGet(pid)
 	select {
 	case <-time.After(delay):
 		p.handleNewPeer(ctx, pid, outgoing)

--- a/comm.go
+++ b/comm.go
@@ -122,11 +122,9 @@ func (p *PubSub) handleNewPeer(ctx context.Context, pid peer.ID, outgoing <-chan
 	}
 }
 
-func (p *PubSub) handleNewPeerWithBackoff(ctx context.Context, pid peer.ID, outgoing <-chan *RPC) {
-	delay := p.deadPeerBackoff.updateAndGet(pid)
-
+func (p *PubSub) handleNewPeerWithBackoff(ctx context.Context, pid peer.ID, backoff time.Duration, outgoing <-chan *RPC) {
 	select {
-	case <-time.After(delay):
+	case <-time.After(backoff):
 		p.handleNewPeer(ctx, pid, outgoing)
 	case <-ctx.Done():
 		return

--- a/pubsub.go
+++ b/pubsub.go
@@ -254,7 +254,7 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		newPeerError:          make(chan peer.ID),
 		peerDead:              make(chan struct{}, 1),
 		peerDeadPend:          make(map[peer.ID]struct{}),
-		deadPeerBackoff:       newBackoff(),
+		deadPeerBackoff:       newBackoff(1000),
 		cancelCh:              make(chan *Subscription),
 		getPeers:              make(chan *listPeerReq),
 		addSub:                make(chan *addSubReq),

--- a/pubsub.go
+++ b/pubsub.go
@@ -691,9 +691,7 @@ func (p *PubSub) handleDeadPeers() {
 			log.Debugf("peer declared dead but still connected; respawning writer: %s", pid)
 			messages := make(chan *RPC, p.peerOutboundQueueSize)
 			messages <- p.getHelloPacket()
-			go func() {
-				p.handleNewPeerWithBackoff(p.ctx, pid, messages)
-			}()
+			go p.handleNewPeerWithBackoff(p.ctx, pid, messages)
 			p.peers[pid] = messages
 			continue
 		}

--- a/pubsub.go
+++ b/pubsub.go
@@ -254,7 +254,7 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		newPeerError:          make(chan peer.ID),
 		peerDead:              make(chan struct{}, 1),
 		peerDeadPend:          make(map[peer.ID]struct{}),
-		deadPeerBackoff:       newBackoff(1000),
+		deadPeerBackoff:       newBackoff(ctx, 1000, BackoffCleanupInterval),
 		cancelCh:              make(chan *Subscription),
 		getPeers:              make(chan *listPeerReq),
 		addSub:                make(chan *addSubReq),

--- a/pubsub.go
+++ b/pubsub.go
@@ -254,7 +254,7 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		newPeerError:          make(chan peer.ID),
 		peerDead:              make(chan struct{}, 1),
 		peerDeadPend:          make(map[peer.ID]struct{}),
-		deadPeerBackoff:       newBackoff(ctx, 1000, BackoffCleanupInterval),
+		deadPeerBackoff:       newBackoff(ctx, 1000, BackoffCleanupInterval, MaxBackoffAttempts),
 		cancelCh:              make(chan *Subscription),
 		getPeers:              make(chan *listPeerReq),
 		addSub:                make(chan *addSubReq),


### PR DESCRIPTION
Addresses https://github.com/libp2p/go-libp2p-pubsub/issues/482 by implementing an exponential backoff mechanism for re-spawning new streams to peers that are originally supposedly dead. 

closes https://github.com/libp2p/go-libp2p-pubsub/issues/482