### PR TITLE
Added missing Close call on the AddrBook member of GossipSubRouter

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -3,6 +3,7 @@ package pubsub
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
 	"sort"
 	"time"
@@ -543,6 +544,13 @@ func (gs *GossipSubRouter) manageAddrBook() {
 	for {
 		select {
 		case <-gs.p.ctx.Done():
+			cabCloser, ok := gs.cab.(io.Closer)
+			if ok {
+				errClose := cabCloser.Close()
+				if errClose != nil {
+					log.Warnf("failed to close addr book: %v", errClose)
+				}
+			}
 			return
 		case ev := <-sub.Out():
 			switch ev := ev.(type) {


### PR DESCRIPTION
While upgrading our dependency from v0.9.3 to v0.11.0, our goroutine monitoring tests reported a hanging goroutine from pubsub.

Digging a bit, we discovered that v0.11.0 added a new AddrBook member of GossipSubRouter, but Close method of this is never called.

I've created this PR with the fix. Probably the proper fix would be to also update the AddrBook interface from go-libp2p to export the Close method. This way the cast would be avoided.