### PR TITLE
Check peer's IDONTWANT state right before sending RPC

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -199,6 +199,13 @@ func rpcWithSubs(subs ...*pb.RPC_SubOpts) *RPC {
 	}
 }
 
+func rpcWithMessagesAndChecksums(msgs []*pb.Message, checksums []checksum) *RPC {
+	return &RPC{
+		RPC:              pb.RPC{Publish: msgs},
+		messageChecksums: checksums,
+	}
+}
+
 func rpcWithMessages(msgs ...*pb.Message) *RPC {
 	return &RPC{RPC: pb.RPC{Publish: msgs}}
 }

--- a/comm.go
+++ b/comm.go
@@ -169,6 +169,11 @@ func (p *PubSub) handleSendingMessages(ctx context.Context, s network.Stream, ou
 			return err
 		}
 
+		if rpc.cancelled != nil && rpc.cancelled() {
+			// This rpc has been cancelled, so we don't need to send it
+			return nil
+		}
+
 		_, err = s.Write(buf)
 		return err
 	}
@@ -228,6 +233,9 @@ func copyRPC(rpc *RPC) *RPC {
 	if rpc.Control != nil {
 		res.Control = new(pb.ControlMessage)
 		*res.Control = *rpc.Control
+	}
+	if rpc.cancelled != nil {
+		res.cancelled = rpc.cancelled
 	}
 	return res
 }

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1250,7 +1250,7 @@ func (gs *GossipSubRouter) Publish(msg *Message) {
 		}
 	}
 
-	out := rpcWithMessagesAndChecksums([]*pb.Message{msg.Message}, []checksum{messageChecksum})
+	out := rpcWithMessagesAndChecksums([]*pb.Message{msg.Message}, []checksum{messageChecksum}, gs.unwanted)
 	for pid := range tosend {
 		if pid == from || pid == peer.ID(msg.GetFrom()) {
 			continue

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1453,7 +1453,7 @@ func appendOrMergeRPC(slice []*RPC, limit int, elems ...RPC) []*RPC {
 		// old behavior. In the future let's not merge messages. Since,
 		// it may increase message latency.
 		for _, msg := range elem.GetPublish() {
-			if lastRPC.Publish = append(lastRPC.Publish, msg); lastRPC.Size() > limit {
+			if lastRPC.Publish = append(lastRPC.Publish, msg); lastRPC.RPC.Size() > limit {
 				lastRPC.Publish = lastRPC.Publish[:len(lastRPC.Publish)-1]
 				lastRPC = &RPC{RPC: pb.RPC{}, from: elem.from}
 				lastRPC.Publish = append(lastRPC.Publish, msg)
@@ -1463,7 +1463,7 @@ func appendOrMergeRPC(slice []*RPC, limit int, elems ...RPC) []*RPC {
 
 		// Merge/Append Subscriptions
 		for _, sub := range elem.GetSubscriptions() {
-			if lastRPC.Subscriptions = append(lastRPC.Subscriptions, sub); lastRPC.Size() > limit {
+			if lastRPC.Subscriptions = append(lastRPC.Subscriptions, sub); lastRPC.RPC.Size() > limit {
 				lastRPC.Subscriptions = lastRPC.Subscriptions[:len(lastRPC.Subscriptions)-1]
 				lastRPC = &RPC{RPC: pb.RPC{}, from: elem.from}
 				lastRPC.Subscriptions = append(lastRPC.Subscriptions, sub)
@@ -1475,7 +1475,7 @@ func appendOrMergeRPC(slice []*RPC, limit int, elems ...RPC) []*RPC {
 		if ctl := elem.GetControl(); ctl != nil {
 			if lastRPC.Control == nil {
 				lastRPC.Control = &pb.ControlMessage{}
-				if lastRPC.Size() > limit {
+				if lastRPC.RPC.Size() > limit {
 					lastRPC.Control = nil
 					lastRPC = &RPC{RPC: pb.RPC{Control: &pb.ControlMessage{}}, from: elem.from}
 					out = append(out, lastRPC)
@@ -1483,7 +1483,7 @@ func appendOrMergeRPC(slice []*RPC, limit int, elems ...RPC) []*RPC {
 			}
 
 			for _, graft := range ctl.GetGraft() {
-				if lastRPC.Control.Graft = append(lastRPC.Control.Graft, graft); lastRPC.Size() > limit {
+				if lastRPC.Control.Graft = append(lastRPC.Control.Graft, graft); lastRPC.RPC.Size() > limit {
 					lastRPC.Control.Graft = lastRPC.Control.Graft[:len(lastRPC.Control.Graft)-1]
 					lastRPC = &RPC{RPC: pb.RPC{Control: &pb.ControlMessage{}}, from: elem.from}
 					lastRPC.Control.Graft = append(lastRPC.Control.Graft, graft)
@@ -1492,7 +1492,7 @@ func appendOrMergeRPC(slice []*RPC, limit int, elems ...RPC) []*RPC {
 			}
 
 			for _, prune := range ctl.GetPrune() {
-				if lastRPC.Control.Prune = append(lastRPC.Control.Prune, prune); lastRPC.Size() > limit {
+				if lastRPC.Control.Prune = append(lastRPC.Control.Prune, prune); lastRPC.RPC.Size() > limit {
 					lastRPC.Control.Prune = lastRPC.Control.Prune[:len(lastRPC.Control.Prune)-1]
 					lastRPC = &RPC{RPC: pb.RPC{Control: &pb.ControlMessage{}}, from: elem.from}
 					lastRPC.Control.Prune = append(lastRPC.Control.Prune, prune)
@@ -1506,7 +1506,7 @@ func appendOrMergeRPC(slice []*RPC, limit int, elems ...RPC) []*RPC {
 					// For IWANTs we don't need more than a single one,
 					// since there are no topic IDs here.
 					newIWant := &pb.ControlIWant{}
-					if lastRPC.Control.Iwant = append(lastRPC.Control.Iwant, newIWant); lastRPC.Size() > limit {
+					if lastRPC.Control.Iwant = append(lastRPC.Control.Iwant, newIWant); lastRPC.RPC.Size() > limit {
 						lastRPC.Control.Iwant = lastRPC.Control.Iwant[:len(lastRPC.Control.Iwant)-1]
 						lastRPC = &RPC{RPC: pb.RPC{Control: &pb.ControlMessage{
 							Iwant: []*pb.ControlIWant{newIWant},
@@ -1515,7 +1515,7 @@ func appendOrMergeRPC(slice []*RPC, limit int, elems ...RPC) []*RPC {
 					}
 				}
 				for _, msgID := range iwant.GetMessageIDs() {
-					if lastRPC.Control.Iwant[0].MessageIDs = append(lastRPC.Control.Iwant[0].MessageIDs, msgID); lastRPC.Size() > limit {
+					if lastRPC.Control.Iwant[0].MessageIDs = append(lastRPC.Control.Iwant[0].MessageIDs, msgID); lastRPC.RPC.Size() > limit {
 						lastRPC.Control.Iwant[0].MessageIDs = lastRPC.Control.Iwant[0].MessageIDs[:len(lastRPC.Control.Iwant[0].MessageIDs)-1]
 						lastRPC = &RPC{RPC: pb.RPC{Control: &pb.ControlMessage{
 							Iwant: []*pb.ControlIWant{{MessageIDs: []string{msgID}}},

--- a/gossipsub_spam_test.go
+++ b/gossipsub_spam_test.go
@@ -929,12 +929,12 @@ func TestGossipsubHandleIDontwantSpam(t *testing.T) {
 		t.Errorf("Wanted message count of %d but received %d", 1, grt.peerdontwant[rPid])
 	}
 	mid := fmt.Sprintf("idontwant-%d", GossipSubMaxIDontWantLength-1)
-	if _, ok := grt.unwanted[rPid][computeChecksum(mid)]; !ok {
+	if !grt.unwanted.has(rPid, computeChecksum(mid)) {
 		t.Errorf("Desired message id was not stored in the unwanted map: %s", mid)
 	}
 
 	mid = fmt.Sprintf("idontwant-%d", GossipSubMaxIDontWantLength)
-	if _, ok := grt.unwanted[rPid][computeChecksum(mid)]; ok {
+	if grt.unwanted.has(rPid, computeChecksum(mid)) {
 		t.Errorf("Unwanted message id was stored in the unwanted map: %s", mid)
 	}
 }

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -3588,7 +3588,11 @@ func TestGossipsubIDONTWANTCancelsQueuedRPC(t *testing.T) {
 		},
 	}
 	q := psubs[1].peers[publisherHost.ID()]
-	psubs[1].rt.(*GossipSubRouter).doSendRPC(idontwantRPC, publisherHost.ID(), q, true)
+
+	// Call this via the eval func to run it in the event loop
+	psubs[1].eval <- func() {
+		psubs[1].rt.(*GossipSubRouter).doSendRPC(idontwantRPC, publisherHost.ID(), q, true)
+	}
 
 	// Wait for the RPCs to send
 	time.Sleep(time.Second)

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -2348,9 +2348,9 @@ func validRPCSizes(slice []*RPC, limit int) bool {
 	return true
 }
 
-func validRPCToPublishSizes(slice []RPCToPublish, limit int) bool {
+func validRPCSizesStructSlice(slice []RPC, limit int) bool {
 	for _, rpc := range slice {
-		if rpc.toPB().Size() > limit {
+		if rpc.Size() > limit {
 			return false
 		}
 	}
@@ -2565,7 +2565,7 @@ func FuzzAppendOrMergeRPC(f *testing.F) {
 	})
 }
 
-func FuzzRPCToPublish(f *testing.F) {
+func FuzzRPCSplit(f *testing.F) {
 	minMaxMsgSize := 100
 	maxMaxMsgSize := 2048
 	f.Fuzz(func(t *testing.T, data []byte) {
@@ -2574,20 +2574,9 @@ func FuzzRPCToPublish(f *testing.F) {
 			maxSize = minMaxMsgSize
 		}
 		rpc := generateRPC(data, maxSize)
-		publishMsgs := make([]*Message, len(rpc.Publish))
-		for i, msg := range rpc.Publish {
-			publishMsgs[i] = &Message{
-				Message: msg,
-			}
-		}
-		rpcToPublish := &RPCToPublish{
-			publish: publishMsgs,
-			subs:    rpc.Subscriptions,
-			control: rpc.Control,
-		}
-		rpcs := rpcToPublish.split(maxSize)
+		rpcs := rpc.split(maxSize)
 
-		if !validRPCToPublishSizes(rpcs, maxSize) {
+		if !validRPCSizesStructSlice(rpcs, maxSize) {
 			t.Fatalf("invalid RPC size")
 		}
 	})

--- a/pubsub.go
+++ b/pubsub.go
@@ -245,7 +245,8 @@ type RPC struct {
 	pb.RPC
 
 	// unexported on purpose, not sending this over the wire
-	from peer.ID
+	from      peer.ID
+	cancelled func() bool
 }
 
 type Option func(*PubSub) error

--- a/pubsub.go
+++ b/pubsub.go
@@ -253,7 +253,7 @@ type RPC struct {
 }
 
 func (r *RPC) filterUnwanted(to peer.ID) *RPC {
-	if len(r.Publish) != len(r.messageChecksums) {
+	if len(r.Publish) != len(r.messageChecksums) || r.unwanted == nil {
 		return r
 	}
 	// First check if there are any unwanted messages.
@@ -341,7 +341,7 @@ func (r *RPC) split(maxRPCSize int) []RPC {
 
 	var currentSize int
 	if ctrlSize > 0 {
-		currentSize = ctrlSize + sovRpc(uint64(ctrlSize)) + 1
+		currentSize = ctrlSize + 1 + sovRpc(uint64(ctrlSize))
 	}
 	// Split subscriptions.
 	for _, rpc := range r.Subscriptions {
@@ -443,21 +443,6 @@ func (r *RPC) rpcControlComponents() iter.Seq2[int, func(*pb.ControlMessage)] {
 			}
 		}
 	}
-}
-
-// Size returns the size of the pb encoded RPC in bytes.
-func (r *RPC) Size() int {
-	pbRPC := pb.RPC{
-		Subscriptions: r.Subscriptions,
-		Control:       r.Control,
-	}
-	size := pbRPC.Size()
-	for _, msg := range r.Publish {
-		mSize := msg.Size()
-		// +1 for the protobuf field number + wire type
-		size += mSize + 1 + sovRpc(uint64(mSize)) + 1
-	}
-	return size
 }
 
 type Option func(*PubSub) error

--- a/pubsub.go
+++ b/pubsub.go
@@ -253,6 +253,9 @@ type RPC struct {
 }
 
 func (r *RPC) filterUnwanted(to peer.ID) *RPC {
+	if len(r.Publish) != len(r.messageChecksums) {
+		return r
+	}
 	// First check if there are any unwanted messages.
 	// If all messages are wanted, we can return the original RPC.
 	anyUnwanted := false

--- a/pubsub.go
+++ b/pubsub.go
@@ -377,6 +377,8 @@ func (r *RPC) split(maxRPCSize int) []RPC {
 	// Set common fields for all RPCs
 	for i := range out {
 		out[i].from = r.from
+		out[i].unwanted = r.unwanted
+		out[i].messageChecksums = r.messageChecksums
 	}
 	return out
 }


### PR DESCRIPTION
Related to #611.

A bit hacky, and there's a couple of footguns with the various RPC copies.

It would be nice to use a context for this, but it doesn't work well because the send is async so we'd have to keep the context around long enough for the send to finish and then clean it up.

Having the rpc check a map behind a lock is one of the cheapest options.

A slight improvement here would be to send the cancelled function separately from the RPC at the expense of more code changes.

Another approach is to change the priority queue to be aware of cancellation, but I think this looks a lot like this approach.

