### PR TITLE
remove usage of deprecated peerid.Pretty method

### DIFF
--- a/discovery_test.go
+++ b/discovery_test.go
@@ -170,7 +170,7 @@ func TestSimpleDiscovery(t *testing.T) {
 
 	for i, h := range hosts[1:] {
 		if !server.hasPeerRecord("floodsub:"+topic, h.ID()) {
-			t.Fatalf("Server did not register host %d with ID: %s", i+1, h.ID().Pretty())
+			t.Fatalf("Server did not register host %d with ID: %s", i+1, h.ID())
 		}
 	}
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1183,7 +1183,7 @@ func (gs *GossipSubRouter) sendRPC(p peer.ID, out *RPC) {
 }
 
 func (gs *GossipSubRouter) doDropRPC(rpc *RPC, p peer.ID, reason string) {
-	log.Debugf("dropping message to peer %s: %s", p.Pretty(), reason)
+	log.Debugf("dropping message to peer %s: %s", p, reason)
 	gs.tracer.DropRPC(rpc, p)
 	// push control messages that need to be retried
 	ctl := rpc.GetControl()

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1161,7 +1161,7 @@ func TestGossipsubStarTopologyWithSignedPeerRecords(t *testing.T) {
 	for i := range hosts[1:] {
 		privKey := hosts[i].Peerstore().PrivKey(hosts[i].ID())
 		if privKey == nil {
-			t.Fatalf("unable to get private key for host %s", hosts[i].ID().Pretty())
+			t.Fatalf("unable to get private key for host %s", hosts[i].ID())
 		}
 		ai := host.InfoFromHost(hosts[i])
 		rec := peer.PeerRecordFromAddrInfo(*ai)


### PR DESCRIPTION
This will be removed in the next go-libp2p version: https://github.com/libp2p/go-libp2p/pull/2565
