### PR TITLE
fix handling of dead peers

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -720,7 +720,6 @@ func (p *PubSub) handleDeadPeers() {
 			messages <- p.getHelloPacket()
 			p.peers[pid] = messages
 			go p.handleNewPeerWithBackoff(p.ctx, pid, backoffDelay, messages)
-			continue
 		}
 	}
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -695,6 +695,16 @@ func (p *PubSub) handleDeadPeers() {
 		}
 
 		close(ch)
+		delete(p.peers, pid)
+
+		for t, tmap := range p.topics {
+			if _, ok := tmap[pid]; ok {
+				delete(tmap, pid)
+				p.notifyLeave(t, pid)
+			}
+		}
+
+		p.rt.RemovePeer(pid)
 
 		if p.host.Network().Connectedness(pid) == network.Connected {
 			backoffDelay, err := p.deadPeerBackoff.updateAndGet(pid)
@@ -708,20 +718,10 @@ func (p *PubSub) handleDeadPeers() {
 			log.Debugf("peer declared dead but still connected; respawning writer: %s", pid)
 			messages := make(chan *RPC, p.peerOutboundQueueSize)
 			messages <- p.getHelloPacket()
-			go p.handleNewPeerWithBackoff(p.ctx, pid, backoffDelay, messages)
 			p.peers[pid] = messages
+			go p.handleNewPeerWithBackoff(p.ctx, pid, backoffDelay, messages)
 			continue
 		}
-
-		delete(p.peers, pid)
-		for t, tmap := range p.topics {
-			if _, ok := tmap[pid]; ok {
-				delete(tmap, pid)
-				p.notifyLeave(t, pid)
-			}
-		}
-
-		p.rt.RemovePeer(pid)
 	}
 }
 


### PR DESCRIPTION
It wass possible to leave a closed channel in the peer mapping, which can cause a panic.
See https://github.com/filecoin-project/lotus/issues/8806