### PR TITLE
feat: support transient connections control

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -286,7 +286,11 @@ func WithPeerScore(params *PeerScoreParams, thresholds *PeerScoreThresholds) Opt
 			return err
 		}
 
+		if useTransient, _ := network.GetUseTransient(ps.ctx); useTransient {
+			params.EnableTransient = useTransient
+		}
 		gs.score = newPeerScore(params)
+
 		gs.gossipThreshold = thresholds.GossipThreshold
 		gs.publishThreshold = thresholds.PublishThreshold
 		gs.graylistThreshold = thresholds.GraylistThreshold
@@ -527,7 +531,9 @@ loop:
 		stat := c.Stat()
 
 		if stat.Transient {
-			continue
+			if useTransient, _ := network.GetUseTransient(gs.p.ctx); !useTransient {
+				continue
+			}
 		}
 
 		if stat.Direction == network.DirOutbound {

--- a/notify.go
+++ b/notify.go
@@ -19,7 +19,9 @@ func (p *PubSubNotif) ClosedStream(n network.Network, s network.Stream) {
 func (p *PubSubNotif) Connected(n network.Network, c network.Conn) {
 	// ignore transient connections
 	if c.Stat().Transient {
-		return
+		if useTransient, _ := network.GetUseTransient(p.ctx); !useTransient {
+			return
+		}
 	}
 
 	go func() {
@@ -60,7 +62,9 @@ func (p *PubSubNotif) Initialize() {
 	p.newPeersMx.Lock()
 	for _, pid := range p.host.Network().Peers() {
 		if isTransient(pid) {
-			continue
+			if useTransient, _ := network.GetUseTransient(p.ctx); !useTransient {
+				continue
+			}
 		}
 
 		p.newPeersPend[pid] = struct{}{}

--- a/score.go
+++ b/score.go
@@ -989,7 +989,7 @@ func (ps *peerScore) getIPs(p peer.ID) []string {
 	conns := ps.host.Network().ConnsToPeer(p)
 	res := make([]string, 0, 1)
 	for _, c := range conns {
-		if c.Stat().Transient {
+		if c.Stat().Transient && !ps.params.EnableTransient {
 			// ignore transient
 			continue
 		}

--- a/score_params.go
+++ b/score_params.go
@@ -96,6 +96,9 @@ type PeerScoreParams struct {
 
 	// time to remember a message delivery for. Default to global TimeCacheDuration if 0.
 	SeenMsgTTL time.Duration
+
+	// whether to use transient connections
+	EnableTransient bool
 }
 
 type TopicScoreParams struct {


### PR DESCRIPTION
pubsub now will call `network.GetUseTransient(ctx)` to decide whether to
use transient connections

issue: https://github.com/libp2p/go-libp2p-pubsub/issues/489