### PR TITLE
fix(IDONTWANT)!: Do not IDONTWANT your sender

### DIFF
--- a/floodsub.go
+++ b/floodsub.go
@@ -71,7 +71,7 @@ func (fs *FloodSubRouter) AcceptFrom(peer.ID) AcceptStatus {
 	return AcceptAll
 }
 
-func (fs *FloodSubRouter) PreValidation([]*Message) {}
+func (fs *FloodSubRouter) PreValidation(from peer.ID, msgs []*Message) {}
 
 func (fs *FloodSubRouter) HandleRPC(rpc *RPC) {}
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -707,7 +707,7 @@ func (gs *GossipSubRouter) AcceptFrom(p peer.ID) AcceptStatus {
 // PreValidation sends the IDONTWANT control messages to all the mesh
 // peers. They need to be sent right before the validation because they
 // should be seen by the peers as soon as possible.
-func (gs *GossipSubRouter) PreValidation(msgs []*Message) {
+func (gs *GossipSubRouter) PreValidation(from peer.ID, msgs []*Message) {
 	tmids := make(map[string][]string)
 	for _, msg := range msgs {
 		if len(msg.GetData()) < gs.params.IDontWantMessageThreshold {
@@ -724,6 +724,10 @@ func (gs *GossipSubRouter) PreValidation(msgs []*Message) {
 		shuffleStrings(mids)
 		// send IDONTWANT to all the mesh peers
 		for p := range gs.mesh[topic] {
+			if p == from {
+				// We don't send IDONTWANT to the peer that sent us the messages
+				continue
+			}
 			// send to only peers that support IDONTWANT
 			if gs.feature(GossipSubFeatureIdontwant, gs.peers[p]) {
 				idontwant := []*pb.ControlIDontWant{{MessageIDs: mids}}

--- a/pubsub.go
+++ b/pubsub.go
@@ -203,7 +203,7 @@ type PubSubRouter interface {
 	AcceptFrom(peer.ID) AcceptStatus
 	// PreValidation is invoked on messages in the RPC envelope right before pushing it to
 	// the validation pipeline
-	PreValidation([]*Message)
+	PreValidation(from peer.ID, msgs []*Message)
 	// HandleRPC is invoked to process control messages in the RPC envelope.
 	// It is invoked after subscriptions and payload messages have been processed.
 	HandleRPC(*RPC)
@@ -1106,7 +1106,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 				toPush = append(toPush, msg)
 			}
 		}
-		p.rt.PreValidation(toPush)
+		p.rt.PreValidation(rpc.from, toPush)
 		for _, msg := range toPush {
 			p.pushMsg(msg)
 		}

--- a/randomsub.go
+++ b/randomsub.go
@@ -94,7 +94,7 @@ func (rs *RandomSubRouter) AcceptFrom(peer.ID) AcceptStatus {
 	return AcceptAll
 }
 
-func (rs *RandomSubRouter) PreValidation([]*Message) {}
+func (rs *RandomSubRouter) PreValidation(from peer.ID, msgs []*Message) {}
 
 func (rs *RandomSubRouter) HandleRPC(rpc *RPC) {}
 


### PR DESCRIPTION
We were sending IDONTWANT to the sender of the received message. This is pointless, as the sender should not repeat a message it already sent. The sender could also have tracked that it had sent this peer the message (we don't do this currently, and it's probably not necessary).

@ppopth 