### PR TITLE
fix: topicscore params can't be set for dynamically subscribed topic

### DIFF
--- a/score.go
+++ b/score.go
@@ -202,7 +202,7 @@ func (ps *peerScore) SetTopicScoreParams(topic string, p *TopicScoreParams) erro
 	ps.Lock()
 	defer ps.Unlock()
 
-	old, _ := ps.params.Topics[topic]
+	old := ps.params.Topics[topic]
 	ps.params.Topics[topic] = p
 
 	// check to see if the counter Caps are being lowered; if that's the case we need to recap them

--- a/score.go
+++ b/score.go
@@ -202,12 +202,8 @@ func (ps *peerScore) SetTopicScoreParams(topic string, p *TopicScoreParams) erro
 	ps.Lock()
 	defer ps.Unlock()
 
-	old, exist := ps.params.Topics[topic]
+	old, _ := ps.params.Topics[topic]
 	ps.params.Topics[topic] = p
-
-	if !exist {
-		return nil
-	}
 
 	// check to see if the counter Caps are being lowered; if that's the case we need to recap them
 	recap := false


### PR DESCRIPTION
topicscore params can't be set for a topic subscribed after gossipsub is initialized.

Fixed #533 