### PR TITLE
Missing flood protection check for number of message IDs when handling `Ihave` messages 

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -683,13 +683,11 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 	}
 
 	// IHAVE flood protection
-	// prevent the remote peer from sending too many IHAVE messages
 	gs.peerhave[p]++
 	if gs.peerhave[p] > gs.params.MaxIHaveMessages {
 		log.Debugf("IHAVE: peer %s has advertised too many times (%d) within this heartbeat interval; ignoring", p, gs.peerhave[p])
 		return nil
 	}
-	// prevent ourselfs to process Ihaves if we reached the max sent message ID limit
 	if gs.iasked[p] >= gs.params.MaxIHaveLength {
 		log.Debugf("IHAVE: peer %s has already advertised too many messages (%d); ignoring", p, gs.iasked[p])
 		return nil


### PR DESCRIPTION
# Description
After looking at the gossipsub `Iwant`/`Ihave` handlers, I realised that there is a missing spam prevention check when opening the `Ihave` messages from a received `ControlMessage`.

To give some context, [the spec](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#spam-protection-measures) defines that each Ihave message should have an upper limit of aggregated message IDs, which in this go implementation is defined by [`maxMessageLength = 5_000`](https://github.com/libp2p/go-libp2p-pubsub/blob/dbd1c9eadedc402fa40ba3e45296594d7e828110/gossipsub.go#L59) message IDs per Ihave and topic, as `Ihave` messages [can be aggregated in a single RPC call](https://github.com/libp2p/go-libp2p-pubsub/blob/dbd1c9eadedc402fa40ba3e45296594d7e828110/gossipsub.go#L1256).

This spam check is already done at the moment of [emitting the Gossips](https://github.com/libp2p/go-libp2p-pubsub/blob/dbd1c9eadedc402fa40ba3e45296594d7e828110/gossipsub.go#L1782). However, I can't see a similar check at the moment of [handling each of the message IDs](https://github.com/libp2p/go-libp2p-pubsub/blob/dbd1c9eadedc402fa40ba3e45296594d7e828110/gossipsub.go#L698) within the `Ihave` messages.

We do checked that the remote peer stayed within the number of `Ihave` messages, and that we didn't exceed the message ID count for asked messages, but it doesn't check anything related to the size of the array of message IDs per each topic I have. 

This PR adds that missing spam protection step, ensuring that we only read the first `maxMessageLength` messages of each `Ihave` as @MarcoPolo suggested.

Let me know if there is anything else that should be added or modified. 