### PR TITLE
Enables non-atomic validation for peer scoring parameters

### DIFF
--- a/score_params.go
+++ b/score_params.go
@@ -52,7 +52,7 @@ func (p *PeerScoreThresholds) validate() error {
 
 type PeerScoreParams struct {
 	// whether it is allowed to just set some params and not all of them.
-	SelectiveParams bool
+	SkipAtomicValidation bool
 
 	// Score parameters per topic.
 	Topics map[string]*TopicScoreParams
@@ -103,7 +103,7 @@ type PeerScoreParams struct {
 
 type TopicScoreParams struct {
 	// whether it is allowed to just set some params and not all of them.
-	SelectiveParams bool
+	SkipAtomicValidation bool
 
 	// The weight of the topic.
 	TopicWeight float64
@@ -240,6 +240,13 @@ func (p *TopicScoreParams) validate() error {
 }
 
 func (p *TopicScoreParams) validateTimeInMeshParams() error {
+	if p.SkipAtomicValidation {
+		// in selective mode, parameters at their zero values are dismissed from validation.
+		if p.TimeInMeshQuantum == 0 && p.TimeInMeshCap == 0 {
+			return nil
+		}
+	}
+
 	if p.TimeInMeshQuantum == 0 {
 		return fmt.Errorf("invalid TimeInMeshQuantum; must be non zero")
 	}
@@ -257,6 +264,13 @@ func (p *TopicScoreParams) validateTimeInMeshParams() error {
 }
 
 func (p *TopicScoreParams) validateMessageDeliveryParams() error {
+	if p.SkipAtomicValidation {
+		// in selective mode, parameters at their zero values are dismissed from validation.
+		if p.FirstMessageDeliveriesCap == 0 && p.MeshMessageDeliveriesDecay == 0 {
+			return nil
+		}
+	}
+
 	if p.FirstMessageDeliveriesWeight < 0 || isInvalidNumber(p.FirstMessageDeliveriesWeight) {
 		return fmt.Errorf("invallid FirstMessageDeliveriesWeight; must be positive (or 0 to disable) and a valid number")
 	}
@@ -271,6 +285,13 @@ func (p *TopicScoreParams) validateMessageDeliveryParams() error {
 }
 
 func (p *TopicScoreParams) validateMeshMessageDeliveryParams() error {
+	if p.SkipAtomicValidation {
+		// in selective mode, parameters at their zero values are dismissed from validation.
+		if p.FirstMessageDeliveriesCap == 0 && p.MeshMessageDeliveriesDecay == 0 {
+			return nil
+		}
+	}
+
 	if p.MeshMessageDeliveriesWeight > 0 || isInvalidNumber(p.MeshMessageDeliveriesWeight) {
 		return fmt.Errorf("invalid MeshMessageDeliveriesWeight; must be negative (or 0 to disable) and a valid number")
 	}
@@ -294,6 +315,13 @@ func (p *TopicScoreParams) validateMeshMessageDeliveryParams() error {
 }
 
 func (p *TopicScoreParams) validateMessageFailurePenaltyParams() error {
+	if p.SkipAtomicValidation {
+		// in selective mode, parameters at their zero values are dismissed from validation.
+		if p.MeshFailurePenaltyDecay == 0 {
+			return nil
+		}
+	}
+
 	if p.MeshFailurePenaltyWeight > 0 || isInvalidNumber(p.MeshFailurePenaltyWeight) {
 		return fmt.Errorf("invalid MeshFailurePenaltyWeight; must be negative (or 0 to disable) and a valid number")
 	}
@@ -305,6 +333,13 @@ func (p *TopicScoreParams) validateMessageFailurePenaltyParams() error {
 }
 
 func (p *TopicScoreParams) validateInvalidMessageDeliveryParams() error {
+	if p.SkipAtomicValidation {
+		// in selective mode, parameters at their zero values are dismissed from validation.
+		if p.InvalidMessageDeliveriesDecay == 0 {
+			return nil
+		}
+	}
+
 	if p.InvalidMessageDeliveriesWeight > 0 || isInvalidNumber(p.InvalidMessageDeliveriesWeight) {
 		return fmt.Errorf("invalid InvalidMessageDeliveriesWeight; must be negative (or 0 to disable) and a valid number")
 	}

--- a/score_params.go
+++ b/score_params.go
@@ -10,6 +10,9 @@ import (
 )
 
 type PeerScoreThresholds struct {
+	// whether it is allowed to just set some params and not all of them.
+	SkipAtomicValidation bool
+
 	// GossipThreshold is the score threshold below which gossip propagation is supressed;
 	// should be negative.
 	GossipThreshold float64
@@ -32,21 +35,36 @@ type PeerScoreThresholds struct {
 }
 
 func (p *PeerScoreThresholds) validate() error {
-	if p.GossipThreshold > 0 || isInvalidNumber(p.GossipThreshold) {
-		return fmt.Errorf("invalid gossip threshold; it must be <= 0 and a valid number")
+	if !p.SkipAtomicValidation || p.GossipThreshold != 0 {
+		if p.GossipThreshold > 0 || isInvalidNumber(p.GossipThreshold) {
+			return fmt.Errorf("invalid gossip threshold; it must be <= 0 and a valid number")
+		}
 	}
-	if p.PublishThreshold > 0 || p.PublishThreshold > p.GossipThreshold || isInvalidNumber(p.PublishThreshold) {
-		return fmt.Errorf("invalid publish threshold; it must be <= 0 and <= gossip threshold and a valid number")
+
+	if !p.SkipAtomicValidation || p.PublishThreshold != 0 {
+		if p.PublishThreshold > 0 || p.PublishThreshold > p.GossipThreshold || isInvalidNumber(p.PublishThreshold) {
+			return fmt.Errorf("invalid publish threshold; it must be <= 0 and <= gossip threshold and a valid number")
+		}
 	}
-	if p.GraylistThreshold > 0 || p.GraylistThreshold > p.PublishThreshold || isInvalidNumber(p.GraylistThreshold) {
-		return fmt.Errorf("invalid graylist threshold; it must be <= 0 and <= publish threshold and a valid number")
+
+	if !p.SkipAtomicValidation || p.GraylistThreshold != 0 {
+		if p.GraylistThreshold > 0 || p.GraylistThreshold > p.PublishThreshold || isInvalidNumber(p.GraylistThreshold) {
+			return fmt.Errorf("invalid graylist threshold; it must be <= 0 and <= publish threshold and a valid number")
+		}
 	}
-	if p.AcceptPXThreshold < 0 || isInvalidNumber(p.AcceptPXThreshold) {
-		return fmt.Errorf("invalid accept PX threshold; it must be >= 0 and a valid number")
+
+	if !p.SkipAtomicValidation || p.AcceptPXThreshold != 0 {
+		if p.AcceptPXThreshold < 0 || isInvalidNumber(p.AcceptPXThreshold) {
+			return fmt.Errorf("invalid accept PX threshold; it must be >= 0 and a valid number")
+		}
 	}
-	if p.OpportunisticGraftThreshold < 0 || isInvalidNumber(p.OpportunisticGraftThreshold) {
-		return fmt.Errorf("invalid opportunistic grafting threshold; it must be >= 0 and a valid number")
+
+	if !p.SkipAtomicValidation || p.OpportunisticGraftThreshold != 0 {
+		if p.OpportunisticGraftThreshold < 0 || isInvalidNumber(p.OpportunisticGraftThreshold) {
+			return fmt.Errorf("invalid opportunistic grafting threshold; it must be >= 0 and a valid number")
+		}
 	}
+
 	return nil
 }
 

--- a/score_params.go
+++ b/score_params.go
@@ -13,7 +13,7 @@ type PeerScoreThresholds struct {
 	// whether it is allowed to just set some params and not all of them.
 	SkipAtomicValidation bool
 
-	// GossipThreshold is the score threshold below which gossip propagation is supressed;
+	// GossipThreshold is the score threshold below which gossip propagation is suppressed;
 	// should be negative.
 	GossipThreshold float64
 
@@ -21,8 +21,8 @@ type PeerScoreThresholds struct {
 	// publishing (also applies to fanout and floodsub peers); should be negative and <= GossipThreshold.
 	PublishThreshold float64
 
-	// GraylistThreshold is the score threshold below which message processing is supressed altogether,
-	// implementing an effective graylist according to peer score; should be negative and <= PublisThreshold.
+	// GraylistThreshold is the score threshold below which message processing is suppressed altogether,
+	// implementing an effective gray list according to peer score; should be negative and <= PublishThreshold.
 	GraylistThreshold float64
 
 	// AcceptPXThreshold is the score threshold below which PX will be ignored; this should be positive
@@ -35,19 +35,14 @@ type PeerScoreThresholds struct {
 }
 
 func (p *PeerScoreThresholds) validate() error {
-	if !p.SkipAtomicValidation || p.GossipThreshold != 0 {
+
+	if !p.SkipAtomicValidation || p.PublishThreshold != 0 || p.GossipThreshold != 0 || p.GraylistThreshold != 0 {
 		if p.GossipThreshold > 0 || isInvalidNumber(p.GossipThreshold) {
 			return fmt.Errorf("invalid gossip threshold; it must be <= 0 and a valid number")
 		}
-	}
-
-	if !p.SkipAtomicValidation || p.PublishThreshold != 0 {
 		if p.PublishThreshold > 0 || p.PublishThreshold > p.GossipThreshold || isInvalidNumber(p.PublishThreshold) {
 			return fmt.Errorf("invalid publish threshold; it must be <= 0 and <= gossip threshold and a valid number")
 		}
-	}
-
-	if !p.SkipAtomicValidation || p.GraylistThreshold != 0 {
 		if p.GraylistThreshold > 0 || p.GraylistThreshold > p.PublishThreshold || isInvalidNumber(p.GraylistThreshold) {
 			return fmt.Errorf("invalid graylist threshold; it must be <= 0 and <= publish threshold and a valid number")
 		}

--- a/score_params.go
+++ b/score_params.go
@@ -363,7 +363,7 @@ func (p *TopicScoreParams) validateMeshMessageDeliveryParams() error {
 func (p *TopicScoreParams) validateMessageFailurePenaltyParams() error {
 	if p.SkipAtomicValidation {
 		// in selective mode, parameters at their zero values are dismissed from validation.
-		if p.MeshFailurePenaltyDecay == 0 {
+		if p.MeshFailurePenaltyDecay == 0 && p.MeshFailurePenaltyWeight == 0 {
 			return nil
 		}
 	}
@@ -384,7 +384,7 @@ func (p *TopicScoreParams) validateMessageFailurePenaltyParams() error {
 func (p *TopicScoreParams) validateInvalidMessageDeliveryParams() error {
 	if p.SkipAtomicValidation {
 		// in selective mode, parameters at their zero values are dismissed from validation.
-		if p.InvalidMessageDeliveriesDecay == 0 {
+		if p.InvalidMessageDeliveriesDecay == 0 && p.InvalidMessageDeliveriesWeight == 0 {
 			return nil
 		}
 	}

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -118,82 +118,207 @@ func testPeerScoreThresholdsValidation(t *testing.T, skipAtomicValidation bool) 
 	}
 }
 
-func TestTopicScoreParamsValidation_AtomicValidation(t *testing.T) {
-	if (&TopicScoreParams{}).validate() == nil {
+func TestTopicScoreParamsValidation_InvalidParams_AtomicValidation(t *testing.T) {
+	testTopicScoreParamsValidationWithInvalidParameters(t, false)
+}
+
+func TestTopicScoreParamsValidation_InvalidParams_SkipAtomicValidation(t *testing.T) {
+	testTopicScoreParamsValidationWithInvalidParameters(t, true)
+}
+
+func testTopicScoreParamsValidationWithInvalidParameters(t *testing.T, skipAtomicValidation bool) {
+
+	if skipAtomicValidation {
+		if (&TopicScoreParams{
+			SkipAtomicValidation: true}).validate() != nil {
+			t.Fatal("expected validation success")
+		}
+	} else {
+		if (&TopicScoreParams{}).validate() == nil {
+			t.Fatal("expected validation failure")
+		}
+	}
+
+	if (&TopicScoreParams{
+		SkipAtomicValidation: skipAtomicValidation,
+		TopicWeight:          -1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
 
-	if (&TopicScoreParams{TopicWeight: -1}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation: skipAtomicValidation,
+		TimeInMeshWeight:     -1,
+		TimeInMeshQuantum:    time.Second,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation: skipAtomicValidation,
+		TimeInMeshWeight:     1,
+		TimeInMeshQuantum:    -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation: skipAtomicValidation,
+		TimeInMeshWeight:     1,
+		TimeInMeshQuantum:    time.Second,
+		TimeInMeshCap:        -1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
 
-	if (&TopicScoreParams{TimeInMeshWeight: -1, TimeInMeshQuantum: time.Second}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation:         skipAtomicValidation,
+		TimeInMeshQuantum:            time.Second,
+		FirstMessageDeliveriesWeight: -1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&TopicScoreParams{TimeInMeshWeight: 1, TimeInMeshQuantum: -1}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation:         skipAtomicValidation,
+		TimeInMeshQuantum:            time.Second,
+		FirstMessageDeliveriesWeight: 1,
+		FirstMessageDeliveriesDecay:  -1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&TopicScoreParams{TimeInMeshWeight: 1, TimeInMeshQuantum: time.Second, TimeInMeshCap: -1}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation:         skipAtomicValidation,
+		TimeInMeshQuantum:            time.Second,
+		FirstMessageDeliveriesWeight: 1,
+		FirstMessageDeliveriesDecay:  2,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, FirstMessageDeliveriesWeight: -1}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, FirstMessageDeliveriesWeight: 1, FirstMessageDeliveriesDecay: -1}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, FirstMessageDeliveriesWeight: 1, FirstMessageDeliveriesDecay: 2}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, FirstMessageDeliveriesWeight: 1, FirstMessageDeliveriesDecay: .5, FirstMessageDeliveriesCap: -1}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, MeshMessageDeliveriesWeight: 1}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, MeshMessageDeliveriesWeight: -1, MeshMessageDeliveriesDecay: -1}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, MeshMessageDeliveriesWeight: -1, MeshMessageDeliveriesDecay: 2}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, MeshMessageDeliveriesWeight: -1, MeshMessageDeliveriesDecay: .5, MeshMessageDeliveriesCap: -1}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, MeshMessageDeliveriesWeight: -1, MeshMessageDeliveriesDecay: .5, MeshMessageDeliveriesCap: 5, MeshMessageDeliveriesThreshold: -3}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, MeshMessageDeliveriesWeight: -1, MeshMessageDeliveriesDecay: .5, MeshMessageDeliveriesCap: 5, MeshMessageDeliveriesThreshold: 3, MeshMessageDeliveriesWindow: -1}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, MeshMessageDeliveriesWeight: -1, MeshMessageDeliveriesDecay: .5, MeshMessageDeliveriesCap: 5, MeshMessageDeliveriesThreshold: 3, MeshMessageDeliveriesWindow: time.Millisecond, MeshMessageDeliveriesActivation: time.Millisecond}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation:         skipAtomicValidation,
+		TimeInMeshQuantum:            time.Second,
+		FirstMessageDeliveriesWeight: 1,
+		FirstMessageDeliveriesDecay:  .5,
+		FirstMessageDeliveriesCap:    -1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
 
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, MeshFailurePenaltyWeight: 1}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		TimeInMeshQuantum:           time.Second,
+		MeshMessageDeliveriesWeight: 1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, MeshFailurePenaltyWeight: -1, MeshFailurePenaltyDecay: -1}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		TimeInMeshQuantum:           time.Second,
+		MeshMessageDeliveriesWeight: -1,
+		MeshMessageDeliveriesDecay:  -1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, MeshFailurePenaltyWeight: -1, MeshFailurePenaltyDecay: 2}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		TimeInMeshQuantum:           time.Second,
+		MeshMessageDeliveriesWeight: -1,
+		MeshMessageDeliveriesDecay:  2}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		TimeInMeshQuantum:           time.Second,
+		MeshMessageDeliveriesWeight: -1,
+		MeshMessageDeliveriesDecay:  .5,
+		MeshMessageDeliveriesCap:    -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:           skipAtomicValidation,
+		TimeInMeshQuantum:              time.Second,
+		MeshMessageDeliveriesWeight:    -1,
+		MeshMessageDeliveriesDecay:     .5,
+		MeshMessageDeliveriesCap:       5,
+		MeshMessageDeliveriesThreshold: -3,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:           skipAtomicValidation,
+		TimeInMeshQuantum:              time.Second,
+		MeshMessageDeliveriesWeight:    -1,
+		MeshMessageDeliveriesDecay:     .5,
+		MeshMessageDeliveriesCap:       5,
+		MeshMessageDeliveriesThreshold: 3,
+		MeshMessageDeliveriesWindow:    -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:            skipAtomicValidation,
+		TimeInMeshQuantum:               time.Second,
+		MeshMessageDeliveriesWeight:     -1,
+		MeshMessageDeliveriesDecay:      .5,
+		MeshMessageDeliveriesCap:        5,
+		MeshMessageDeliveriesThreshold:  3,
+		MeshMessageDeliveriesWindow:     time.Millisecond,
+		MeshMessageDeliveriesActivation: time.Millisecond}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
 
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, InvalidMessageDeliveriesWeight: 1}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation:     skipAtomicValidation,
+		TimeInMeshQuantum:        time.Second,
+		MeshFailurePenaltyWeight: 1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, InvalidMessageDeliveriesWeight: -1, InvalidMessageDeliveriesDecay: -1}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation:     skipAtomicValidation,
+		TimeInMeshQuantum:        time.Second,
+		MeshFailurePenaltyWeight: -1,
+		MeshFailurePenaltyDecay:  -1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&TopicScoreParams{TimeInMeshQuantum: time.Second, InvalidMessageDeliveriesWeight: -1, InvalidMessageDeliveriesDecay: 2}).validate() == nil {
+	if (&TopicScoreParams{
+		SkipAtomicValidation:     skipAtomicValidation,
+		TimeInMeshQuantum:        time.Second,
+		MeshFailurePenaltyWeight: -1,
+		MeshFailurePenaltyDecay:  2,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
 
+	if (&TopicScoreParams{
+		SkipAtomicValidation:           skipAtomicValidation,
+		TimeInMeshQuantum:              time.Second,
+		InvalidMessageDeliveriesWeight: 1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:           skipAtomicValidation,
+		TimeInMeshQuantum:              time.Second,
+		InvalidMessageDeliveriesWeight: -1,
+		InvalidMessageDeliveriesDecay:  -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:           skipAtomicValidation,
+		TimeInMeshQuantum:              time.Second,
+		InvalidMessageDeliveriesWeight: -1,
+		InvalidMessageDeliveriesDecay:  2,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestTopicScoreParamsValidation_ValidParams_AtomicValidation(t *testing.T) {
 	// Don't use these params in production!
 	if (&TopicScoreParams{
+		SkipAtomicValidation:            false,
 		TopicWeight:                     1,
 		TimeInMeshWeight:                0.01,
 		TimeInMeshQuantum:               time.Second,
@@ -217,238 +342,48 @@ func TestTopicScoreParamsValidation_AtomicValidation(t *testing.T) {
 }
 
 func TestTopicScoreParamsValidation_NonAtomicValidation(t *testing.T) {
-	if (&TopicScoreParams{SkipAtomicValidation: true}).validate() != nil {
-		t.Fatal("expected no validation error in non-atomic mode")
-	}
-
-	// Following tests evaluate that even when we skip atomic validation, those parameters that are set with a value are
-	// going through validation.
-	if (&TopicScoreParams{
-		SkipAtomicValidation: true,
-		TopicWeight:          -1,
-	}).
-		validate() == nil {
-		t.Fatalf("expected validation error")
-	}
-
-	if (&TopicScoreParams{
-		SkipAtomicValidation: true,
-		TimeInMeshWeight:     -1,
-		TimeInMeshQuantum:    time.Second,
-	}).validate() == nil {
-		t.Fatalf("expected validation error")
-	}
-
-	if (&TopicScoreParams{
-		SkipAtomicValidation: true,
-		TimeInMeshWeight:     1,
-		TimeInMeshQuantum:    time.Second,
-		TimeInMeshCap:        -1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-
-	if (&TopicScoreParams{
-		SkipAtomicValidation:         true,
-		TimeInMeshQuantum:            time.Second,
-		FirstMessageDeliveriesWeight: -1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:         true,
-		TimeInMeshQuantum:            time.Second,
-		FirstMessageDeliveriesWeight: 1,
-		FirstMessageDeliveriesDecay:  -1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:         true,
-		TimeInMeshQuantum:            time.Second,
-		FirstMessageDeliveriesWeight: 1,
-		FirstMessageDeliveriesDecay:  2,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:         true,
-		TimeInMeshQuantum:            time.Second,
-		FirstMessageDeliveriesWeight: 1,
-		FirstMessageDeliveriesDecay:  .5,
-		FirstMessageDeliveriesCap:    -1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-
-	if (&TopicScoreParams{
-		SkipAtomicValidation:        true,
-		TimeInMeshQuantum:           time.Second,
-		MeshMessageDeliveriesWeight: 1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{SkipAtomicValidation: true,
-		TimeInMeshQuantum:           time.Second,
-		MeshMessageDeliveriesWeight: -1,
-		MeshMessageDeliveriesDecay:  -1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:        true,
-		TimeInMeshQuantum:           time.Second,
-		MeshMessageDeliveriesWeight: -1,
-		MeshMessageDeliveriesDecay:  2,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:        true,
-		TimeInMeshQuantum:           time.Second,
-		MeshMessageDeliveriesWeight: -1,
-		MeshMessageDeliveriesDecay:  .5,
-		MeshMessageDeliveriesCap:    -1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:           true,
-		TimeInMeshQuantum:              time.Second,
-		MeshMessageDeliveriesWeight:    -1,
-		MeshMessageDeliveriesDecay:     .5,
-		MeshMessageDeliveriesCap:       5,
-		MeshMessageDeliveriesThreshold: -3,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:           true,
-		TimeInMeshQuantum:              time.Second,
-		MeshMessageDeliveriesWeight:    -1,
-		MeshMessageDeliveriesDecay:     .5,
-		MeshMessageDeliveriesCap:       5,
-		MeshMessageDeliveriesThreshold: 3,
-		MeshMessageDeliveriesWindow:    -1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:            true,
-		TimeInMeshQuantum:               time.Second,
-		MeshMessageDeliveriesWeight:     -1,
-		MeshMessageDeliveriesDecay:      .5,
-		MeshMessageDeliveriesCap:        5,
-		MeshMessageDeliveriesThreshold:  3,
-		MeshMessageDeliveriesWindow:     time.Millisecond,
-		MeshMessageDeliveriesActivation: time.Millisecond,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-
-	if (&TopicScoreParams{
-		SkipAtomicValidation:     true,
-		TimeInMeshQuantum:        time.Second,
-		MeshFailurePenaltyWeight: 1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:     true,
-		TimeInMeshQuantum:        time.Second,
-		MeshFailurePenaltyWeight: -1,
-		MeshFailurePenaltyDecay:  -1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:     true,
-		TimeInMeshQuantum:        time.Second,
-		MeshFailurePenaltyWeight: -1,
-		MeshFailurePenaltyDecay:  2,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-
-	if (&TopicScoreParams{
-		SkipAtomicValidation:           true,
-		TimeInMeshQuantum:              time.Second,
-		InvalidMessageDeliveriesWeight: 1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:           true,
-		TimeInMeshQuantum:              time.Second,
-		InvalidMessageDeliveriesWeight: -1,
-		InvalidMessageDeliveriesDecay:  -1,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-	if (&TopicScoreParams{
-		SkipAtomicValidation:           true,
-		TimeInMeshQuantum:              time.Second,
-		InvalidMessageDeliveriesWeight: -1,
-		InvalidMessageDeliveriesDecay:  2,
-	}).validate() == nil {
-		t.Fatal("expected validation error")
-	}
-
 	// Don't use these params in production!
 	// In non-atomic (selective) validation mode, the subset of parameters passes
 	// validation if the individual parameters values pass validation.
-	p := TopicScoreParams{SkipAtomicValidation: true}
-
-	if err := p.validate(); err != nil {
-		t.Fatalf("expected validation success, got: %s", err)
-	}
-
-	// including topic weight
-	p.TopicWeight = 1
-	if err := p.validate(); err != nil {
-		t.Fatalf("expected validation success, got: %s", err)
-	}
-
-	// including time in mesh parameters
-	p.TimeInMeshWeight = 0.01
-	p.TimeInMeshQuantum = time.Second
-	p.TimeInMeshCap = 10
-	if err := p.validate(); err != nil {
-		t.Fatalf("expected validation success, got: %s", err)
-	}
-
-	// including first message delivery parameters
-	p.FirstMessageDeliveriesWeight = 1
-	p.FirstMessageDeliveriesDecay = 0.5
-	p.FirstMessageDeliveriesCap = 10
-	if err := p.validate(); err != nil {
-		t.Fatalf("expected validation success, got: %s", err)
-	}
-
-	// including mesh message delivery parameters
-	p.MeshMessageDeliveriesWeight = -1
-	p.MeshMessageDeliveriesDecay = 0.05
-	p.MeshMessageDeliveriesCap = 10
-	p.MeshMessageDeliveriesThreshold = 5
-	p.MeshMessageDeliveriesWindow = time.Millisecond
-	p.MeshMessageDeliveriesActivation = time.Second
-	if err := p.validate(); err != nil {
-		t.Fatalf("expected validation success, got: %s", err)
-	}
-
-	// including mesh failure penalty parameters
-	p.MeshFailurePenaltyWeight = -1
-	p.MeshFailurePenaltyDecay = 0.5
-	if err := p.validate(); err != nil {
-		t.Fatalf("expected validation success, got: %s", err)
-	}
-
-	// including invalid message delivery parameters
-	p.InvalidMessageDeliveriesWeight = -1
-	p.InvalidMessageDeliveriesDecay = 0.5
-	if err := p.validate(); err != nil {
-		t.Fatalf("expected validation success, got: %s", err)
-	}
+	p := &TopicScoreParams{}
+	setTopicParamAndValidate(t, p, func(params *TopicScoreParams) {
+		params.SkipAtomicValidation = true
+	})
+	// including topic weight.
+	setTopicParamAndValidate(t, p, func(params *TopicScoreParams) {
+		params.TopicWeight = 1
+	})
+	// including time in mesh parameters.
+	setTopicParamAndValidate(t, p, func(params *TopicScoreParams) {
+		params.TimeInMeshWeight = 0.01
+		params.TimeInMeshQuantum = time.Second
+		params.TimeInMeshCap = 10
+	})
+	// including first message delivery parameters.
+	setTopicParamAndValidate(t, p, func(params *TopicScoreParams) {
+		params.FirstMessageDeliveriesWeight = 1
+		params.FirstMessageDeliveriesDecay = 0.5
+		params.FirstMessageDeliveriesCap = 10
+	})
+	// including mesh message delivery parameters.
+	setTopicParamAndValidate(t, p, func(params *TopicScoreParams) {
+		params.MeshMessageDeliveriesWeight = -1
+		params.MeshMessageDeliveriesDecay = 0.5
+		params.MeshMessageDeliveriesCap = 10
+		params.MeshMessageDeliveriesThreshold = 5
+		params.MeshMessageDeliveriesWindow = time.Millisecond
+		params.MeshMessageDeliveriesActivation = time.Second
+	})
+	// including mesh failure penalty parameters.
+	setTopicParamAndValidate(t, p, func(params *TopicScoreParams) {
+		params.MeshFailurePenaltyWeight = -1
+		params.MeshFailurePenaltyDecay = 0.5
+	})
+	// including invalid message delivery parameters.
+	setTopicParamAndValidate(t, p, func(params *TopicScoreParams) {
+		params.InvalidMessageDeliveriesWeight = -1
+		params.InvalidMessageDeliveriesDecay = 0.5
+	})
 }
 
 func TestPeerScoreParamsValidation_InvalidParams_AtomicValidation(t *testing.T) {
@@ -790,6 +725,13 @@ func TestScoreParameterDecay(t *testing.T) {
 }
 
 func setParamAndValidate(t *testing.T, params *PeerScoreParams, set func(*PeerScoreParams)) {
+	set(params)
+	if err := params.validate(); err != nil {
+		t.Fatalf("expected validation success, got: %s", err)
+	}
+}
+
+func setTopicParamAndValidate(t *testing.T, params *TopicScoreParams, set func(topic *TopicScoreParams)) {
 	set(params)
 	if err := params.validate(); err != nil {
 		t.Fatalf("expected validation success, got: %s", err)

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -47,7 +47,7 @@ func TestPeerScoreThresholdsValidation(t *testing.T) {
 	}
 }
 
-func TestTopicScoreParamsValidation(t *testing.T) {
+func TestTopicScoreParamsValidation_AtomicValidation(t *testing.T) {
 	if (&TopicScoreParams{}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
@@ -145,6 +145,241 @@ func TestTopicScoreParamsValidation(t *testing.T) {
 	}
 }
 
+func TestTopicScoreParamsValidation_NonAtomicValidation(t *testing.T) {
+	if (&TopicScoreParams{SkipAtomicValidation: true}).validate() != nil {
+		t.Fatal("expected no validation error in non-atomic mode")
+	}
+
+	// Following tests evaluate that even when we skip atomic validation, those parameters that are set with a value are
+	// going through validation.
+	if (&TopicScoreParams{
+		SkipAtomicValidation: true,
+		TopicWeight:          -1,
+	}).
+		validate() == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	if (&TopicScoreParams{
+		SkipAtomicValidation: true,
+		TimeInMeshWeight:     -1,
+		TimeInMeshQuantum:    time.Second,
+	}).validate() == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	if (&TopicScoreParams{
+		SkipAtomicValidation: true,
+		TimeInMeshWeight:     1,
+		TimeInMeshQuantum:    time.Second,
+		TimeInMeshCap:        -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+
+	if (&TopicScoreParams{
+		SkipAtomicValidation:         true,
+		TimeInMeshQuantum:            time.Second,
+		FirstMessageDeliveriesWeight: -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:         true,
+		TimeInMeshQuantum:            time.Second,
+		FirstMessageDeliveriesWeight: 1,
+		FirstMessageDeliveriesDecay:  -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:         true,
+		TimeInMeshQuantum:            time.Second,
+		FirstMessageDeliveriesWeight: 1,
+		FirstMessageDeliveriesDecay:  2,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:         true,
+		TimeInMeshQuantum:            time.Second,
+		FirstMessageDeliveriesWeight: 1,
+		FirstMessageDeliveriesDecay:  .5,
+		FirstMessageDeliveriesCap:    -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+
+	if (&TopicScoreParams{
+		SkipAtomicValidation:        true,
+		TimeInMeshQuantum:           time.Second,
+		MeshMessageDeliveriesWeight: 1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{SkipAtomicValidation: true,
+		TimeInMeshQuantum:           time.Second,
+		MeshMessageDeliveriesWeight: -1,
+		MeshMessageDeliveriesDecay:  -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:        true,
+		TimeInMeshQuantum:           time.Second,
+		MeshMessageDeliveriesWeight: -1,
+		MeshMessageDeliveriesDecay:  2,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:        true,
+		TimeInMeshQuantum:           time.Second,
+		MeshMessageDeliveriesWeight: -1,
+		MeshMessageDeliveriesDecay:  .5,
+		MeshMessageDeliveriesCap:    -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:           true,
+		TimeInMeshQuantum:              time.Second,
+		MeshMessageDeliveriesWeight:    -1,
+		MeshMessageDeliveriesDecay:     .5,
+		MeshMessageDeliveriesCap:       5,
+		MeshMessageDeliveriesThreshold: -3,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:           true,
+		TimeInMeshQuantum:              time.Second,
+		MeshMessageDeliveriesWeight:    -1,
+		MeshMessageDeliveriesDecay:     .5,
+		MeshMessageDeliveriesCap:       5,
+		MeshMessageDeliveriesThreshold: 3,
+		MeshMessageDeliveriesWindow:    -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:            true,
+		TimeInMeshQuantum:               time.Second,
+		MeshMessageDeliveriesWeight:     -1,
+		MeshMessageDeliveriesDecay:      .5,
+		MeshMessageDeliveriesCap:        5,
+		MeshMessageDeliveriesThreshold:  3,
+		MeshMessageDeliveriesWindow:     time.Millisecond,
+		MeshMessageDeliveriesActivation: time.Millisecond,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+
+	if (&TopicScoreParams{
+		SkipAtomicValidation:     true,
+		TimeInMeshQuantum:        time.Second,
+		MeshFailurePenaltyWeight: 1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:     true,
+		TimeInMeshQuantum:        time.Second,
+		MeshFailurePenaltyWeight: -1,
+		MeshFailurePenaltyDecay:  -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:     true,
+		TimeInMeshQuantum:        time.Second,
+		MeshFailurePenaltyWeight: -1,
+		MeshFailurePenaltyDecay:  2,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+
+	if (&TopicScoreParams{
+		SkipAtomicValidation:           true,
+		TimeInMeshQuantum:              time.Second,
+		InvalidMessageDeliveriesWeight: 1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:           true,
+		TimeInMeshQuantum:              time.Second,
+		InvalidMessageDeliveriesWeight: -1,
+		InvalidMessageDeliveriesDecay:  -1,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+	if (&TopicScoreParams{
+		SkipAtomicValidation:           true,
+		TimeInMeshQuantum:              time.Second,
+		InvalidMessageDeliveriesWeight: -1,
+		InvalidMessageDeliveriesDecay:  2,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+
+	// Don't use these params in production!
+	// In non-atomic (selective) validation mode, the subset of parameters passes
+	// validation if the individual parameters values pass validation.
+	p := TopicScoreParams{SkipAtomicValidation: true}
+
+	if err := p.validate(); err != nil {
+		t.Fatalf("expected validation success, got: %s", err)
+	}
+
+	// including topic weight
+	p.TopicWeight = 1
+	if err := p.validate(); err != nil {
+		t.Fatalf("expected validation success, got: %s", err)
+	}
+
+	// including time in mesh parameters
+	p.TimeInMeshWeight = 0.01
+	p.TimeInMeshQuantum = time.Second
+	p.TimeInMeshCap = 10
+	if err := p.validate(); err != nil {
+		t.Fatalf("expected validation success, got: %s", err)
+	}
+
+	// including first message delivery parameters
+	p.FirstMessageDeliveriesWeight = 1
+	p.FirstMessageDeliveriesDecay = 0.5
+	p.FirstMessageDeliveriesCap = 10
+	if err := p.validate(); err != nil {
+		t.Fatalf("expected validation success, got: %s", err)
+	}
+
+	// including mesh message delivery parameters
+	p.MeshMessageDeliveriesWeight = -1
+	p.MeshMessageDeliveriesDecay = 0.05
+	p.MeshMessageDeliveriesCap = 10
+	p.MeshMessageDeliveriesThreshold = 5
+	p.MeshMessageDeliveriesWindow = time.Millisecond
+	p.MeshMessageDeliveriesActivation = time.Second
+	if err := p.validate(); err != nil {
+		t.Fatalf("expected validation success, got: %s", err)
+	}
+
+	// including mesh failure penalty parameters
+	p.MeshFailurePenaltyWeight = -1
+	p.MeshFailurePenaltyDecay = 0.5
+	if err := p.validate(); err != nil {
+		t.Fatalf("expected validation success, got: %s", err)
+	}
+
+	// including invalid message delivery parameters
+	p.InvalidMessageDeliveriesWeight = -1
+	p.InvalidMessageDeliveriesDecay = 0.5
+	if err := p.validate(); err != nil {
+		t.Fatalf("expected validation success, got: %s", err)
+	}
+}
+
 func TestPeerScoreParamsValidation(t *testing.T) {
 	appScore := func(peer.ID) float64 { return 0 }
 
@@ -213,7 +448,7 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 		IPColocationFactorWeight:    -1,
 		IPColocationFactorThreshold: 1,
 		Topics: map[string]*TopicScoreParams{
-			"test": &TopicScoreParams{
+			"test": {
 				TopicWeight:                     1,
 				TimeInMeshWeight:                0.01,
 				TimeInMeshQuantum:               time.Second,
@@ -246,7 +481,7 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 		IPColocationFactorWeight:    -1,
 		IPColocationFactorThreshold: 1,
 		Topics: map[string]*TopicScoreParams{
-			"test": &TopicScoreParams{
+			"test": {
 				TopicWeight:                     -1,
 				TimeInMeshWeight:                0.01,
 				TimeInMeshQuantum:               time.Second,
@@ -294,7 +529,7 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 		IPColocationFactorWeight:    -1,
 		IPColocationFactorThreshold: 1,
 		Topics: map[string]*TopicScoreParams{
-			"test": &TopicScoreParams{
+			"test": {
 				TopicWeight:                     math.Inf(0),
 				TimeInMeshWeight:                math.NaN(),
 				TimeInMeshQuantum:               time.Second,

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -8,41 +8,112 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-func TestPeerScoreThresholdsValidation(t *testing.T) {
-	if (&PeerScoreThresholds{GossipThreshold: 1}).validate() == nil {
+func TestPeerScoreThreshold_AtomicValidation(t *testing.T) {
+	testPeerScoreThresholdsValidation(t, false)
+}
+
+func TestPeerScoreThreshold_SkipAtomicValidation(t *testing.T) {
+	testPeerScoreThresholdsValidation(t, true)
+}
+
+func testPeerScoreThresholdsValidation(t *testing.T, skipAtomicValidation bool) {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation: skipAtomicValidation,
+		GossipThreshold:      1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreThresholds{PublishThreshold: 1}).validate() == nil {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation: skipAtomicValidation,
+		PublishThreshold:     1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: 0}).validate() == nil {
+
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation: skipAtomicValidation,
+		GossipThreshold:      -1,
+		PublishThreshold:     0,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: -2, GraylistThreshold: 0}).validate() == nil {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation: skipAtomicValidation,
+		GossipThreshold:      -1,
+		PublishThreshold:     -2,
+		GraylistThreshold:    0,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreThresholds{AcceptPXThreshold: -1}).validate() == nil {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation: skipAtomicValidation,
+		AcceptPXThreshold:    -1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreThresholds{OpportunisticGraftThreshold: -1}).validate() == nil {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation:        skipAtomicValidation,
+		OpportunisticGraftThreshold: -1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: -2, GraylistThreshold: -3, AcceptPXThreshold: 1, OpportunisticGraftThreshold: 2}).validate() != nil {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation:        skipAtomicValidation,
+		GossipThreshold:             -1,
+		PublishThreshold:            -2,
+		GraylistThreshold:           -3,
+		AcceptPXThreshold:           1,
+		OpportunisticGraftThreshold: 2}).validate() != nil {
 		t.Fatal("expected validation success")
 	}
-	if (&PeerScoreThresholds{GossipThreshold: math.Inf(-1), PublishThreshold: -2, GraylistThreshold: -3, AcceptPXThreshold: 1, OpportunisticGraftThreshold: 2}).validate() == nil {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation:        skipAtomicValidation,
+		GossipThreshold:             math.Inf(-1),
+		PublishThreshold:            -2,
+		GraylistThreshold:           -3,
+		AcceptPXThreshold:           1,
+		OpportunisticGraftThreshold: 2,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: math.Inf(-1), GraylistThreshold: -3, AcceptPXThreshold: 1, OpportunisticGraftThreshold: 2}).validate() == nil {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation:        skipAtomicValidation,
+		GossipThreshold:             -1,
+		PublishThreshold:            math.Inf(-1),
+		GraylistThreshold:           -3,
+		AcceptPXThreshold:           1,
+		OpportunisticGraftThreshold: 2,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: -2, GraylistThreshold: math.Inf(-1), AcceptPXThreshold: 1, OpportunisticGraftThreshold: 2}).validate() == nil {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation:        skipAtomicValidation,
+		GossipThreshold:             -1,
+		PublishThreshold:            -2,
+		GraylistThreshold:           math.Inf(-1),
+		AcceptPXThreshold:           1,
+		OpportunisticGraftThreshold: 2,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: -2, GraylistThreshold: -3, AcceptPXThreshold: math.NaN(), OpportunisticGraftThreshold: 2}).validate() == nil {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation:        skipAtomicValidation,
+		GossipThreshold:             -1,
+		PublishThreshold:            -2,
+		GraylistThreshold:           -3,
+		AcceptPXThreshold:           math.NaN(),
+		OpportunisticGraftThreshold: 2,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreThresholds{GossipThreshold: -1, PublishThreshold: -2, GraylistThreshold: -3, AcceptPXThreshold: 1, OpportunisticGraftThreshold: math.Inf(0)}).validate() == nil {
+	if (&PeerScoreThresholds{
+		SkipAtomicValidation:        skipAtomicValidation,
+		GossipThreshold:             -1,
+		PublishThreshold:            -2,
+		GraylistThreshold:           -3,
+		AcceptPXThreshold:           1,
+		OpportunisticGraftThreshold: math.Inf(0),
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
 }

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -380,39 +380,212 @@ func TestTopicScoreParamsValidation_NonAtomicValidation(t *testing.T) {
 	}
 }
 
-func TestPeerScoreParamsValidation(t *testing.T) {
+func TestPeerScoreParamsValidation_InvalidParams_AtomicValidation(t *testing.T) {
+	testPeerScoreParamsValidationWithInvalidParams(t, false)
+}
+
+func TestPeerScoreParamsValidation_InvalidParams_SkipAtomicValidation(t *testing.T) {
+	testPeerScoreParamsValidationWithInvalidParams(t, true)
+}
+
+func testPeerScoreParamsValidationWithInvalidParams(t *testing.T, skipAtomicValidation bool) {
 	appScore := func(peer.ID) float64 { return 0 }
 
-	if (&PeerScoreParams{TopicScoreCap: -1, AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01}).validate() == nil {
+	if (&PeerScoreParams{
+		SkipAtomicValidation: skipAtomicValidation,
+		TopicScoreCap:        -1,
+		AppSpecificScore:     appScore,
+		DecayInterval:        time.Second,
+		DecayToZero:          0.01,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{TopicScoreCap: 1, DecayInterval: time.Second, DecayToZero: 0.01}).validate() == nil {
+
+	if skipAtomicValidation {
+		if (&PeerScoreParams{
+			SkipAtomicValidation: skipAtomicValidation,
+			TopicScoreCap:        1,
+			DecayInterval:        time.Second,
+			DecayToZero:          0.01,
+		}).validate() != nil {
+			t.Fatal("expected validation success")
+		}
+	} else {
+		if (&PeerScoreParams{
+			SkipAtomicValidation: skipAtomicValidation,
+			TopicScoreCap:        1,
+			DecayInterval:        time.Second,
+			DecayToZero:          0.01,
+		}).validate() == nil {
+			t.Fatal("expected validation error")
+		}
+	}
+
+	if (&PeerScoreParams{
+		SkipAtomicValidation:     skipAtomicValidation,
+		TopicScoreCap:            1,
+		AppSpecificScore:         appScore,
+		DecayInterval:            time.Second,
+		DecayToZero:              0.01,
+		IPColocationFactorWeight: 1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{TopicScoreCap: 1, AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, IPColocationFactorWeight: 1}).validate() == nil {
+	if (&PeerScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		TopicScoreCap:               1,
+		AppSpecificScore:            appScore,
+		DecayInterval:               time.Second,
+		DecayToZero:                 0.01,
+		IPColocationFactorWeight:    -1,
+		IPColocationFactorThreshold: -1}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{TopicScoreCap: 1, AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, IPColocationFactorWeight: -1, IPColocationFactorThreshold: -1}).validate() == nil {
+	if (&PeerScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		TopicScoreCap:               1,
+		AppSpecificScore:            appScore,
+		DecayInterval:               time.Millisecond,
+		DecayToZero:                 0.01,
+		IPColocationFactorWeight:    -1,
+		IPColocationFactorThreshold: 1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{TopicScoreCap: 1, AppSpecificScore: appScore, DecayInterval: time.Millisecond, DecayToZero: 0.01, IPColocationFactorWeight: -1, IPColocationFactorThreshold: 1}).validate() == nil {
+	if (&PeerScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		TopicScoreCap:               1,
+		AppSpecificScore:            appScore,
+		DecayInterval:               time.Second,
+		DecayToZero:                 -1,
+		IPColocationFactorWeight:    -1,
+		IPColocationFactorThreshold: 1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{TopicScoreCap: 1, AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: -1, IPColocationFactorWeight: -1, IPColocationFactorThreshold: 1}).validate() == nil {
+	if (&PeerScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		TopicScoreCap:               1,
+		AppSpecificScore:            appScore,
+		DecayInterval:               time.Second,
+		DecayToZero:                 2,
+		IPColocationFactorWeight:    -1,
+		IPColocationFactorThreshold: 1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{TopicScoreCap: 1, AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 2, IPColocationFactorWeight: -1, IPColocationFactorThreshold: 1}).validate() == nil {
+	if (&PeerScoreParams{
+		SkipAtomicValidation:   skipAtomicValidation,
+		AppSpecificScore:       appScore,
+		DecayInterval:          time.Second,
+		DecayToZero:            0.01,
+		BehaviourPenaltyWeight: 1}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: 1}).validate() == nil {
+	if (&PeerScoreParams{
+		SkipAtomicValidation:   skipAtomicValidation,
+		AppSpecificScore:       appScore,
+		DecayInterval:          time.Second,
+		DecayToZero:            0.01,
+		BehaviourPenaltyWeight: -1,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: -1}).validate() == nil {
+	if (&PeerScoreParams{
+		SkipAtomicValidation:   skipAtomicValidation,
+		AppSpecificScore:       appScore,
+		DecayInterval:          time.Second,
+		DecayToZero:            0.01,
+		BehaviourPenaltyWeight: -1,
+		BehaviourPenaltyDecay:  2,
+	}).validate() == nil {
 		t.Fatal("expected validation error")
 	}
-	if (&PeerScoreParams{AppSpecificScore: appScore, DecayInterval: time.Second, DecayToZero: 0.01, BehaviourPenaltyWeight: -1, BehaviourPenaltyDecay: 2}).validate() == nil {
-		t.Fatal("expected validation error")
+
+	// Checks the topic parameters for invalid values such as infinite and
+	// NaN numbers.
+	if (&PeerScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		TopicScoreCap:               1,
+		AppSpecificScore:            appScore,
+		DecayInterval:               time.Second,
+		DecayToZero:                 0.01,
+		IPColocationFactorWeight:    -1,
+		IPColocationFactorThreshold: 1,
+		Topics: map[string]*TopicScoreParams{
+			"test": {
+				TopicWeight:                     math.Inf(0),
+				TimeInMeshWeight:                math.NaN(),
+				TimeInMeshQuantum:               time.Second,
+				TimeInMeshCap:                   10,
+				FirstMessageDeliveriesWeight:    math.Inf(1),
+				FirstMessageDeliveriesDecay:     0.5,
+				FirstMessageDeliveriesCap:       10,
+				MeshMessageDeliveriesWeight:     math.Inf(-1),
+				MeshMessageDeliveriesDecay:      math.NaN(),
+				MeshMessageDeliveriesCap:        math.Inf(0),
+				MeshMessageDeliveriesThreshold:  5,
+				MeshMessageDeliveriesWindow:     time.Millisecond,
+				MeshMessageDeliveriesActivation: time.Second,
+				MeshFailurePenaltyWeight:        -1,
+				MeshFailurePenaltyDecay:         math.NaN(),
+				InvalidMessageDeliveriesWeight:  math.Inf(0),
+				InvalidMessageDeliveriesDecay:   math.NaN(),
+			},
+		},
+	}).validate() == nil {
+		t.Fatal("expected validation failure")
 	}
+
+	if (&PeerScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		AppSpecificScore:            appScore,
+		DecayInterval:               time.Second,
+		DecayToZero:                 math.Inf(0),
+		IPColocationFactorWeight:    math.Inf(-1),
+		IPColocationFactorThreshold: 1,
+		BehaviourPenaltyWeight:      math.Inf(0),
+		BehaviourPenaltyDecay:       math.NaN(),
+	}).validate() == nil {
+		t.Fatal("expected validation failure")
+	}
+
+	if (&PeerScoreParams{
+		SkipAtomicValidation:        skipAtomicValidation,
+		TopicScoreCap:               1,
+		AppSpecificScore:            appScore,
+		DecayInterval:               time.Second,
+		DecayToZero:                 0.01,
+		IPColocationFactorWeight:    -1,
+		IPColocationFactorThreshold: 1,
+		Topics: map[string]*TopicScoreParams{
+			"test": {
+				TopicWeight:                     -1,
+				TimeInMeshWeight:                0.01,
+				TimeInMeshQuantum:               time.Second,
+				TimeInMeshCap:                   10,
+				FirstMessageDeliveriesWeight:    1,
+				FirstMessageDeliveriesDecay:     0.5,
+				FirstMessageDeliveriesCap:       10,
+				MeshMessageDeliveriesWeight:     -1,
+				MeshMessageDeliveriesDecay:      0.5,
+				MeshMessageDeliveriesCap:        10,
+				MeshMessageDeliveriesThreshold:  5,
+				MeshMessageDeliveriesWindow:     time.Millisecond,
+				MeshMessageDeliveriesActivation: time.Second,
+				MeshFailurePenaltyWeight:        -1,
+				MeshFailurePenaltyDecay:         0.5,
+				InvalidMessageDeliveriesWeight:  -1,
+				InvalidMessageDeliveriesDecay:   0.5,
+			},
+		},
+	}).validate() == nil {
+		t.Fatal("expected validation failure")
+	}
+}
+
+func TestPeerScoreParamsValidation_ValidParams_AtomicValidation(t *testing.T) {
+	appScore := func(peer.ID) float64 { return 0 }
 
 	// don't use these params in production!
 	if (&PeerScoreParams{
@@ -471,18 +644,52 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 	}).validate() != nil {
 		t.Fatal("expected validation success")
 	}
+}
+
+func TestPeerScoreParamsValidation_ValidParams_SkipAtomicValidation(t *testing.T) {
+	appScore := func(peer.ID) float64 { return 0 }
 
 	// don't use these params in production!
-	if (&PeerScoreParams{
-		TopicScoreCap:               1,
-		AppSpecificScore:            appScore,
-		DecayInterval:               time.Second,
-		DecayToZero:                 0.01,
-		IPColocationFactorWeight:    -1,
-		IPColocationFactorThreshold: 1,
-		Topics: map[string]*TopicScoreParams{
+	p := &PeerScoreParams{}
+	setParamAndValidate(t, p, func(params *PeerScoreParams) {
+		params.SkipAtomicValidation = true
+	})
+	setParamAndValidate(t, p, func(params *PeerScoreParams) {
+		params.AppSpecificScore = appScore
+	})
+	setParamAndValidate(t, p, func(params *PeerScoreParams) {
+		params.DecayInterval = time.Second
+		params.DecayToZero = 0.01
+	})
+	setParamAndValidate(t, p, func(params *PeerScoreParams) {
+		params.IPColocationFactorWeight = -1
+		params.IPColocationFactorThreshold = 1
+	})
+	setParamAndValidate(t, p, func(params *PeerScoreParams) {
+		params.BehaviourPenaltyWeight = -1
+		params.BehaviourPenaltyDecay = 0.999
+	})
+
+	p = &PeerScoreParams{SkipAtomicValidation: true, AppSpecificScore: appScore}
+	setParamAndValidate(t, p, func(params *PeerScoreParams) {
+		params.TopicScoreCap = 1
+	})
+	setParamAndValidate(t, p, func(params *PeerScoreParams) {
+		params.DecayInterval = time.Second
+		params.DecayToZero = 0.01
+	})
+	setParamAndValidate(t, p, func(params *PeerScoreParams) {
+		params.IPColocationFactorWeight = -1
+		params.IPColocationFactorThreshold = 1
+	})
+	setParamAndValidate(t, p, func(params *PeerScoreParams) {
+		params.BehaviourPenaltyWeight = -1
+		params.BehaviourPenaltyDecay = 0.999
+	})
+	setParamAndValidate(t, p, func(params *PeerScoreParams) {
+		params.Topics = map[string]*TopicScoreParams{
 			"test": {
-				TopicWeight:                     -1,
+				TopicWeight:                     1,
 				TimeInMeshWeight:                0.01,
 				TimeInMeshQuantum:               time.Second,
 				TimeInMeshCap:                   10,
@@ -500,64 +707,20 @@ func TestPeerScoreParamsValidation(t *testing.T) {
 				InvalidMessageDeliveriesWeight:  -1,
 				InvalidMessageDeliveriesDecay:   0.5,
 			},
-		},
-	}).validate() == nil {
-		t.Fatal("expected validation failure")
-	}
-
-	// Checks the topic parameters for invalid values such as infinite and
-	// NaN numbers.
-
-	// Don't use these params in production!
-	if (&PeerScoreParams{
-		AppSpecificScore:            appScore,
-		DecayInterval:               time.Second,
-		DecayToZero:                 math.Inf(0),
-		IPColocationFactorWeight:    math.Inf(-1),
-		IPColocationFactorThreshold: 1,
-		BehaviourPenaltyWeight:      math.Inf(0),
-		BehaviourPenaltyDecay:       math.NaN(),
-	}).validate() == nil {
-		t.Fatal("expected validation failure")
-	}
-
-	if (&PeerScoreParams{
-		TopicScoreCap:               1,
-		AppSpecificScore:            appScore,
-		DecayInterval:               time.Second,
-		DecayToZero:                 0.01,
-		IPColocationFactorWeight:    -1,
-		IPColocationFactorThreshold: 1,
-		Topics: map[string]*TopicScoreParams{
-			"test": {
-				TopicWeight:                     math.Inf(0),
-				TimeInMeshWeight:                math.NaN(),
-				TimeInMeshQuantum:               time.Second,
-				TimeInMeshCap:                   10,
-				FirstMessageDeliveriesWeight:    math.Inf(1),
-				FirstMessageDeliveriesDecay:     0.5,
-				FirstMessageDeliveriesCap:       10,
-				MeshMessageDeliveriesWeight:     math.Inf(-1),
-				MeshMessageDeliveriesDecay:      math.NaN(),
-				MeshMessageDeliveriesCap:        math.Inf(0),
-				MeshMessageDeliveriesThreshold:  5,
-				MeshMessageDeliveriesWindow:     time.Millisecond,
-				MeshMessageDeliveriesActivation: time.Second,
-				MeshFailurePenaltyWeight:        -1,
-				MeshFailurePenaltyDecay:         math.NaN(),
-				InvalidMessageDeliveriesWeight:  math.Inf(0),
-				InvalidMessageDeliveriesDecay:   math.NaN(),
-			},
-		},
-	}).validate() == nil {
-		t.Fatal("expected validation failure")
-	}
-
+		}
+	})
 }
 
 func TestScoreParameterDecay(t *testing.T) {
 	decay1hr := ScoreParameterDecay(time.Hour)
 	if decay1hr != .9987216039048303 {
 		t.Fatalf("expected .9987216039048303, got %f", decay1hr)
+	}
+}
+
+func setParamAndValidate(t *testing.T, params *PeerScoreParams, set func(*PeerScoreParams)) {
+	set(params)
+	if err := params.validate(); err != nil {
+		t.Fatalf("expected validation success, got: %s", err)
 	}
 }


### PR DESCRIPTION
In the context of peer scoring, looking at [how the parameters and thresholds are currently set](https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub.go#L270) at GossipSub, leaving some parameters unset, yields an error upon initialization of the GossipSub. For some applications and experimentations, we need to selectively set some of the parameters, e.g., only enabling staked participation in a permission setup. However, individual configuration of the scoring parameters is not feasible at the current state of GossipSub without setting all parameters and threshold values at their valid range. Missing even one parameter with a valid configuration fails the GossipSub instantiation.

This PR enables _non-atomic_ validation mode for the parameters and thresholds related to the peer scoring by adding a `SkipAtomicValidation` member field to the parameters and thresholds struct. By default, this variable is evaluated as `false`, i.e., zero value for `bool` data type. `!SkipAtomicValidation` indicates an atomic mode for validating thresholds and parameters which means all values must be set at their valid ranges. This is synonymous to how the validation is currently done at GossipSub. On the other hand, `SkipAtomicValidation` indicates a non-atomic mode for validating thresholds and parameters, which relaxes the validation criteria by allowing the application developer to selectively set _some of_ the parameters and threshold values. 

In contrast to the atomic validation mode which imposes all parameters and thresholds having a valid value, in the non-atomic mode, the parameters and thresholds can be left at their default (i.e., Golang zero) values as long as either all or none of the parameters related to the same context are set (e.g., mesh failure). 