### PR TITLE
Improve IDONTWANT Flood Protection

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -68,8 +68,8 @@ var (
 	GossipSubGraftFloodThreshold              = 10 * time.Second
 	GossipSubMaxIHaveLength                   = 5000
 	GossipSubMaxIHaveMessages                 = 10
-	GossipSubMaxIDontWantLength               = 100
-	GossipSubMaxIDontWantMessages             = 100
+	GossipSubMaxIDontWantLength               = 10
+	GossipSubMaxIDontWantMessages             = 1000
 	GossipSubIWantFollowupTime                = 3 * time.Second
 	GossipSubIDontWantMessageThreshold        = 1024 // 1KB
 	GossipSubIDontWantMessageTTL              = 3    // 3 heartbeats


### PR DESCRIPTION
In this PR we add in a new config parameter called `MaxIDontWantLength`  which would be very similarly used as `MaxIHaveLength` has been used of `IHAVE` messgaes . This parameter has been set as the value of `10` now. 

The main purpose is to bring how IDONTWANT messages are handled in line with how IHAVE have been handled. We add the relevant changes to the `handleIDontWant` method along with adding in a new regression test for this check. 