### PR TITLE
fix: Don't bother parsing an empty slice

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -77,6 +77,9 @@ func (p *PubSub) handleNewStream(s network.Stream) {
 
 			return
 		}
+		if len(msgbytes) == 0 {
+			continue
+		}
 
 		rpc := new(RPC)
 		err = rpc.Unmarshal(msgbytes)


### PR DESCRIPTION
A slight optimization if we know there's nothing to parse.