### PR TITLE
feat(gossipsub): Add MessageBatch

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1142,15 +1142,16 @@ func (gs *GossipSubRouter) connector() {
 	}
 }
 
-func (gs *GossipSubRouter) PublishBatch(batch *MessageBatch) {
-	for _, msg := range batch.messages {
+func (gs *GossipSubRouter) PublishBatch(messages []*Message, opts *BatchPublishOptions) {
+	strategy := opts.Strategy
+	for _, msg := range messages {
 		msgID := gs.p.idGen.ID(msg)
 		for p, rpc := range gs.rpcs(msg) {
-			batch.Scheduler.AddRPC(p, msgID, rpc)
+			strategy.AddRPC(p, msgID, rpc)
 		}
 	}
 
-	for p, rpc := range batch.Scheduler.All() {
+	for p, rpc := range strategy.All() {
 		gs.sendRPC(p, rpc, false)
 	}
 }

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1146,11 +1146,11 @@ func (gs *GossipSubRouter) PublishBatch(batch *MessageBatch) {
 	for _, msg := range batch.messages {
 		msgID := gs.p.idGen.ID(msg)
 		for p, rpc := range gs.rpcs(msg) {
-			batch.Strategy.AddRPC(p, msgID, rpc)
+			batch.Scheduler.AddRPC(p, msgID, rpc)
 		}
 	}
 
-	for p, rpc := range batch.Strategy.All() {
+	for p, rpc := range batch.Scheduler.All() {
 		gs.sendRPC(p, rpc, false)
 	}
 }

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -3435,11 +3435,11 @@ func BenchmarkRarestFirstRPCScheduler(b *testing.B) {
 	var strategy RarestFirstRPCScheduler
 
 	peers := make([]peer.ID, numPeers)
-	for i := 0; i < int(numPeers); i++ {
+	for i := range int(numPeers) {
 		peers[i] = peer.ID(fmt.Sprintf("peer%d", i))
 	}
 	msgs := make([]string, numMessages)
-	for i := 0; i < numMessages; i++ {
+	for i := range numMessages {
 		msgs[i] = fmt.Sprintf("msg%d", i)
 	}
 

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -3411,8 +3411,8 @@ func TestRarestFirstRPCScheduler(t *testing.T) {
 
 		// 3.
 		inputSet := make(map[string]bool)
-		for i := 0; i < int(numMessages); i++ {
-			for j := 0; j < int(numPeers); j++ {
+		for i := range int(numMessages) {
+			for j := range int(numPeers) {
 				inputSet[fmt.Sprintf("msg%d:peer%d", i, j)] = true
 			}
 		}

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -3451,7 +3451,7 @@ func BenchmarkRarestFirstRPCScheduler(b *testing.B) {
 		msgIdx := i % numMessages
 		strategy.AddRPC(peers[j], msgs[msgIdx], emptyRPC)
 		if i%100 == 0 {
-			for _, _ = range strategy.All() {
+			for range strategy.All() {
 			}
 		}
 	}

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -3337,7 +3337,7 @@ func BenchmarkAllocDoDropRPC(b *testing.B) {
 	}
 }
 
-func TestRarestFirstPublishStrategy(t *testing.T) {
+func TestRarestFirstRPCScheduler(t *testing.T) {
 	const maxNumPeers = 256
 	const maxNumMessages = 1_000
 
@@ -3347,7 +3347,7 @@ func TestRarestFirstPublishStrategy(t *testing.T) {
 
 		output := make([]pendingRPC, 0, numMessages*numPeers)
 
-		var strategy RarestFirstStrategy
+		var strategy RarestFirstRPCScheduler
 
 		peers := make([]peer.ID, numPeers)
 		for i := 0; i < int(numPeers); i++ {
@@ -3429,10 +3429,10 @@ func TestRarestFirstPublishStrategy(t *testing.T) {
 	}
 }
 
-func BenchmarkRarestFirstPublishStrategy(b *testing.B) {
+func BenchmarkRarestFirstRPCScheduler(b *testing.B) {
 	const numPeers = 1_000
 	const numMessages = 1_000
-	var strategy RarestFirstStrategy
+	var strategy RarestFirstRPCScheduler
 
 	peers := make([]peer.ID, numPeers)
 	for i := 0; i < int(numPeers); i++ {

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -3337,7 +3337,7 @@ func BenchmarkAllocDoDropRPC(b *testing.B) {
 	}
 }
 
-func TestRarestFirstRPCScheduler(t *testing.T) {
+func TestRoundRobinMessageIDScheduler(t *testing.T) {
 	const maxNumPeers = 256
 	const maxNumMessages = 1_000
 
@@ -3347,7 +3347,7 @@ func TestRarestFirstRPCScheduler(t *testing.T) {
 
 		output := make([]pendingRPC, 0, numMessages*numPeers)
 
-		var strategy RarestFirstRPCScheduler
+		var strategy RoundRobinMessageIDScheduler
 
 		peers := make([]peer.ID, numPeers)
 		for i := 0; i < int(numPeers); i++ {
@@ -3429,10 +3429,10 @@ func TestRarestFirstRPCScheduler(t *testing.T) {
 	}
 }
 
-func BenchmarkRarestFirstRPCScheduler(b *testing.B) {
+func BenchmarkRoundRobinMessageIDScheduler(b *testing.B) {
 	const numPeers = 1_000
 	const numMessages = 1_000
-	var strategy RarestFirstRPCScheduler
+	var strategy RoundRobinMessageIDScheduler
 
 	peers := make([]peer.ID, numPeers)
 	for i := range int(numPeers) {

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -3520,3 +3520,25 @@ func TestMessageBatchPublish(t *testing.T) {
 		}
 	}
 }
+
+func TestPublishDuplicateMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hosts := getDefaultHosts(t, 1)
+	psubs := getGossipsubs(ctx, hosts, WithMessageIdFn(func(msg *pb.Message) string {
+		return string(msg.Data)
+	}))
+	topic, err := psubs[0].Join("foobar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = topic.Publish(ctx, []byte("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = topic.Publish(ctx, []byte("hello"))
+	if err != nil {
+		t.Fatal("Duplicate message should not return an error")
+	}
+}

--- a/messagebatch.go
+++ b/messagebatch.go
@@ -1,0 +1,64 @@
+package pubsub
+
+import (
+	"iter"
+	"sync"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// MessageBatch allows a user to batch related messages and then publish them
+// at once. This allows the system to prioritize sending a single copy of each
+// message before sending more copies. This helps bandwidth constrained peers.
+type MessageBatch struct {
+	Strategy BatchPublishStrategy
+	messages []*Message
+}
+
+// BatchPublishStrategy is the publishing strategy publishing a batch of messages.
+type BatchPublishStrategy interface {
+	// AddRPC adds an RPC to the strategy.
+	AddRPC(peer peer.ID, msgID string, rpc *RPC)
+	// All returns an ordered sequence of RPCs to publish.
+	All() iter.Seq2[peer.ID, *RPC]
+}
+
+type pendingRPC struct {
+	peer peer.ID
+	rpc  *RPC
+}
+
+type RarestFirstStrategy struct {
+	sync.Mutex
+	rpcs map[string][]pendingRPC
+}
+
+func (s *RarestFirstStrategy) AddRPC(peer peer.ID, msgID string, rpc *RPC) {
+	s.Lock()
+	defer s.Unlock()
+	if s.rpcs == nil {
+		s.rpcs = make(map[string][]pendingRPC)
+	}
+	s.rpcs[msgID] = append(s.rpcs[msgID], pendingRPC{peer: peer, rpc: rpc})
+}
+
+func (s *RarestFirstStrategy) All() iter.Seq2[peer.ID, *RPC] {
+	return func(yield func(peer.ID, *RPC) bool) {
+		s.Lock()
+		defer s.Unlock()
+
+		for len(s.rpcs) > 0 {
+			for msgID, rpcs := range s.rpcs {
+				if len(rpcs) == 0 {
+					delete(s.rpcs, msgID)
+					continue
+				}
+				if !yield(rpcs[0].peer, rpcs[0].rpc) {
+					return
+				}
+
+				s.rpcs[msgID] = rpcs[1:]
+			}
+		}
+	}
+}

--- a/messagebatch.go
+++ b/messagebatch.go
@@ -31,18 +31,19 @@ type pendingRPC struct {
 	rpc  *RPC
 }
 
-type RarestFirstRPCScheduler struct {
+// RoundRobinMessageIDScheduler schedules outgoing RPCs in round-robin order of message IDs.
+type RoundRobinMessageIDScheduler struct {
 	rpcs map[string][]pendingRPC
 }
 
-func (s *RarestFirstRPCScheduler) AddRPC(peer peer.ID, msgID string, rpc *RPC) {
+func (s *RoundRobinMessageIDScheduler) AddRPC(peer peer.ID, msgID string, rpc *RPC) {
 	if s.rpcs == nil {
 		s.rpcs = make(map[string][]pendingRPC)
 	}
 	s.rpcs[msgID] = append(s.rpcs[msgID], pendingRPC{peer: peer, rpc: rpc})
 }
 
-func (s *RarestFirstRPCScheduler) All() iter.Seq2[peer.ID, *RPC] {
+func (s *RoundRobinMessageIDScheduler) All() iter.Seq2[peer.ID, *RPC] {
 	return func(yield func(peer.ID, *RPC) bool) {
 		for len(s.rpcs) > 0 {
 			for msgID, rpcs := range s.rpcs {

--- a/messagebatch.go
+++ b/messagebatch.go
@@ -2,7 +2,6 @@ package pubsub
 
 import (
 	"iter"
-	"sync"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -29,13 +28,10 @@ type pendingRPC struct {
 }
 
 type RarestFirstRPCScheduler struct {
-	sync.Mutex
 	rpcs map[string][]pendingRPC
 }
 
 func (s *RarestFirstRPCScheduler) AddRPC(peer peer.ID, msgID string, rpc *RPC) {
-	s.Lock()
-	defer s.Unlock()
 	if s.rpcs == nil {
 		s.rpcs = make(map[string][]pendingRPC)
 	}
@@ -44,9 +40,6 @@ func (s *RarestFirstRPCScheduler) AddRPC(peer peer.ID, msgID string, rpc *RPC) {
 
 func (s *RarestFirstRPCScheduler) All() iter.Seq2[peer.ID, *RPC] {
 	return func(yield func(peer.ID, *RPC) bool) {
-		s.Lock()
-		defer s.Unlock()
-
 		for len(s.rpcs) > 0 {
 			for msgID, rpcs := range s.rpcs {
 				if len(rpcs) == 0 {

--- a/messagebatch.go
+++ b/messagebatch.go
@@ -28,12 +28,12 @@ type pendingRPC struct {
 	rpc  *RPC
 }
 
-type RarestFirstStrategy struct {
+type RarestFirstRPCScheduler struct {
 	sync.Mutex
 	rpcs map[string][]pendingRPC
 }
 
-func (s *RarestFirstStrategy) AddRPC(peer peer.ID, msgID string, rpc *RPC) {
+func (s *RarestFirstRPCScheduler) AddRPC(peer peer.ID, msgID string, rpc *RPC) {
 	s.Lock()
 	defer s.Unlock()
 	if s.rpcs == nil {
@@ -42,7 +42,7 @@ func (s *RarestFirstStrategy) AddRPC(peer peer.ID, msgID string, rpc *RPC) {
 	s.rpcs[msgID] = append(s.rpcs[msgID], pendingRPC{peer: peer, rpc: rpc})
 }
 
-func (s *RarestFirstStrategy) All() iter.Seq2[peer.ID, *RPC] {
+func (s *RarestFirstRPCScheduler) All() iter.Seq2[peer.ID, *RPC] {
 	return func(yield func(peer.ID, *RPC) bool) {
 		s.Lock()
 		defer s.Unlock()

--- a/messagebatch.go
+++ b/messagebatch.go
@@ -10,8 +10,12 @@ import (
 // once. This allows the Scheduler to define an order for outgoing RPCs.
 // This helps bandwidth constrained peers.
 type MessageBatch struct {
-	Scheduler RPCScheduler
-	messages  []*Message
+	messages []*Message
+}
+
+type messageBatchAndPublishOptions struct {
+	messages []*Message
+	opts     *BatchPublishOptions
 }
 
 // RPCScheduler schedules outgoing RPCs.

--- a/messagebatch.go
+++ b/messagebatch.go
@@ -8,18 +8,18 @@ import (
 )
 
 // MessageBatch allows a user to batch related messages and then publish them at
-// once. This allows the Scheduler to define an order for the outgoing RPCs.
+// once. This allows the Scheduler to define an order for outgoing RPCs.
 // This helps bandwidth constrained peers.
 type MessageBatch struct {
 	Scheduler RPCScheduler
 	messages  []*Message
 }
 
-// RPCScheduler is the publishing strategy publishing a set of RPCs.
+// RPCScheduler schedules outgoing RPCs.
 type RPCScheduler interface {
-	// AddRPC adds an RPC to the strategy.
+	// AddRPC adds an RPC to the scheduler.
 	AddRPC(peer peer.ID, msgID string, rpc *RPC)
-	// All returns an ordered iterator of RPCs to publish.
+	// All returns an ordered iterator of RPCs.
 	All() iter.Seq2[peer.ID, *RPC]
 }
 

--- a/messagebatch.go
+++ b/messagebatch.go
@@ -7,19 +7,19 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-// MessageBatch allows a user to batch related messages and then publish them
-// at once. This allows the system to prioritize sending a single copy of each
-// message before sending more copies. This helps bandwidth constrained peers.
+// MessageBatch allows a user to batch related messages and then publish them at
+// once. This allows the Scheduler to define an order for the outgoing RPCs.
+// This helps bandwidth constrained peers.
 type MessageBatch struct {
-	Strategy BatchPublishStrategy
-	messages []*Message
+	Scheduler RPCScheduler
+	messages  []*Message
 }
 
-// BatchPublishStrategy is the publishing strategy publishing a batch of messages.
-type BatchPublishStrategy interface {
+// RPCScheduler is the publishing strategy publishing a set of RPCs.
+type RPCScheduler interface {
 	// AddRPC adds an RPC to the strategy.
 	AddRPC(peer peer.ID, msgID string, rpc *RPC)
-	// All returns an ordered sequence of RPCs to publish.
+	// All returns an ordered iterator of RPCs to publish.
 	All() iter.Seq2[peer.ID, *RPC]
 }
 

--- a/pubsub.go
+++ b/pubsub.go
@@ -1392,14 +1392,14 @@ func (p *PubSub) PublishBatch(batch *MessageBatch) error {
 
 	// Copy the batch to avoid the footgun of reusing strategy state across batches
 	var copy MessageBatch
-	copy.Strategy = batch.Strategy
+	copy.Scheduler = batch.Scheduler
 	copy.messages = batch.messages
-	batch.Strategy = nil
+	batch.Scheduler = nil
 	batch.messages = nil
 
-	if copy.Strategy == nil {
+	if copy.Scheduler == nil {
 		// Default to RarestFirstStrategy
-		copy.Strategy = &RarestFirstStrategy{}
+		copy.Scheduler = &RarestFirstStrategy{}
 	}
 
 	p.sendMessageBatch <- &copy

--- a/pubsub.go
+++ b/pubsub.go
@@ -1399,7 +1399,7 @@ func (p *PubSub) PublishBatch(batch *MessageBatch) error {
 
 	if copy.Scheduler == nil {
 		// Default to RarestFirstStrategy
-		copy.Scheduler = &RarestFirstStrategy{}
+		copy.Scheduler = &RarestFirstRPCScheduler{}
 	}
 
 	p.sendMessageBatch <- &copy

--- a/pubsub.go
+++ b/pubsub.go
@@ -1385,6 +1385,8 @@ func (p *PubSub) Publish(topic string, data []byte, opts ...PubOpt) error {
 // ensure messages are not dropped. WithPeerOutboundQueueSize should be set to
 // at least the expected number of batched messages per peer plus some slack to
 // account for gossip messages.
+//
+// The default publish strategy is RoundRobinMessageIDScheduler.
 func (p *PubSub) PublishBatch(batch *MessageBatch, opts ...BatchPubOpt) error {
 	if _, ok := p.rt.(BatchPublisher); !ok {
 		return fmt.Errorf("pubsub router is not a BatchPublisher")
@@ -1392,7 +1394,10 @@ func (p *PubSub) PublishBatch(batch *MessageBatch, opts ...BatchPubOpt) error {
 
 	publishOptions := &BatchPublishOptions{}
 	for _, o := range opts {
-		o(publishOptions)
+		err := o(publishOptions)
+		if err != nil {
+			return err
+		}
 	}
 	setDefaultBatchPublishOptions(publishOptions)
 

--- a/pubsub.go
+++ b/pubsub.go
@@ -235,6 +235,7 @@ type Message struct {
 	ReceivedFrom  peer.ID
 	ValidatorData interface{}
 	Local         bool
+	messageBatch  *MessageBatch
 }
 
 func (m *Message) GetFrom() peer.ID {
@@ -1101,7 +1102,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 				continue
 			}
 
-			msg := &Message{pmsg, "", rpc.from, nil, false}
+			msg := &Message{pmsg, "", rpc.from, nil, false, nil}
 			if p.shouldPush(msg) {
 				toPush = append(toPush, msg)
 			}

--- a/pubsub.go
+++ b/pubsub.go
@@ -1390,7 +1390,7 @@ func (p *PubSub) PublishBatch(batch *MessageBatch) error {
 		return fmt.Errorf("pubsub router is not a BatchPublisher")
 	}
 
-	// Copy the batch to avoid the footgun of reusing strategy state across batches
+	// Copy the batch to avoid the footgun of reusing scheduler state across batches
 	var copy MessageBatch
 	copy.Scheduler = batch.Scheduler
 	copy.messages = batch.messages
@@ -1398,7 +1398,7 @@ func (p *PubSub) PublishBatch(batch *MessageBatch) error {
 	batch.messages = nil
 
 	if copy.Scheduler == nil {
-		// Default to RarestFirstStrategy
+		// Default to Rarest first
 		copy.Scheduler = &RarestFirstRPCScheduler{}
 	}
 

--- a/topic.go
+++ b/topic.go
@@ -224,6 +224,19 @@ type PubOpt func(pub *PublishOptions) error
 
 // Publish publishes data to topic.
 func (t *Topic) Publish(ctx context.Context, data []byte, opts ...PubOpt) error {
+	return t.publish(ctx, data, opts...)
+}
+
+func (t *Topic) AddToBatch(ctx context.Context, batch *MessageBatch, data []byte, opts ...PubOpt) error {
+	batch.pendingMsgs.Add(1)
+	opts = append(opts, func(o *PublishOptions) error {
+		o.messageBatch = batch
+		return nil
+	})
+	return t.publish(ctx, data, opts...)
+}
+
+func (t *Topic) publish(ctx context.Context, data []byte, opts ...PubOpt) error {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
 	if t.closed {

--- a/topic.go
+++ b/topic.go
@@ -228,7 +228,7 @@ type BatchPubOpt func(pub *BatchPublishOptions) error
 
 func setDefaultBatchPublishOptions(opts *BatchPublishOptions) {
 	if opts.Strategy == nil {
-		opts.Strategy = &RarestFirstRPCScheduler{}
+		opts.Strategy = &RoundRobinMessageIDScheduler{}
 	}
 }
 

--- a/topic.go
+++ b/topic.go
@@ -219,7 +219,18 @@ type PublishOptions struct {
 	validatorData any
 }
 
+type BatchPublishOptions struct {
+	Strategy RPCScheduler
+}
+
 type PubOpt func(pub *PublishOptions) error
+type BatchPubOpt func(pub *BatchPublishOptions) error
+
+func setDefaultBatchPublishOptions(opts *BatchPublishOptions) {
+	if opts.Strategy == nil {
+		opts.Strategy = &RarestFirstRPCScheduler{}
+	}
+}
 
 // Publish publishes data to topic.
 func (t *Topic) Publish(ctx context.Context, data []byte, opts ...PubOpt) error {

--- a/topic.go
+++ b/topic.go
@@ -217,6 +217,7 @@ type PublishOptions struct {
 	customKey     ProvideKey
 	local         bool
 	validatorData any
+	messageBatch  *MessageBatch
 }
 
 type PubOpt func(pub *PublishOptions) error
@@ -309,7 +310,7 @@ func (t *Topic) Publish(ctx context.Context, data []byte, opts ...PubOpt) error 
 		}
 	}
 
-	return t.p.val.PushLocal(&Message{m, "", t.p.host.ID(), pub.validatorData, pub.local})
+	return t.p.val.PushLocal(&Message{m, "", t.p.host.ID(), pub.validatorData, pub.local, pub.messageBatch})
 }
 
 // WithReadiness returns a publishing option for only publishing when the router is ready.

--- a/tracer.go
+++ b/tracer.go
@@ -26,17 +26,18 @@ var MinTraceBatchSize = 16
 
 // rejection reasons
 const (
-	RejectBlacklstedPeer      = "blacklisted peer"
-	RejectBlacklistedSource   = "blacklisted source"
-	RejectMissingSignature    = "missing signature"
-	RejectUnexpectedSignature = "unexpected signature"
-	RejectUnexpectedAuthInfo  = "unexpected auth info"
-	RejectInvalidSignature    = "invalid signature"
-	RejectValidationQueueFull = "validation queue full"
-	RejectValidationThrottled = "validation throttled"
-	RejectValidationFailed    = "validation failed"
-	RejectValidationIgnored   = "validation ignored"
-	RejectSelfOrigin          = "self originated message"
+	RejectBlacklstedPeer             = "blacklisted peer"
+	RejectBlacklistedSource          = "blacklisted source"
+	RejectMissingSignature           = "missing signature"
+	RejectUnexpectedSignature        = "unexpected signature"
+	RejectUnexpectedAuthInfo         = "unexpected auth info"
+	RejectInvalidSignature           = "invalid signature"
+	RejectValidationQueueFull        = "validation queue full"
+	RejectValidationThrottled        = "validation throttled"
+	RejectValidationFailed           = "validation failed"
+	RejectValidationIgnored          = "validation ignored"
+	RejectValidationIgnoredDuplicate = "validation ignored (duplicate)"
+	RejectSelfOrigin                 = "self originated message"
 )
 
 type basicTracer struct {

--- a/tracer.go
+++ b/tracer.go
@@ -26,18 +26,17 @@ var MinTraceBatchSize = 16
 
 // rejection reasons
 const (
-	RejectBlacklstedPeer             = "blacklisted peer"
-	RejectBlacklistedSource          = "blacklisted source"
-	RejectMissingSignature           = "missing signature"
-	RejectUnexpectedSignature        = "unexpected signature"
-	RejectUnexpectedAuthInfo         = "unexpected auth info"
-	RejectInvalidSignature           = "invalid signature"
-	RejectValidationQueueFull        = "validation queue full"
-	RejectValidationThrottled        = "validation throttled"
-	RejectValidationFailed           = "validation failed"
-	RejectValidationIgnored          = "validation ignored"
-	RejectValidationIgnoredDuplicate = "validation ignored (duplicate)"
-	RejectSelfOrigin                 = "self originated message"
+	RejectBlacklstedPeer      = "blacklisted peer"
+	RejectBlacklistedSource   = "blacklisted source"
+	RejectMissingSignature    = "missing signature"
+	RejectUnexpectedSignature = "unexpected signature"
+	RejectUnexpectedAuthInfo  = "unexpected auth info"
+	RejectInvalidSignature    = "invalid signature"
+	RejectValidationQueueFull = "validation queue full"
+	RejectValidationThrottled = "validation throttled"
+	RejectValidationFailed    = "validation failed"
+	RejectValidationIgnored   = "validation ignored"
+	RejectSelfOrigin          = "self originated message"
 )
 
 type basicTracer struct {

--- a/validation.go
+++ b/validation.go
@@ -226,6 +226,18 @@ func (v *validation) RemoveValidator(req *rmValReq) {
 	}
 }
 
+// PushLocal synchronously pushes a locally published message and performs applicable
+// validations.
+// Returns an error if validation fails
+func (v *validation) PushLocal(msg *Message) error {
+	err := v.ValidateLocal(msg)
+	if err != nil {
+		return err
+	}
+
+	return v.sendMsgBlocking(msg)
+}
+
 // ValidateLocal synchronously validates a locally published message and
 // performs applicable validations. Returns an error if validation fails.
 func (v *validation) ValidateLocal(msg *Message) error {
@@ -283,7 +295,7 @@ func (v *validation) validateWorker() {
 	for {
 		select {
 		case req := <-v.validateQ:
-			v.validate(req.vals, req.src, req.msg, false, v.sendMsgBlocking)
+			_ = v.validate(req.vals, req.src, req.msg, false, v.sendMsgBlocking)
 		case <-v.p.ctx.Done():
 			return
 		}

--- a/validation.go
+++ b/validation.go
@@ -226,10 +226,9 @@ func (v *validation) RemoveValidator(req *rmValReq) {
 	}
 }
 
-// PushLocal synchronously pushes a locally published message and performs applicable
-// validations.
-// Returns an error if validation fails
-func (v *validation) PushLocal(msg *Message) error {
+// ValidateLocal synchronously validates a locally published message and
+// performs applicable validations. Returns an error if validation fails.
+func (v *validation) ValidateLocal(msg *Message) error {
 	v.p.tracer.PublishMessage(msg)
 
 	err := v.p.checkSigningPolicy(msg)
@@ -238,7 +237,9 @@ func (v *validation) PushLocal(msg *Message) error {
 	}
 
 	vals := v.getValidators(msg)
-	return v.validate(vals, msg.ReceivedFrom, msg, true)
+	return v.validate(vals, msg.ReceivedFrom, msg, true, func(msg *Message) error {
+		return nil
+	})
 }
 
 // Push pushes a message into the validation pipeline.
@@ -282,15 +283,26 @@ func (v *validation) validateWorker() {
 	for {
 		select {
 		case req := <-v.validateQ:
-			v.validate(req.vals, req.src, req.msg, false)
+			v.validate(req.vals, req.src, req.msg, false, v.sendMsgBlocking)
 		case <-v.p.ctx.Done():
 			return
 		}
 	}
 }
 
-// validate performs validation and only sends the message if all validators succeed
-func (v *validation) validate(vals []*validatorImpl, src peer.ID, msg *Message, synchronous bool) error {
+func (v *validation) sendMsgBlocking(msg *Message) error {
+	select {
+	case v.p.sendMsg <- msg:
+		return nil
+	case <-v.p.ctx.Done():
+		return v.p.ctx.Err()
+	}
+}
+
+// validate performs validation and only calls onValid if all validators succeed.
+// If synchronous is true, onValid will be called before this function returns
+// if the message is new and accepted.
+func (v *validation) validate(vals []*validatorImpl, src peer.ID, msg *Message, synchronous bool, onValid func(*Message) error) error {
 	// If signature verification is enabled, but signing is disabled,
 	// the Signature is required to be nil upon receiving the message in PubSub.pushMsg.
 	if msg.Signature != nil {
@@ -306,7 +318,7 @@ func (v *validation) validate(vals []*validatorImpl, src peer.ID, msg *Message, 
 	id := v.p.idGen.ID(msg)
 	if !v.p.markSeen(id) {
 		v.tracer.DuplicateMessage(msg)
-		return nil
+		return ValidationError{Reason: RejectValidationIgnoredDuplicate}
 	} else {
 		v.tracer.ValidateMessage(msg)
 	}
@@ -345,7 +357,7 @@ loop:
 		select {
 		case v.validateThrottle <- struct{}{}:
 			go func() {
-				v.doValidateTopic(async, src, msg, result)
+				v.doValidateTopic(async, src, msg, result, onValid)
 				<-v.validateThrottle
 			}()
 		default:
@@ -360,13 +372,8 @@ loop:
 		return ValidationError{Reason: RejectValidationIgnored}
 	}
 
-	// no async validators, accepted message, send it!
-	select {
-	case v.p.sendMsg <- msg:
-		return nil
-	case <-v.p.ctx.Done():
-		return v.p.ctx.Err()
-	}
+	// no async validators, accepted message
+	return onValid(msg)
 }
 
 func (v *validation) validateSignature(msg *Message) bool {
@@ -379,7 +386,7 @@ func (v *validation) validateSignature(msg *Message) bool {
 	return true
 }
 
-func (v *validation) doValidateTopic(vals []*validatorImpl, src peer.ID, msg *Message, r ValidationResult) {
+func (v *validation) doValidateTopic(vals []*validatorImpl, src peer.ID, msg *Message, r ValidationResult, onValid func(*Message) error) {
 	result := v.validateTopic(vals, src, msg)
 
 	if result == ValidationAccept && r != ValidationAccept {
@@ -388,7 +395,7 @@ func (v *validation) doValidateTopic(vals []*validatorImpl, src peer.ID, msg *Me
 
 	switch result {
 	case ValidationAccept:
-		v.p.sendMsg <- msg
+		_ = onValid(msg)
 	case ValidationReject:
 		log.Debugf("message validation failed; dropping message from %s", src)
 		v.tracer.RejectMessage(msg, RejectValidationFailed)


### PR DESCRIPTION
to support batch publishing messages

Replaces #602.

Batch publishing lets the system know there are multiple related messages to be published so it can prioritize sending different messages before sending copies of messages. For example, with the default API, when you publish two messages A and B, under the hood A gets sent to D=8 peers first, before B gets sent out. With this MessageBatch api we can now send one copy of A _and then_ one copy of B before sending multiple copies.

When a node has bandwidth constraints relative to the messages it is publishing this improves dissemination time.

For more context see this post: https://ethresear.ch/t/improving-das-performance-with-gossipsub-batch-publishing/21713