### PR TITLE
Allow Batch Publishing For Applications

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -1163,7 +1163,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 				continue
 			}
 
-			msg := &Message{pmsg, "", rpc.from, nil, false}
+			msg := &Message{pmsg, "", rpc.from, nil, false, nil}
 			if p.shouldPush(msg) {
 				toPush = append(toPush, msg)
 			}

--- a/topic.go
+++ b/topic.go
@@ -346,9 +346,9 @@ func WithSecretKeyAndPeerId(key crypto.PrivKey, pid peer.ID) PubOpt {
 }
 
 // WithBatchPublishing returns a publishing option that allows multiple messages to be published as a batch
-// rather than sequentially. The desired messages have their message-ids provided as an argument. This allows
+// rather than sequentially. The desired messages are already added in to the batch message object. This allows
 // the different rpc messages to mesh or direct peers to be interleaved with each other. In order for the batch
-// to succeed, all messages in the batch must be published if not the routine would terminate.
+// to succeed, all messages in the batch must be published via the router if not the batch will never be published.
 func WithBatchPublishing(msgBatch *BatchMessage) PubOpt {
 	return func(pub *PublishOptions) error {
 		pub.batchedMessages = msgBatch


### PR DESCRIPTION
For a more detailed reasoning on the motivation for this:
https://ethresear.ch/t/improving-das-performance-with-gossipsub-batch-publishing/21713

 
This pull request adds in a new publishing option that allows messages to be published as a batch instead of being queued and sent out individually. Why would this be desired ? Applications can send out multiple messages at the same time. In the event a node has constrained upload bandwidth and these messages are large, the router would take up a longer than desired time sending out `D` copies to all mesh peers for the first message published. This can add a non-trivial amount of latency for the other messages being propagated to the rest of the network. 

This option allows these messages and their copies to be shuffled randomly and then queued in a random order and sent out to their respective peers. This allows for the first copy of any message in the batch to be propagated to the rest of the network much faster. With a first copy being sent out quicker, this leads to earlier message arrival time for the whole network. 

- [x] Add Batch Publishing Option.
- [x] Add Batch Message Object to track all the desired message ids and the rpc messages to be published to individual peers.
- [x] Allow Publishing of the whole batch once it is complete.
- [ ] Add Tests that the feature works as expected.  