### PR TITLE
use event bus for monitoring peer connections and protocol updates

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -20,9 +20,6 @@ func (p *PubSubNotif) startMonitoring() error {
 		return fmt.Errorf("unable to subscribe to EventBus: %w", err)
 	}
 
-	// add current peers
-	p.addPeers(p.host.Network().Peers()...)
-
 	go func() {
 		defer sub.Close()
 
@@ -38,7 +35,7 @@ func (p *PubSubNotif) startMonitoring() error {
 			case event.EvtPeerConnectednessChanged:
 				// send record to connected peer only
 				if evt.Connectedness == network.Connected {
-					go p.addPeers(evt.Peer)
+					go p.AddPeers(evt.Peer)
 				}
 			case event.EvtPeerProtocolsUpdated:
 				supportedProtocols := p.rt.Protocols()
@@ -47,7 +44,7 @@ func (p *PubSubNotif) startMonitoring() error {
 				for _, addedProtocol := range evt.Added {
 					for _, wantedProtocol := range supportedProtocols {
 						if wantedProtocol == addedProtocol {
-							go p.addPeers(evt.Peer)
+							go p.AddPeers(evt.Peer)
 							break protocol_loop
 						}
 					}
@@ -69,7 +66,7 @@ func (p *PubSubNotif) isTransient(pid peer.ID) bool {
 	return true
 }
 
-func (p *PubSubNotif) addPeers(peers ...peer.ID) {
+func (p *PubSubNotif) AddPeers(peers ...peer.ID) {
 	p.newPeersPrioLk.RLock()
 	p.newPeersMx.Lock()
 

--- a/notify_test.go
+++ b/notify_test.go
@@ -1,0 +1,76 @@
+package pubsub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
+)
+
+func TestNotifyPeerProtocolsUpdated(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hosts := getNetHosts(t, ctx, 2)
+
+	// Initialize id services.
+	{
+		ids1, err := identify.NewIDService(hosts[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids1.Start()
+		defer ids1.Close()
+
+		ids2, err := identify.NewIDService(hosts[1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids2.Start()
+		defer ids2.Close()
+	}
+
+	psubs0 := getPubsub(ctx, hosts[0])
+	connect(t, hosts[0], hosts[1])
+	// Delay to make sure that peers are connected.
+	<-time.After(time.Millisecond * 100)
+	psubs1 := getPubsub(ctx, hosts[1])
+
+	// Pubsub 0 joins topic "test".
+	topic0, err := psubs0.Join("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer topic0.Close()
+
+	sub0, err := topic0.Subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub0.Cancel()
+
+	// Pubsub 1 joins topic "test".
+	topic1, err := psubs1.Join("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer topic1.Close()
+
+	sub1, err := topic1.Subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub1.Cancel()
+
+	// Delay before checking results (similar to most tests).
+	<-time.After(time.Millisecond * 100)
+
+	if len(topic0.ListPeers()) == 0 {
+		t.Fatalf("topic0 should at least have 1 peer")
+	}
+
+	if len(topic1.ListPeers()) == 0 {
+		t.Fatalf("topic1 should at least have 1 peer")
+	}
+}

--- a/pubsub.go
+++ b/pubsub.go
@@ -327,13 +327,14 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 			h.SetStreamHandler(id, ps.handleNewStream)
 		}
 	}
-	h.Network().Notify((*PubSubNotif)(ps))
 
 	ps.val.Start(ps)
 
 	go ps.processLoop(ctx)
 
-	(*PubSubNotif)(ps).Initialize()
+	if err := (*PubSubNotif)(ps).startMonitoring(); err != nil {
+		return nil, fmt.Errorf("unable to start pubsub monitoring: %w", err)
+	}
 
 	return ps, nil
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -328,13 +328,18 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		}
 	}
 
+	// start monitoring for new peers
+	notify := (*PubSubNotif)(ps)
+	if err := notify.startMonitoring(); err != nil {
+		return nil, fmt.Errorf("unable to start pubsub monitoring: %w", err)
+	}
+
 	ps.val.Start(ps)
 
 	go ps.processLoop(ctx)
 
-	if err := (*PubSubNotif)(ps).startMonitoring(); err != nil {
-		return nil, fmt.Errorf("unable to start pubsub monitoring: %w", err)
-	}
+	// add current peers to notify system
+	notify.AddPeers(h.Network().Peers()...)
 
 	return ps, nil
 }


### PR DESCRIPTION
This fixes a bug where another peer is not added to a topic after subscribing. This bug happens, for example, when a discovery system (like MDNS) is set up before pubsub initialization. Even though the peers have been discovered, they are not added to the new pubsub topics.

The bug can be seen by running [TestNotifyPeerProtocolsUpdated](https://github.com/jefft0/go-libp2p-pubsub/blob/15e9deb37922aa06420eb905fab1e898eefe90bc/notify_test.go#L11) in the master branch:

    git clone https://github.com/libp2p/go-libp2p-pubsub
    cd go-libp2p-pubsub
    curl https://raw.githubusercontent.com/jefft0/go-libp2p-pubsub/fix/notify-protocol-update/notify_test.go -o notify_test.go
    go test -run TestNotifyPeerProtocolsUpdated .

It prints "topic1 should at least have 1 peer". In our code we had to workaround this by disabling discovery (MDNS) and deferring discovery until after the pubsub protocols are registered. However, this pull request fixes the problem so that a workaround is not needed. It uses the event bus to monitor for peer connections and protocol updates. When `hosts[1]` joins `topic1`, the other peer is automatically added and the test passes.