### PR TITLE
chore: ignore signing keys during WithLocalPublication publishing

### DIFF
--- a/topic.go
+++ b/topic.go
@@ -215,7 +215,7 @@ type ProvideKey func() (crypto.PrivKey, peer.ID)
 type PublishOptions struct {
 	ready     RouterReady
 	customKey ProvideKey
-	local bool
+	local     bool
 }
 
 type PubOpt func(pub *PublishOptions) error
@@ -239,7 +239,7 @@ func (t *Topic) Publish(ctx context.Context, data []byte, opts ...PubOpt) error 
 		}
 	}
 
-	if pub.customKey != nil {
+	if pub.customKey != nil && !pub.local {
 		key, pid = pub.customKey()
 		if key == nil {
 			return ErrNilSignKey


### PR DESCRIPTION
We can ignore signing keys as there is no sense to verify ourselves during local publication.