### PR TITLE
Skip 32-bit tests in CI

### DIFF
--- a/.github/workflows/go-test-config.json
+++ b/.github/workflows/go-test-config.json
@@ -1,3 +1,4 @@
 {
-  "skipOSes": ["windows", "macos"]
+  "skipOSes": ["windows", "macos"],
+  "skip32bit": true
 }


### PR DESCRIPTION
This is roughly a third of our CI time, and, as far as I know, running 32bit tests has never caught an issue.

Also, I'm unaware of anyone using this library on a 32bit x86 system. I believe the last 32bit x86 CPU released was the [pentium 4](https://en.wikipedia.org/wiki/List_of_Intel_Pentium_4_processors) close to 20 years ago.