### PR TITLE
Revert "fix: topicscore params can't be set for dynamically subscribed topic"

### DIFF
--- a/score.go
+++ b/score.go
@@ -202,8 +202,12 @@ func (ps *peerScore) SetTopicScoreParams(topic string, p *TopicScoreParams) erro
 	ps.Lock()
 	defer ps.Unlock()
 
-	old := ps.params.Topics[topic]
+	old, exist := ps.params.Topics[topic]
 	ps.params.Topics[topic] = p
+
+	if !exist {
+		return nil
+	}
 
 	// check to see if the counter Caps are being lowered; if that's the case we need to recap them
 	recap := false


### PR DESCRIPTION
Reverts libp2p/go-libp2p-pubsub#540

This needs to be reverted; the check was necessary and not impeding the setting.
Without the check, if the topic score params did not previously exist, it will crash with nil pointer dereference.