### PR TITLE
Replaced topic lock by atomic boolean to avoid lock contention

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,5 @@ require (
 	github.com/libp2p/go-msgio v0.2.0
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee
+	go.uber.org/atomic v1.7.0
 )

--- a/pubsub.go
+++ b/pubsub.go
@@ -221,7 +221,7 @@ type Message struct {
 	ID            string
 	ReceivedFrom  peer.ID
 	ValidatorData interface{}
-	Local bool
+	Local         bool
 }
 
 func (m *Message) GetFrom() peer.ID {


### PR DESCRIPTION
PR opened in response to #494.

In the `topic` struct, there is currently lock contention due to the internal lock that is used to check if the topic has been closed or not. This generates lock contention, in those cases where the `publish` call takes a long time, such as if messages are signed with RSA.

Therefore, in this PR is proposed to replace the lock with an atomic boolean, allowing concurrent calls to Publish, and relieving lock contention.