### PR TITLE
ci: disable testing on macos

### DIFF
--- a/.github/workflows/go-test-config.json
+++ b/.github/workflows/go-test-config.json
@@ -1,4 +1,4 @@
 {
-  "skipOSes": ["windows"],
+  "skipOSes": ["windows", "macos"],
   "skipRace": true
 }


### PR DESCRIPTION
It appears to be a bit flaky and we have nothing macos specific in this repo.