### PR TITLE
Send IDONTWANT before first publish

### DIFF
--- a/floodsub.go
+++ b/floodsub.go
@@ -71,7 +71,7 @@ func (fs *FloodSubRouter) AcceptFrom(peer.ID) AcceptStatus {
 	return AcceptAll
 }
 
-func (fs *FloodSubRouter) PreValidation(from peer.ID, msgs []*Message) {}
+func (fs *FloodSubRouter) Preprocess(from peer.ID, msgs []*Message) {}
 
 func (fs *FloodSubRouter) HandleRPC(rpc *RPC) {}
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -707,10 +707,10 @@ func (gs *GossipSubRouter) AcceptFrom(p peer.ID) AcceptStatus {
 	return gs.gate.AcceptFrom(p)
 }
 
-// PreValidation sends the IDONTWANT control messages to all the mesh
+// Preprocess sends the IDONTWANT control messages to all the mesh
 // peers. They need to be sent right before the validation because they
 // should be seen by the peers as soon as possible.
-func (gs *GossipSubRouter) PreValidation(from peer.ID, msgs []*Message) {
+func (gs *GossipSubRouter) Preprocess(from peer.ID, msgs []*Message) {
 	tmids := make(map[string][]string)
 	for _, msg := range msgs {
 		if len(msg.GetData()) < gs.params.IDontWantMessageThreshold {

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -2847,7 +2847,7 @@ var _ RawTracer = &mockRawTracer{}
 func TestGossipsubNoIDONTWANTToMessageSender(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	hosts := getDefaultHosts(t, 3)
+	hosts := getDefaultHosts(t, 2)
 	denseConnect(t, hosts)
 
 	psubs := make([]*PubSub, 2)
@@ -2891,7 +2891,7 @@ func TestGossipsubNoIDONTWANTToMessageSender(t *testing.T) {
 func TestGossipsubIDONTWANTBeforeFirstPublish(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	hosts := getDefaultHosts(t, 3)
+	hosts := getDefaultHosts(t, 2)
 	denseConnect(t, hosts)
 
 	psubs := make([]*PubSub, 2)

--- a/pubsub.go
+++ b/pubsub.go
@@ -204,9 +204,9 @@ type PubSubRouter interface {
 	// Allows routers with internal scoring to vet peers before committing any processing resources
 	// to the message and implement an effective graylist and react to validation queue overload.
 	AcceptFrom(peer.ID) AcceptStatus
-	// PreValidation is invoked on messages in the RPC envelope right before pushing it to
+	// Preprocess is invoked on messages in the RPC envelope right before pushing it to
 	// the validation pipeline
-	PreValidation(from peer.ID, msgs []*Message)
+	Preprocess(from peer.ID, msgs []*Message)
 	// HandleRPC is invoked to process control messages in the RPC envelope.
 	// It is invoked after subscriptions and payload messages have been processed.
 	HandleRPC(*RPC)
@@ -1117,7 +1117,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 				toPush = append(toPush, msg)
 			}
 		}
-		p.rt.PreValidation(rpc.from, toPush)
+		p.rt.Preprocess(rpc.from, toPush)
 		for _, msg := range toPush {
 			p.pushMsg(msg)
 		}

--- a/randomsub.go
+++ b/randomsub.go
@@ -94,7 +94,7 @@ func (rs *RandomSubRouter) AcceptFrom(peer.ID) AcceptStatus {
 	return AcceptAll
 }
 
-func (rs *RandomSubRouter) PreValidation(from peer.ID, msgs []*Message) {}
+func (rs *RandomSubRouter) Preprocess(from peer.ID, msgs []*Message) {}
 
 func (rs *RandomSubRouter) HandleRPC(rpc *RPC) {}
 

--- a/topic.go
+++ b/topic.go
@@ -349,6 +349,7 @@ func (t *Topic) validate(ctx context.Context, data []byte, opts ...PubOpt) (*Mes
 	}
 
 	msg := &Message{m, "", t.p.host.ID(), pub.validatorData, pub.local}
+	t.p.rt.PreValidation(t.p.host.ID(), []*Message{msg})
 	err := t.p.val.ValidateLocal(msg)
 	if err != nil {
 		return nil, err

--- a/topic.go
+++ b/topic.go
@@ -349,7 +349,7 @@ func (t *Topic) validate(ctx context.Context, data []byte, opts ...PubOpt) (*Mes
 	}
 
 	msg := &Message{m, "", t.p.host.ID(), pub.validatorData, pub.local}
-	t.p.rt.PreValidation(t.p.host.ID(), []*Message{msg})
+	t.p.rt.Preprocess(t.p.host.ID(), []*Message{msg})
 	err := t.p.val.ValidateLocal(msg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
See #610 

We previously send IDONTWANT only when forwarding. This has us send IDONTWANT on our initial publish as well. Helps in the case that one or more peers may also publish the same thing at around the same time (see #610 for a longer explanation) and prevents "boomerang" duplicates where a peer sends you back the message you sent before you get a chance to send it to them.

This also serves as a hint to a peer that you are about to send them a certain message.