### PR TITLE
Fix the Router's Ability to Prune the Mesh Periodically

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1605,7 +1605,7 @@ func (gs *GossipSubRouter) heartbeat() {
 		}
 
 		// do we have too many peers?
-		if len(peers) > gs.params.Dhi {
+		if len(peers) >= gs.params.Dhi {
 			plst := peerMapToList(peers)
 
 			// sort by score (but shuffle first for the case we don't use the score)


### PR DESCRIPTION
When a new peer wants to graft us into their mesh, we check our current mesh size to determine whether we can add any more new peers to it. This is done to prevent our mesh size from being greater than `Dhi`  and prevent mesh takeover attacks here:

https://github.com/libp2p/go-libp2p-pubsub/blob/c06df2f9a38e9382e644b241adf0e96e5ca00955/gossipsub.go#L943

During every heartbeat we check our mesh size and if it is **greater** than `Dhi` then we will prune our mesh back down to `D`. 
https://github.com/libp2p/go-libp2p-pubsub/blob/c06df2f9a38e9382e644b241adf0e96e5ca00955/gossipsub.go#L1608

However if you look closely at both lines there is a problematic end result. Since we only stop grafting new peers into our mesh if our current mesh size is **greater than or equal to** `Dhi` and we only prune peers if the current mesh size is greater than `Dhi`. 

This would result in the mesh being in a state of stasis at `Dhi`. Rather than float between `D` and `Dhi` , the mesh stagnates at `Dhi` . This would end up increasing the target degree of the node to `Dhi` from `D`. This had been observed in ethereum mainnet by recording mesh interactions and message fulfillment from those peers.

This PR fixes it by adding an equality check to the conditional so that it can be periodically pruned.  The PR also adds a regression test for this particular case.
 