### PR TITLE
fix: stop timer in a way that works before and after go1.23

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -245,9 +245,7 @@ func (d *discover) Bootstrap(ctx context.Context, topic string, ready RouterRead
 	}
 
 	t := time.NewTimer(time.Hour)
-	if !t.Stop() {
-		<-t.C
-	}
+	t.Stop()
 	defer t.Stop()
 
 	for {


### PR DESCRIPTION
In this case, a stopped timer is created. Since the timer duration is set to 1 hour and is immediately stopped, the timer should never fire and the channel should never need to be cleared (as is generally needed for go1.22). For go-1.23 the timer semantics have changed so that reading the timer channel following Stop will always block. Therefore, for both these cases, only calling Stop is sufficient to create the stopped timer.