### PR TITLE
Fix Memory Leak In New Timecache Implementations

### DIFF
--- a/timecache/first_seen_cache_test.go
+++ b/timecache/first_seen_cache_test.go
@@ -26,8 +26,10 @@ func TestFirstSeenCacheExpire(t *testing.T) {
 	}
 
 	time.Sleep(2 * time.Second)
-	if tc.Has(fmt.Sprint(0)) {
-		t.Fatal("should have dropped this from the cache already")
+	for i := 0; i < 10; i++ {
+		if tc.Has(fmt.Sprint(i)) {
+			t.Fatalf("should have dropped this key: %s from the cache already", fmt.Sprint(i))
+		}
 	}
 }
 

--- a/timecache/last_seen_cache_test.go
+++ b/timecache/last_seen_cache_test.go
@@ -25,8 +25,10 @@ func TestLastSeenCacheExpire(t *testing.T) {
 	}
 
 	time.Sleep(2 * time.Second)
-	if tc.Has(fmt.Sprint(0)) {
-		t.Fatal("should have dropped this from the cache already")
+	for i := 0; i < 11; i++ {
+		if tc.Has(fmt.Sprint(i)) {
+			t.Fatalf("should have dropped this key: %s from the cache already", fmt.Sprint(i))
+		}
 	}
 }
 

--- a/timecache/util.go
+++ b/timecache/util.go
@@ -9,7 +9,7 @@ import (
 var backgroundSweepInterval = time.Minute
 
 func background(ctx context.Context, lk sync.Locker, m map[string]time.Time) {
-	ticker := time.NewTimer(backgroundSweepInterval)
+	ticker := time.NewTicker(backgroundSweepInterval)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
In our latest release of prysm, we updated it to use version v0.9.2 of `go-libp2p-pubsub`. However, immediately after a few hours
we received multiple reports of memory leaks with prysm and prysm nodes constantly crashing with an OOM. After fetching a few profiles, this is what we found:

![image](https://user-images.githubusercontent.com/33201827/225288917-743f2ddf-7068-4829-b57b-fc45130a657e.png)

The majority of heap usage was being consumed by the first seen cache. After digging into it and the PR which introduced it 
https://github.com/libp2p/go-libp2p-pubsub/pull/523 , it was found out that the background routine was not clearing our expired entries from the cache. This is because it used `NewTimer` instead of `NewTicker` when performing the sweep. So this would only fire an event once into the channel and fire no more events after. 

This PR introduces the fix along with fixing the test so that this particular case is correctly checked for. 