### PR TITLE
fix(BatchPublishing): Make topic.AddToBatch threadsafe

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -1600,12 +1600,10 @@ func (p *PubSub) PublishBatch(batch *MessageBatch, opts ...BatchPubOpt) error {
 	setDefaultBatchPublishOptions(publishOptions)
 
 	p.sendMessageBatch <- messageBatchAndPublishOptions{
-		messages: batch.messages,
+		messages: batch.take(),
 		opts:     publishOptions,
 	}
 
-	// Clear the batch's messages in case a user reuses the same batch object
-	batch.messages = nil
 	return nil
 }
 

--- a/topic.go
+++ b/topic.go
@@ -257,7 +257,7 @@ func (t *Topic) AddToBatch(ctx context.Context, batch *MessageBatch, data []byte
 		}
 		return err
 	}
-	batch.messages = append(batch.messages, msg)
+	batch.add(msg)
 	return nil
 }
 


### PR DESCRIPTION
topic.Publish is already thread safe. topic.AddToBatch should strive to follow similar semantics.

Looking at how this would integrate with Prysm, they use separate goroutines per message they'd like to batch.