### PR TITLE
Fix race when calling Preprocess and msg ID generator

### DIFF
--- a/midgen.go
+++ b/midgen.go
@@ -9,6 +9,7 @@ import (
 // msgIDGenerator handles computing IDs for msgs
 // It allows setting custom generators(MsgIdFunction) per topic
 type msgIDGenerator struct {
+	sync.Mutex
 	Default MsgIdFunction
 
 	topicGensLk sync.RWMutex
@@ -31,6 +32,8 @@ func (m *msgIDGenerator) Set(topic string, gen MsgIdFunction) {
 
 // ID computes ID for the msg or short-circuits with the cached value.
 func (m *msgIDGenerator) ID(msg *Message) string {
+	m.Lock()
+	defer m.Unlock()
 	if msg.ID != "" {
 		return msg.ID
 	}

--- a/topic.go
+++ b/topic.go
@@ -349,7 +349,9 @@ func (t *Topic) validate(ctx context.Context, data []byte, opts ...PubOpt) (*Mes
 	}
 
 	msg := &Message{m, "", t.p.host.ID(), pub.validatorData, pub.local}
-	t.p.rt.Preprocess(t.p.host.ID(), []*Message{msg})
+	t.p.eval <- func() {
+		t.p.rt.Preprocess(t.p.host.ID(), []*Message{msg})
+	}
 	err := t.p.val.ValidateLocal(msg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #624 . Same as the first two commits from #626 , but skips the test changes and enabling race test in CI in order to make a smaller PR.