### PR TITLE
Migrate to `log/slog`

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -190,7 +190,7 @@ func (d *discover) Advertise(topic string) {
 	go func() {
 		next, err := d.discovery.Advertise(advertisingCtx, topic)
 		if err != nil {
-			log.Warnf("bootstrap: error providing rendezvous for %s: %s", topic, err.Error())
+			d.p.logger.Warn("bootstrap: error providing rendezvous for topic", "topic", topic, "err", err)
 			if next == 0 {
 				next = discoveryAdvertiseRetryInterval
 			}
@@ -204,7 +204,7 @@ func (d *discover) Advertise(topic string) {
 			case <-t.C:
 				next, err = d.discovery.Advertise(advertisingCtx, topic)
 				if err != nil {
-					log.Warnf("bootstrap: error providing rendezvous for %s: %s", topic, err.Error())
+					d.p.logger.Warn("bootstrap: error providing rendezvous for topic", "topic", topic, "err", err)
 					if next == 0 {
 						next = discoveryAdvertiseRetryInterval
 					}
@@ -302,7 +302,7 @@ func (d *discover) handleDiscovery(ctx context.Context, topic string, opts []dis
 
 	peerCh, err := d.discovery.FindPeers(discoverCtx, topic, opts...)
 	if err != nil {
-		log.Debugf("error finding peers for topic %s: %v", topic, err)
+		d.p.logger.Debug("error finding peers for topic", "topic", topic, "err", err)
 		return
 	}
 

--- a/floodsub.go
+++ b/floodsub.go
@@ -92,7 +92,7 @@ func (fs *FloodSubRouter) Publish(msg *Message) {
 
 		err := q.Push(out, false)
 		if err != nil {
-			log.Infof("dropping message to peer %s: queue full", pid)
+			fs.p.logger.Info("dropping message to peer: queue full", "peer", pid)
 			fs.tracer.DropRPC(out, pid)
 			// Drop it. The peer is too slow.
 			continue

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,12 @@ go 1.23
 require (
 	github.com/benbjohnson/clock v1.3.5
 	github.com/gogo/protobuf v1.3.2
-	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/libp2p/go-buffer-pool v0.1.0
 	github.com/libp2p/go-libp2p v0.39.1
 	github.com/libp2p/go-libp2p-testing v0.12.0
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/multiformats/go-multiaddr v0.14.0
 	github.com/multiformats/go-varint v0.0.7
-	go.uber.org/zap v1.27.0
 )
 
 require (
@@ -36,6 +34,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/ipfs/go-cid v0.5.0 // indirect
+	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
@@ -105,6 +104,7 @@ require (
 	go.uber.org/fx v1.23.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c // indirect
 	golang.org/x/mod v0.23.0 // indirect

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"log/slog"
 	"math/rand"
 	"sort"
 	"time"
@@ -20,8 +21,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/record"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
-
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -338,7 +337,7 @@ func WithPeerScore(params *PeerScoreParams, thresholds *PeerScoreThresholds) Opt
 			return err
 		}
 
-		gs.score = newPeerScore(params)
+		gs.score = newPeerScore(params, ps.logger)
 		gs.gossipThreshold = thresholds.GossipThreshold
 		gs.publishThreshold = thresholds.PublishThreshold
 		gs.graylistThreshold = thresholds.GraylistThreshold
@@ -463,6 +462,7 @@ func WithGossipSubParams(cfg GossipSubParams) Option {
 // messages to their topic for GossipSubFanoutTTL.
 type GossipSubRouter struct {
 	p            *PubSub
+	logger       *slog.Logger
 	peers        map[peer.ID]protocol.ID          // peer protocols
 	direct       map[peer.ID]struct{}             // direct peers
 	mesh         map[string]map[peer.ID]struct{}  // topic meshes
@@ -536,6 +536,7 @@ func (gs *GossipSubRouter) Protocols() []protocol.ID {
 
 func (gs *GossipSubRouter) Attach(p *PubSub) {
 	gs.p = p
+	gs.logger = p.logger
 	gs.tracer = p.tracer
 
 	// start the scoring
@@ -545,7 +546,7 @@ func (gs *GossipSubRouter) Attach(p *PubSub) {
 	gs.gossipTracer.Start(gs)
 
 	// and the tracer for connmgr tags
-	gs.tagTracer.Start(gs)
+	gs.tagTracer.Start(gs, p.logger)
 
 	// start using the same msg ID function as PubSub for caching messages.
 	gs.mcache.SetMsgIdFn(p.idGen.ID)
@@ -580,7 +581,7 @@ func (gs *GossipSubRouter) manageAddrBook() {
 		&event.EvtPeerConnectednessChanged{},
 	})
 	if err != nil {
-		log.Errorf("failed to subscribe to peer identification events: %v", err)
+		gs.logger.Error("failed to subscribe to peer identification events", "err", err)
 		return
 	}
 	defer sub.Close()
@@ -592,7 +593,7 @@ func (gs *GossipSubRouter) manageAddrBook() {
 			if ok {
 				errClose := cabCloser.Close()
 				if errClose != nil {
-					log.Warnf("failed to close addr book: %v", errClose)
+					gs.logger.Warn("failed to close addr book", "err", errClose)
 				}
 			}
 			return
@@ -608,7 +609,7 @@ func (gs *GossipSubRouter) manageAddrBook() {
 						}
 						_, err := cab.ConsumePeerRecord(ev.SignedPeerRecord, ttl)
 						if err != nil {
-							log.Warnf("failed to consume signed peer record: %v", err)
+							gs.logger.Warn("failed to consume signed peer record", "err", err)
 						}
 					}
 				}
@@ -622,7 +623,7 @@ func (gs *GossipSubRouter) manageAddrBook() {
 }
 
 func (gs *GossipSubRouter) AddPeer(p peer.ID, proto protocol.ID) {
-	log.Debugf("PEERUP: Add new peer %s using %s", p, proto)
+	gs.logger.Debug("PEERUP: Add new peer using protocol", "peer", p, "protocol", proto)
 	gs.tracer.AddPeer(p, proto)
 	gs.peers[p] = proto
 
@@ -651,7 +652,7 @@ loop:
 }
 
 func (gs *GossipSubRouter) RemovePeer(p peer.ID) {
-	log.Debugf("PEERDOWN: Remove disconnected peer %s", p)
+	gs.logger.Debug("PEERDOWN: Remove disconnected peer", "peer", p)
 	gs.tracer.RemovePeer(p)
 	delete(gs.peers, p)
 	for _, peers := range gs.mesh {
@@ -765,18 +766,18 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 	// we ignore IHAVE gossip from any peer whose score is below the gossip threshold
 	score := gs.score.Score(p)
 	if score < gs.gossipThreshold {
-		log.Debugf("IHAVE: ignoring peer %s with score below threshold [score = %f]", p, score)
+		gs.logger.Debug("IHAVE: ignoring peer with score below threshold", "peer", p, "score", score)
 		return nil
 	}
 
 	// IHAVE flood protection
 	gs.peerhave[p]++
 	if gs.peerhave[p] > gs.params.MaxIHaveMessages {
-		log.Debugf("IHAVE: peer %s has advertised too many times (%d) within this heartbeat interval; ignoring", p, gs.peerhave[p])
+		gs.logger.Debug("IHAVE: peer has advertised too many times within this heartbeat interval; ignoring", "peer", p, "count", gs.peerhave[p])
 		return nil
 	}
 	if gs.iasked[p] >= gs.params.MaxIHaveLength {
-		log.Debugf("IHAVE: peer %s has already advertised too many messages (%d); ignoring", p, gs.iasked[p])
+		gs.logger.Debug("IHAVE: peer has already advertised too many messages; ignoring", "peer", p, "messageCount", gs.iasked[p])
 		return nil
 	}
 
@@ -796,7 +797,7 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 		for msgIdx, mid := range ihave.GetMessageIDs() {
 			// prevent remote peer from sending too many msg_ids on a single IHAVE message
 			if msgIdx >= gs.params.MaxIHaveLength {
-				log.Debugf("IHAVE: peer %s has sent IHAVE on topic %s with too many messages (%d); ignoring remaining msgs", p, topic, len(ihave.MessageIDs))
+				gs.logger.Debug("IHAVE: peer has sent IHAVE on topic with too many messages; ignoring remaining msgs", "peer", p, "topic", topic, "messageCount", len(ihave.MessageIDs))
 				break checkIwantMsgsLoop
 			}
 
@@ -816,7 +817,7 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 		iask = gs.params.MaxIHaveLength - gs.iasked[p]
 	}
 
-	log.Debugf("IHAVE: Asking for %d out of %d messages from %s", iask, len(iwant), p)
+	gs.logger.Debug("IHAVE: Asking for messages from peer", "asking", iask, "total", len(iwant), "peer", p)
 
 	iwantlst := make([]string, 0, len(iwant))
 	for mid := range iwant {
@@ -839,7 +840,7 @@ func (gs *GossipSubRouter) handleIWant(p peer.ID, ctl *pb.ControlMessage) []*pb.
 	// we don't respond to IWANT requests from any peer whose score is below the gossip threshold
 	score := gs.score.Score(p)
 	if score < gs.gossipThreshold {
-		log.Debugf("IWANT: ignoring peer %s with score below threshold [score = %f]", p, score)
+		gs.logger.Debug("IWANT: ignoring peer with score below threshold", "peer", p, "score", score)
 		return nil
 	}
 
@@ -861,7 +862,7 @@ func (gs *GossipSubRouter) handleIWant(p peer.ID, ctl *pb.ControlMessage) []*pb.
 			}
 
 			if count > gs.params.GossipRetransmission {
-				log.Debugf("IWANT: Peer %s has asked for message %s too many times; ignoring request", p, mid)
+				gs.logger.Debug("IWANT: Peer has asked for message too many times; ignoring request", "peer", p, "messageID", mid)
 				continue
 			}
 
@@ -873,7 +874,7 @@ func (gs *GossipSubRouter) handleIWant(p peer.ID, ctl *pb.ControlMessage) []*pb.
 		return nil
 	}
 
-	log.Debugf("IWANT: Sending %d messages to %s", len(ihave), p)
+	gs.logger.Debug("IWANT: Sending messages to peer", "messageCount", len(ihave), "peer", p)
 
 	msgs := make([]*pb.Message, 0, len(ihave))
 	for _, msg := range ihave {
@@ -914,7 +915,7 @@ func (gs *GossipSubRouter) handleGraft(p peer.ID, ctl *pb.ControlMessage) []*pb.
 		// we don't GRAFT to/from direct peers; complain loudly if this happens
 		_, direct := gs.direct[p]
 		if direct {
-			log.Warnf("GRAFT: ignoring request from direct peer %s", p)
+			gs.logger.Warn("GRAFT: ignoring request from direct peer", "peer", p)
 			// this is possibly a bug from non-reciprocal configuration; send a PRUNE
 			prune = append(prune, topic)
 			// but don't PX
@@ -925,7 +926,7 @@ func (gs *GossipSubRouter) handleGraft(p peer.ID, ctl *pb.ControlMessage) []*pb.
 		// make sure we are not backing off that peer
 		expire, backoff := gs.backoff[topic][p]
 		if backoff && now.Before(expire) {
-			log.Debugf("GRAFT: ignoring backed off peer %s", p)
+			gs.logger.Debug("GRAFT: ignoring backed off peer", "peer", p)
 			// add behavioural penalty
 			gs.score.AddPenalty(p, 1)
 			// no PX
@@ -945,7 +946,7 @@ func (gs *GossipSubRouter) handleGraft(p peer.ID, ctl *pb.ControlMessage) []*pb.
 		// check the score
 		if score < 0 {
 			// we don't GRAFT peers with negative score
-			log.Debugf("GRAFT: ignoring peer %s with negative score [score = %f, topic = %s]", p, score, topic)
+			gs.logger.Debug("GRAFT: ignoring peer with negative score", "peer", p, "score", score, "topic", topic)
 			// we do send them PRUNE however, because it's a matter of protocol correctness
 			prune = append(prune, topic)
 			// but we won't PX to them
@@ -964,7 +965,7 @@ func (gs *GossipSubRouter) handleGraft(p peer.ID, ctl *pb.ControlMessage) []*pb.
 			continue
 		}
 
-		log.Debugf("GRAFT: add mesh link from %s in %s", p, topic)
+		gs.logger.Debug("GRAFT: add mesh link from peer in topic", "peer", p, "topic", topic)
 		gs.tracer.Graft(p, topic)
 		peers[p] = struct{}{}
 	}
@@ -991,7 +992,7 @@ func (gs *GossipSubRouter) handlePrune(p peer.ID, ctl *pb.ControlMessage) {
 			continue
 		}
 
-		log.Debugf("PRUNE: Remove mesh link to %s in %s", p, topic)
+		gs.logger.Debug("PRUNE: Remove mesh link to peer in topic", "peer", p, "topic", topic)
 		gs.tracer.Prune(p, topic)
 		delete(peers, p)
 		// is there a backoff specified by the peer? if so obey it.
@@ -1006,7 +1007,7 @@ func (gs *GossipSubRouter) handlePrune(p peer.ID, ctl *pb.ControlMessage) {
 		if len(px) > 0 {
 			// we ignore PX from peers with insufficient score
 			if score < gs.acceptPXThreshold {
-				log.Debugf("PRUNE: ignoring PX from peer %s with insufficient score [score = %f, topic = %s]", p, score, topic)
+				gs.logger.Debug("PRUNE: ignoring PX from peer with insufficient score", "peer", p, "score", score, "topic", topic)
 				continue
 			}
 
@@ -1022,7 +1023,7 @@ func (gs *GossipSubRouter) handleIDontWant(p peer.ID, ctl *pb.ControlMessage) {
 
 	// IDONTWANT flood protection
 	if gs.peerdontwant[p] >= gs.params.MaxIDontWantMessages {
-		log.Debugf("IDONWANT: peer %s has advertised too many times (%d) within this heartbeat interval; ignoring", p, gs.peerdontwant[p])
+		gs.logger.Debug("IDONWANT: peer has advertised too many times within this heartbeat interval; ignoring", "peer", p, "count", gs.peerdontwant[p])
 		return
 	}
 	gs.peerdontwant[p]++
@@ -1034,7 +1035,7 @@ mainIDWLoop:
 		for _, mid := range idontwant.GetMessageIDs() {
 			// IDONTWANT flood protection
 			if totalUnwantedIds >= gs.params.MaxIDontWantLength {
-				log.Debugf("IDONWANT: peer %s has advertised too many ids (%d) within this message; ignoring", p, totalUnwantedIds)
+				gs.logger.Debug("IDONWANT: peer has advertised too many ids within this message; ignoring", "peer", p, "idCount", totalUnwantedIds)
 				break mainIDWLoop
 			}
 
@@ -1085,16 +1086,16 @@ func (gs *GossipSubRouter) pxConnect(peers []*pb.PeerInfo) {
 			// the peer sent us a signed record; ensure that it is valid
 			envelope, r, err := record.ConsumeEnvelope(pi.SignedPeerRecord, peer.PeerRecordEnvelopeDomain)
 			if err != nil {
-				log.Warnf("error unmarshalling peer record obtained through px: %s", err)
+				gs.logger.Warn("error unmarshalling peer record obtained through px", "err", err)
 				continue
 			}
 			rec, ok := r.(*peer.PeerRecord)
 			if !ok {
-				log.Warnf("bogus peer record obtained through px: envelope payload is not PeerRecord")
+				gs.logger.Warn("bogus peer record obtained through px: envelope payload is not PeerRecord")
 				continue
 			}
 			if rec.PeerID != p {
-				log.Warnf("bogus peer record obtained through px: peer ID %s doesn't match expected peer %s", rec.PeerID, p)
+				gs.logger.Warn("bogus peer record obtained through px: peer ID doesn't match expected peer", "recordPeerID", rec.PeerID, "expectedPeer", p)
 				continue
 			}
 			spr = envelope
@@ -1111,7 +1112,7 @@ func (gs *GossipSubRouter) pxConnect(peers []*pb.PeerInfo) {
 		select {
 		case gs.connect <- ci:
 		default:
-			log.Debugf("ignoring peer connection attempt; too many pending connections")
+			gs.logger.Debug("ignoring peer connection attempt; too many pending connections")
 		}
 	}
 }
@@ -1124,12 +1125,12 @@ func (gs *GossipSubRouter) connector() {
 				continue
 			}
 
-			log.Debugf("connecting to %s", ci.p)
+			gs.logger.Debug("connecting to peer", "peer", ci.p)
 			cab, ok := peerstore.GetCertifiedAddrBook(gs.cab)
 			if ok && ci.spr != nil {
 				_, err := cab.ConsumePeerRecord(ci.spr, peerstore.TempAddrTTL)
 				if err != nil {
-					log.Debugf("error processing peer record: %s", err)
+					gs.logger.Debug("error processing peer record", "err", err)
 				}
 			}
 
@@ -1137,7 +1138,7 @@ func (gs *GossipSubRouter) connector() {
 			err := gs.p.host.Connect(ctx, peer.AddrInfo{ID: ci.p, Addrs: gs.cab.Addrs(ci.p)})
 			cancel()
 			if err != nil {
-				log.Debugf("error connecting to %s: %s", ci.p, err)
+				gs.logger.Debug("error connecting to peer", "peer", ci.p, "err", err)
 			}
 
 		case <-gs.p.ctx.Done():
@@ -1254,7 +1255,7 @@ func (gs *GossipSubRouter) Join(topic string) {
 		return
 	}
 
-	log.Debugf("JOIN %s", topic)
+	gs.logger.Debug("JOIN topic", "topic", topic)
 	gs.tracer.Join(topic)
 
 	gmap, ok = gs.fanout[topic]
@@ -1299,7 +1300,7 @@ func (gs *GossipSubRouter) Join(topic string) {
 	}
 
 	for p := range gmap {
-		log.Debugf("JOIN: Add mesh link to %s in %s", p, topic)
+		gs.logger.Debug("JOIN: Add mesh link to peer in topic", "peer", p, "topic", topic)
 		gs.tracer.Graft(p, topic)
 		gs.sendGraft(p, topic)
 	}
@@ -1311,13 +1312,13 @@ func (gs *GossipSubRouter) Leave(topic string) {
 		return
 	}
 
-	log.Debugf("LEAVE %s", topic)
+	gs.logger.Debug("LEAVE topic", "topic", topic)
 	gs.tracer.Leave(topic)
 
 	delete(gs.mesh, topic)
 
 	for p := range gmap {
-		log.Debugf("LEAVE: Remove mesh link to %s in %s", p, topic)
+		gs.logger.Debug("LEAVE: Remove mesh link to peer in topic", "peer", p, "topic", topic)
 		gs.tracer.Prune(p, topic)
 		gs.sendPrune(p, topic, true)
 		// Add a backoff to this peer to prevent us from eagerly
@@ -1386,9 +1387,7 @@ func (gs *GossipSubRouter) sendRPC(p peer.ID, out *RPC, urgent bool) {
 }
 
 func (gs *GossipSubRouter) doDropRPC(rpc *RPC, p peer.ID, reason string) {
-	if log.Level() <= zapcore.DebugLevel {
-		log.Debugf("dropping message to peer %s: %s", p, reason)
-	}
+	gs.logger.Debug("dropping message to peer", "peer", p, "reason", reason)
 	gs.tracer.DropRPC(rpc, p)
 	// push control messages that need to be retried
 	ctl := rpc.GetControl()
@@ -1442,7 +1441,7 @@ func (gs *GossipSubRouter) heartbeat() {
 		if gs.params.SlowHeartbeatWarning > 0 {
 			slowWarning := time.Duration(gs.params.SlowHeartbeatWarning * float64(gs.params.HeartbeatInterval))
 			if dt := time.Since(start); dt > slowWarning {
-				log.Warnw("slow heartbeat", "took", dt)
+				gs.logger.Warn("slow heartbeat", "took", dt)
 			}
 		}
 	}()
@@ -1490,7 +1489,7 @@ func (gs *GossipSubRouter) heartbeat() {
 		}
 
 		graftPeer := func(p peer.ID) {
-			log.Debugf("HEARTBEAT: Add mesh link to %s in %s", p, topic)
+			gs.logger.Debug("HEARTBEAT: Add mesh link to peer in topic", "peer", p, "topic", topic)
 			gs.tracer.Graft(p, topic)
 			peers[p] = struct{}{}
 			topics := tograft[p]
@@ -1500,7 +1499,7 @@ func (gs *GossipSubRouter) heartbeat() {
 		// drop all peers with negative score, without PX
 		for p := range peers {
 			if score(p) < 0 {
-				log.Debugf("HEARTBEAT: Prune peer %s with negative score [score = %f, topic = %s]", p, score(p), topic)
+				gs.logger.Debug("HEARTBEAT: Prune peer with negative score", "peer", p, "score", score(p), "topic", topic)
 				prunePeer(p)
 				noPX[p] = true
 			}
@@ -1581,7 +1580,7 @@ func (gs *GossipSubRouter) heartbeat() {
 
 			// prune the excess peers
 			for _, p := range plst[gs.params.D:] {
-				log.Debugf("HEARTBEAT: Remove mesh link to %s in %s", p, topic)
+				gs.logger.Debug("HEARTBEAT: Remove mesh link to peer in topic", "peer", p, "topic", topic)
 				prunePeer(p)
 			}
 		}
@@ -1642,7 +1641,7 @@ func (gs *GossipSubRouter) heartbeat() {
 				})
 
 				for _, p := range plst {
-					log.Debugf("HEARTBEAT: Opportunistically graft peer %s on topic %s", p, topic)
+					gs.logger.Debug("HEARTBEAT: Opportunistically graft peer on topic", "peer", p, "topic", topic)
 					graftPeer(p)
 				}
 			}
@@ -1733,7 +1732,7 @@ func (gs *GossipSubRouter) clearIDontWantCounters() {
 
 func (gs *GossipSubRouter) applyIwantPenalties() {
 	for p, count := range gs.gossipTracer.GetBrokenPromises() {
-		log.Infof("peer %s didn't follow up in %d IWANT requests; adding penalty", p, count)
+		gs.logger.Info("peer didn't follow up in IWANT requests; adding penalty", "peer", p, "requestCount", count)
 		gs.score.AddPenalty(p, count)
 	}
 }
@@ -1834,7 +1833,7 @@ func (gs *GossipSubRouter) emitGossip(topic string, exclude map[peer.ID]struct{}
 	// if we are emitting more than GossipSubMaxIHaveLength mids, truncate the list
 	if len(mids) > gs.params.MaxIHaveLength {
 		// we do the truncation (with shuffling) per peer below
-		log.Debugf("too many messages for gossip; will truncate IHAVE list (%d messages)", len(mids))
+		gs.logger.Debug("too many messages for gossip; will truncate IHAVE list", "messageCount", len(mids))
 	}
 
 	// Send gossip to GossipFactor peers above threshold, with a minimum of D_lazy.
@@ -1999,7 +1998,7 @@ func (gs *GossipSubRouter) makePrune(p peer.ID, topic string, doPX bool, isUnsub
 				if spr != nil {
 					recordBytes, err = spr.Marshal()
 					if err != nil {
-						log.Warnf("error marshaling signed peer record for %s: %s", p, err)
+						gs.logger.Warn("error marshaling signed peer record for peer", "peer", p, "err", err)
 					}
 				}
 			}

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -7,8 +7,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"log/slog"
 	mrand "math/rand"
 	mrand2 "math/rand/v2"
+	"os"
 	"slices"
 	"sort"
 	"strconv"
@@ -19,6 +21,7 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/libp2p/go-libp2p-pubsub/internal/gologshim"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 
 	"github.com/libp2p/go-libp2p/core/host"
@@ -42,7 +45,21 @@ func getGossipsub(ctx context.Context, h host.Host, opts ...Option) *PubSub {
 
 func getGossipsubs(ctx context.Context, hs []host.Host, opts ...Option) []*PubSub {
 	var psubs []*PubSub
+	optsCopy := make([]Option, len(opts)+1)
+	copy(optsCopy[1:], opts)
+	logger := gologshim.Logger("pubsub")
 	for _, h := range hs {
+		// Set WithLogger option first so that later options can override it
+		optsCopy[0] = WithLogger(logger.With("id", h.ID()))
+		psubs = append(psubs, getGossipsub(ctx, h, optsCopy...))
+	}
+	return psubs
+}
+
+func getGossipsubsOptFn(ctx context.Context, hs []host.Host, optFn func(int, host.Host) []Option) []*PubSub {
+	var psubs []*PubSub
+	for i, h := range hs {
+		opts := optFn(i, h)
 		psubs = append(psubs, getGossipsub(ctx, h, opts...))
 	}
 	return psubs
@@ -53,7 +70,13 @@ func TestSparseGossipsub(t *testing.T) {
 	defer cancel()
 	hosts := getDefaultHosts(t, 20)
 
-	psubs := getGossipsubs(ctx, hosts)
+	psubs := getGossipsubsOptFn(ctx, hosts, func(i int, h host.Host) []Option {
+		lh := slog.NewJSONHandler(os.Stdout, nil)
+		logger := slog.New(lh.WithAttrs([]slog.Attr{slog.String("id", h.ID().String())}))
+		return []Option{
+			WithRPCLogger(logger),
+		}
+	})
 
 	var msgs []*Subscription
 	for _, ps := range psubs {

--- a/internal/gologshim/gologshim.go
+++ b/internal/gologshim/gologshim.go
@@ -1,0 +1,146 @@
+package gologshim
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+)
+
+var lvlToLower = map[slog.Level]slog.Value{
+	slog.LevelDebug: slog.StringValue("debug"),
+	slog.LevelInfo:  slog.StringValue("info"),
+	slog.LevelWarn:  slog.StringValue("warn"),
+	slog.LevelError: slog.StringValue("error"),
+}
+
+// Logger returns a *slog.Logger with a logging level defined by the
+// GOLOG_LOG_LEVEL env var. Supports different levels for different systems. e.g.
+// GOLOG_LOG_LEVEL=foo=info,bar=debug,warn
+// sets the foo system at level info, the bar system at level debug and the
+// fallback level to warn.
+//
+// Prefer a parameterized logger over a global logger.
+func Logger(system string) *slog.Logger {
+	var h slog.Handler
+	c := ConfigFromEnv()
+	handlerOpts := &slog.HandlerOptions{
+		Level:     c.LevelForSystem(system),
+		AddSource: c.addSource,
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				// ipfs go-log uses "ts" for time
+				a.Key = "ts"
+			} else if a.Key == slog.LevelKey {
+				// ipfs go-log uses lowercase level names
+				if lvl, ok := a.Value.Any().(slog.Level); ok {
+					if s, ok := lvlToLower[lvl]; ok {
+						a.Value = s
+					}
+				}
+			}
+			return a
+		},
+	}
+	if c.format == logFormatText {
+		h = slog.NewTextHandler(os.Stderr, handlerOpts)
+	} else {
+		h = slog.NewJSONHandler(os.Stderr, handlerOpts)
+	}
+	attrs := make([]slog.Attr, 1+len(c.labels))
+	attrs = append(attrs, slog.String("logger", system))
+	attrs = append(attrs, c.labels...)
+	h = h.WithAttrs(attrs)
+	return slog.New(h)
+}
+
+type logFormat = int
+
+const (
+	logFormatText logFormat = iota
+	logFormatJSON
+)
+
+type Config struct {
+	fallbackLvl   slog.Level
+	systemToLevel map[string]slog.Level
+	format        logFormat
+	addSource     bool
+	labels        []slog.Attr
+}
+
+func (c *Config) LevelForSystem(system string) slog.Level {
+	if lvl, ok := c.systemToLevel[system]; ok {
+		return lvl
+	}
+	return c.fallbackLvl
+}
+
+var ConfigFromEnv func() *Config = sync.OnceValue(func() *Config {
+	fallback, systemToLevel, err := parseIPFSGoLogEnv(os.Getenv("GOLOG_LOG_LEVEL"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse GOLOG_LOG_LEVEL: %v", err)
+		fallback = slog.LevelInfo
+	}
+	c := &Config{
+		fallbackLvl:   fallback,
+		systemToLevel: systemToLevel,
+		addSource:     true,
+	}
+
+	logFmt := os.Getenv("GOLOG_LOG_FORMAT")
+	if logFmt == "" {
+		logFmt = os.Getenv("GOLOG_LOG_FMT")
+	}
+	if logFmt == "json" {
+		c.format = logFormatJSON
+	}
+
+	logFmt = os.Getenv("GOLOG_LOG_ADD_SOURCE")
+	if logFmt == "0" || logFmt == "false" {
+		c.addSource = false
+	}
+
+	labels := os.Getenv("GOLOG_LOG_LABELS")
+	if labels != "" {
+		labels := strings.Split(labels, ",")
+		if len(labels) > 0 {
+			for _, label := range labels {
+				kv := strings.SplitN(label, "=", 2)
+				if len(kv) == 2 {
+					c.labels = append(c.labels, slog.String(kv[0], kv[1]))
+				} else {
+					fmt.Fprintf(os.Stderr, "Invalid label format: %s", label)
+				}
+			}
+		}
+	}
+
+	return c
+})
+
+func parseIPFSGoLogEnv(loggingLevelEnvStr string) (slog.Level, map[string]slog.Level, error) {
+	fallbackLvl := slog.LevelError
+	var systemToLevel map[string]slog.Level
+	if loggingLevelEnvStr != "" {
+		for _, kvs := range strings.Split(loggingLevelEnvStr, ",") {
+			kv := strings.SplitN(kvs, "=", 2)
+			var lvl slog.Level
+			err := lvl.UnmarshalText([]byte(kv[len(kv)-1]))
+			if err != nil {
+				return lvl, nil, err
+			}
+			switch len(kv) {
+			case 1:
+				fallbackLvl = lvl
+			case 2:
+				if systemToLevel == nil {
+					systemToLevel = make(map[string]slog.Level)
+				}
+				systemToLevel[kv[0]] = lvl
+			}
+		}
+	}
+	return fallbackLvl, systemToLevel, nil
+}

--- a/pb/slog.go
+++ b/pb/slog.go
@@ -1,0 +1,31 @@
+package pubsub_pb
+
+import "log/slog"
+
+var _ slog.LogValuer = (*RPC)(nil)
+
+func (m *RPC) LogValue() slog.Value {
+	// Messages
+	var msgs []any
+	for _, msg := range m.Publish {
+		msgs = append(msgs, slog.Group(
+			"message",
+			slog.String("topic", msg.GetTopic()),
+			slog.Int("dataLen", len(msg.Data)),
+			// For debugging
+			// slog.Any("dataPrefix", msg.Data[0:min(len(msg.Data), 32)]),
+		))
+	}
+
+	var fields []slog.Attr
+	if len(msgs) > 0 {
+		fields = append(fields, slog.Group("publish", msgs...))
+	}
+	if m.Control != nil {
+		fields = append(fields, slog.Any("control", m.Control))
+	}
+	if m.Subscriptions != nil {
+		fields = append(fields, slog.Any("subscriptions", m.Subscriptions))
+	}
+	return slog.GroupValue(fields...)
+}

--- a/peer_gater_test.go
+++ b/peer_gater_test.go
@@ -2,6 +2,7 @@ package pubsub
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -21,7 +22,7 @@ func TestPeerGater(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pg := newPeerGater(ctx, nil, params)
+	pg := newPeerGater(ctx, nil, params, slog.Default())
 	pg.getIP = func(p peer.ID) string {
 		switch p {
 		case peerA:

--- a/peer_notify.go
+++ b/peer_notify.go
@@ -17,7 +17,7 @@ func (ps *PubSub) watchForNewPeers(ctx context.Context) {
 		&event.EvtPeerProtocolsUpdated{},
 	})
 	if err != nil {
-		log.Errorf("failed to subscribe to peer identification events: %v", err)
+		ps.logger.Error("failed to subscribe to peer identification events", "err", err)
 		return
 	}
 	defer sub.Close()

--- a/pubsub.go
+++ b/pubsub.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"log/slog"
 	"math/bits"
 	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/libp2p/go-libp2p-pubsub/internal/gologshim"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p-pubsub/timecache"
 
@@ -21,8 +23,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
-
-	logging "github.com/ipfs/go-log/v2"
 )
 
 // DefaultMaximumMessageSize is 1mb.
@@ -41,8 +41,6 @@ var (
 	// subscription has been cancelled.
 	ErrSubscriptionCancelled = errors.New("subscription cancelled")
 )
-
-var log = logging.Logger("pubsub")
 
 type ProtocolMatchFn = func(protocol.ID) func(protocol.ID) bool
 
@@ -64,6 +62,10 @@ type PubSub struct {
 	disc *discover
 
 	tracer *pubsubTracer
+
+	logger *slog.Logger
+	// rpcLogger is a logger that is only used to log RPC sends and receives
+	rpcLogger *slog.Logger
 
 	peerFilter PeerFilter
 
@@ -457,10 +459,13 @@ type Option func(*PubSub) error
 
 // NewPubSub returns a new PubSub management object.
 func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option) (*PubSub, error) {
+	log := gologshim.Logger("pubsub").With(slog.Attr{Key: "id", Value: slog.StringValue(h.ID().String())})
+
 	ps := &PubSub{
 		host:                  h,
 		ctx:                   ctx,
 		rt:                    rt,
+		logger:                log,
 		val:                   newValidation(),
 		peerFilter:            DefaultPeerFilter,
 		disc:                  &discover{},
@@ -509,6 +514,10 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if ps.rpcLogger == nil {
+		ps.rpcLogger = slog.New(ps.logger.Handler().WithAttrs([]slog.Attr{slog.String("system", "pubsub/rpc")}))
 	}
 
 	if ps.signPolicy.mustSign() {
@@ -698,6 +707,22 @@ func WithRawTracer(tracer RawTracer) Option {
 	}
 }
 
+// WithLogger customizes pubsub's logger.
+func WithLogger(logger *slog.Logger) Option {
+	return func(p *PubSub) error {
+		p.logger = logger
+		return nil
+	}
+}
+
+// WithRPCLogger customizes pubsub's RPC logger
+func WithRPCLogger(logger *slog.Logger) Option {
+	return func(p *PubSub) error {
+		p.rpcLogger = logger
+		return nil
+	}
+}
+
 // WithMaxMessageSize sets the global maximum message size for pubsub wire
 // messages. The default value is 1MiB (DefaultMaxMessageSize).
 //
@@ -786,13 +811,13 @@ func (p *PubSub) processLoop(ctx context.Context) {
 
 			q, ok := p.peers[pid]
 			if !ok {
-				log.Warn("new stream for unknown peer: ", pid)
+				p.logger.Warn("new stream for unknown peer", "peer", pid)
 				s.Reset()
 				continue
 			}
 
 			if p.blacklist.Contains(pid) {
-				log.Warn("closing stream for blacklisted peer: ", pid)
+				p.logger.Warn("closing stream for blacklisted peer", "peer", pid)
 				q.Close()
 				delete(p.peers, pid)
 				s.Reset()
@@ -861,7 +886,7 @@ func (p *PubSub) processLoop(ctx context.Context) {
 			thunk()
 
 		case pid := <-p.blacklistPeer:
-			log.Infof("Blacklisting peer %s", pid)
+			p.logger.Info("Blacklisting peer", "peer", pid)
 			p.blacklist.Add(pid)
 
 			q, ok := p.peers[pid]
@@ -878,7 +903,7 @@ func (p *PubSub) processLoop(ctx context.Context) {
 			}
 
 		case <-ctx.Done():
-			log.Info("pubsub processloop shutting down")
+			p.logger.Info("pubsub processloop shutting down")
 			return
 		}
 	}
@@ -904,12 +929,12 @@ func (p *PubSub) handlePendingPeers() {
 		}
 
 		if _, ok := p.peers[pid]; ok {
-			log.Debug("already have connection to peer: ", pid)
+			p.logger.Debug("already have connection to peer", "peer", pid)
 			continue
 		}
 
 		if p.blacklist.Contains(pid) {
-			log.Warn("ignoring connection from blacklisted peer: ", pid)
+			p.logger.Warn("ignoring connection from blacklisted peer", "peer", pid)
 			continue
 		}
 
@@ -953,13 +978,13 @@ func (p *PubSub) handleDeadPeers() {
 		if p.host.Network().Connectedness(pid) == network.Connected {
 			backoffDelay, err := p.deadPeerBackoff.updateAndGet(pid)
 			if err != nil {
-				log.Debug(err)
+				p.logger.Debug("error updating backoff", "err", err, "peer", pid)
 				continue
 			}
 
 			// still connected, must be a duplicate connection being closed.
 			// we respawn the writer as we need to ensure there is a stream active
-			log.Debugf("peer declared dead but still connected; respawning writer: %s", pid)
+			p.logger.Debug("peer declared dead but still connected; respawning writer", "peer", pid)
 			rpcQueue := newRpcQueue(p.peerOutboundQueueSize)
 			rpcQueue.Push(p.getHelloPacket(), true)
 			p.peers[pid] = rpcQueue
@@ -1129,7 +1154,7 @@ func (p *PubSub) announce(topic string, sub bool) {
 	for pid, peer := range p.peers {
 		err := peer.Push(out, false)
 		if err != nil {
-			log.Infof("Can't send announce message to peer %s: queue full; scheduling retry", pid)
+			p.logger.Info("Can't send announce message to peer: queue full; scheduling retry", "peer", pid)
 			p.tracer.DropRPC(out, pid)
 			go p.announceRetry(pid, topic, sub)
 			continue
@@ -1172,7 +1197,7 @@ func (p *PubSub) doAnnounceRetry(pid peer.ID, topic string, sub bool) {
 	out := rpcWithSubs(subopt)
 	err := peer.Push(out, false)
 	if err != nil {
-		log.Infof("Can't send announce message to peer %s: queue full; scheduling retry", pid)
+		p.logger.Info("Can't send announce message to peer: queue full; scheduling retry", "peer", pid)
 		p.tracer.DropRPC(out, pid)
 		go p.announceRetry(pid, topic, sub)
 		return
@@ -1190,7 +1215,7 @@ func (p *PubSub) notifySubs(msg *Message) {
 		case f.ch <- msg:
 		default:
 			p.tracer.UndeliverableMessage(msg)
-			log.Infof("Can't deliver message to subscription for topic %s; subscriber too slow", topic)
+			p.logger.Info("Can't deliver message to subscription for topic; subscriber too slow", "topic", topic)
 		}
 	}
 }
@@ -1243,7 +1268,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 	if p.appSpecificRpcInspector != nil {
 		// check if the RPC is allowed by the external inspector
 		if err := p.appSpecificRpcInspector(rpc.from, rpc); err != nil {
-			log.Debugf("application-specific inspection failed, rejecting incoming rpc: %s", err)
+			p.logger.Debug("application-specific inspection failed, rejecting incoming rpc", "err", err)
 			return // reject the RPC
 		}
 	}
@@ -1255,7 +1280,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 		var err error
 		subs, err = p.subFilter.FilterIncomingSubscriptions(rpc.from, subs)
 		if err != nil {
-			log.Debugf("subscription filter error: %s; ignoring RPC", err)
+			p.logger.Debug("subscription filter error; ignoring RPC", "err", err)
 			return
 		}
 	}
@@ -1293,12 +1318,12 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 	// ask the router to vet the peer before commiting any processing resources
 	switch p.rt.AcceptFrom(rpc.from) {
 	case AcceptNone:
-		log.Debugf("received RPC from router graylisted peer %s; dropping RPC", rpc.from)
+		p.logger.Debug("received RPC from router graylisted peer; dropping RPC", "peer", rpc.from)
 		return
 
 	case AcceptControl:
 		if len(rpc.GetPublish()) > 0 {
-			log.Debugf("peer %s was throttled by router; ignoring %d payload messages", rpc.from, len(rpc.GetPublish()))
+			p.logger.Debug("peer was throttled by router; ignoring payload messages", "peer", rpc.from, "messageCount", len(rpc.GetPublish()))
 		}
 		p.tracer.ThrottlePeer(rpc.from)
 
@@ -1306,7 +1331,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 		var toPush []*Message
 		for _, pmsg := range rpc.GetPublish() {
 			if !(p.subscribedToMsg(pmsg) || p.canRelayMsg(pmsg)) {
-				log.Debug("received message in topic we didn't subscribe to; ignoring message")
+				p.logger.Debug("received message in topic we didn't subscribe to; ignoring message")
 				continue
 			}
 
@@ -1340,28 +1365,28 @@ func (p *PubSub) shouldPush(msg *Message) bool {
 	src := msg.ReceivedFrom
 	// reject messages from blacklisted peers
 	if p.blacklist.Contains(src) {
-		log.Debugf("dropping message from blacklisted peer %s", src)
+		p.logger.Debug("dropping message from blacklisted peer", "peer", src)
 		p.tracer.RejectMessage(msg, RejectBlacklstedPeer)
 		return false
 	}
 
 	// even if they are forwarded by good peers
 	if p.blacklist.Contains(msg.GetFrom()) {
-		log.Debugf("dropping message from blacklisted source %s", src)
+		p.logger.Debug("dropping message from blacklisted source", "source", src)
 		p.tracer.RejectMessage(msg, RejectBlacklistedSource)
 		return false
 	}
 
 	err := p.checkSigningPolicy(msg)
 	if err != nil {
-		log.Debugf("dropping message from %s: %s", src, err)
+		p.logger.Debug("dropping message from peer", "peer", src, "err", err)
 		return false
 	}
 
 	// reject messages claiming to be from ourselves but not locally published
 	self := p.host.ID()
 	if peer.ID(msg.GetFrom()) == self && src != self {
-		log.Debugf("dropping message claiming to be from self but forwarded from %s", src)
+		p.logger.Debug("dropping message claiming to be from self but forwarded from peer", "peer", src)
 		p.tracer.RejectMessage(msg, RejectSelfOrigin)
 		return false
 	}

--- a/randomsub.go
+++ b/randomsub.go
@@ -153,7 +153,7 @@ func (rs *RandomSubRouter) Publish(msg *Message) {
 
 		err := q.Push(out, false)
 		if err != nil {
-			log.Infof("dropping message to peer %s: queue full", p)
+			rs.p.logger.Info("dropping message to peer: queue full", "peer", p)
 			rs.tracer.DropRPC(out, p)
 			continue
 		}

--- a/score_test.go
+++ b/score_test.go
@@ -1,6 +1,7 @@
 package pubsub
 
 import (
+	"log/slog"
 	"math"
 	"net"
 	"sync"
@@ -28,7 +29,7 @@ func TestScoreTimeInMesh(t *testing.T) {
 	peerA := peer.ID("A")
 
 	// Peer score should start at 0
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 
 	aScore := ps.Score(peerA)
@@ -67,7 +68,7 @@ func TestScoreTimeInMeshCap(t *testing.T) {
 
 	peerA := peer.ID("A")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 	ps.Graft(peerA, mytopic)
 	elapsed := topicScoreParams.TimeInMeshQuantum * 40
@@ -101,7 +102,7 @@ func TestScoreFirstMessageDeliveries(t *testing.T) {
 	params.Topics[mytopic] = topicScoreParams
 	peerA := peer.ID("A")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 	ps.Graft(peerA, mytopic)
 
@@ -141,7 +142,7 @@ func TestScoreFirstMessageDeliveriesCap(t *testing.T) {
 	params.Topics[mytopic] = topicScoreParams
 	peerA := peer.ID("A")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 	ps.Graft(peerA, mytopic)
 
@@ -181,7 +182,7 @@ func TestScoreFirstMessageDeliveriesDecay(t *testing.T) {
 	params.Topics[mytopic] = topicScoreParams
 	peerA := peer.ID("A")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 	ps.Graft(peerA, mytopic)
 
@@ -246,7 +247,7 @@ func TestScoreMeshMessageDeliveries(t *testing.T) {
 	peerC := peer.ID("C")
 	peers := []peer.ID{peerA, peerB, peerC}
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	for _, p := range peers {
 		ps.AddPeer(p, "myproto")
 		ps.Graft(p, mytopic)
@@ -331,7 +332,7 @@ func TestScoreMeshMessageDeliveriesDecay(t *testing.T) {
 
 	peerA := peer.ID("A")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 	ps.Graft(peerA, mytopic)
 
@@ -403,7 +404,7 @@ func TestScoreMeshFailurePenalty(t *testing.T) {
 	peerB := peer.ID("B")
 	peers := []peer.ID{peerA, peerB}
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	for _, p := range peers {
 		ps.AddPeer(p, "myproto")
 		ps.Graft(p, mytopic)
@@ -466,7 +467,7 @@ func TestScoreInvalidMessageDeliveries(t *testing.T) {
 
 	peerA := peer.ID("A")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 	ps.Graft(peerA, mytopic)
 
@@ -503,7 +504,7 @@ func TestScoreInvalidMessageDeliveriesDecay(t *testing.T) {
 
 	peerA := peer.ID("A")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 	ps.Graft(peerA, mytopic)
 
@@ -551,7 +552,7 @@ func TestScoreRejectMessageDeliveries(t *testing.T) {
 	peerA := peer.ID("A")
 	peerB := peer.ID("B")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 	ps.AddPeer(peerB, "myproto")
 
@@ -678,7 +679,7 @@ func TestScoreApplicationScore(t *testing.T) {
 
 	peerA := peer.ID("A")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 	ps.Graft(peerA, mytopic)
 
@@ -710,7 +711,7 @@ func TestScoreIPColocation(t *testing.T) {
 	peerD := peer.ID("D")
 	peers := []peer.ID{peerA, peerB, peerC, peerD}
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	for _, p := range peers {
 		ps.AddPeer(p, "myproto")
 		ps.Graft(p, mytopic)
@@ -766,7 +767,7 @@ func TestScoreIPColocationWhitelist(t *testing.T) {
 	peerD := peer.ID("D")
 	peers := []peer.ID{peerA, peerB, peerC, peerD}
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	for _, p := range peers {
 		ps.AddPeer(p, "myproto")
 		ps.Graft(p, mytopic)
@@ -821,7 +822,7 @@ func TestScoreBehaviourPenalty(t *testing.T) {
 	}
 
 	// instantiate the peerScore
-	ps = newPeerScore(params)
+	ps = newPeerScore(params, slog.Default())
 
 	// next AddPenalty on a non-existent peer
 	ps.AddPenalty(peerA, 1)
@@ -871,7 +872,7 @@ func TestScoreRetention(t *testing.T) {
 
 	peerA := peer.ID("A")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 	ps.Graft(peerA, mytopic)
 
@@ -937,7 +938,7 @@ func TestScoreRecapTopicParams(t *testing.T) {
 	peerB := peer.ID("B")
 	peers := []peer.ID{peerA, peerB}
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	for _, p := range peers {
 		ps.AddPeer(p, "myproto")
 		ps.Graft(p, mytopic)
@@ -1022,7 +1023,7 @@ func TestScoreResetTopicParams(t *testing.T) {
 	// Peer C should have a negative score.
 	peerA := peer.ID("A")
 
-	ps := newPeerScore(params)
+	ps := newPeerScore(params, slog.Default())
 	ps.AddPeer(peerA, "myproto")
 
 	// reject a bunch of messages

--- a/trace_test.go
+++ b/trace_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sync"
 	"testing"
@@ -307,7 +308,7 @@ func TestRemoteTracer(t *testing.T) {
 	mrt := &mockRemoteTracer{}
 	h1.SetStreamHandler(RemoteTracerProtoID, mrt.handleStream)
 
-	tracer, err := NewRemoteTracer(ctx, h2, peer.AddrInfo{ID: h1.ID(), Addrs: h1.Addrs()})
+	tracer, err := NewRemoteTracer(ctx, h2, peer.AddrInfo{ID: h1.ID(), Addrs: h1.Addrs()}, slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/validation_builtin_test.go
+++ b/validation_builtin_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"sync"
 	"testing"
@@ -54,7 +55,7 @@ func testBasicSeqnoValidator(t *testing.T, ttl time.Duration) {
 	hosts := getDefaultHosts(t, 20)
 	psubs := getPubsubsWithOptionC(ctx, hosts,
 		func(i int) Option {
-			return WithDefaultValidator(NewBasicSeqnoValidator(newMockPeerMetadataStore()))
+			return WithDefaultValidator(NewBasicSeqnoValidator(newMockPeerMetadataStore(), slog.Default()))
 		},
 		func(i int) Option {
 			return WithSeenMessagesTTL(ttl)
@@ -102,7 +103,7 @@ func TestBasicSeqnoValidatorReplay(t *testing.T) {
 	hosts := getDefaultHosts(t, 20)
 	psubs := getPubsubsWithOptionC(ctx, hosts[:19],
 		func(i int) Option {
-			return WithDefaultValidator(NewBasicSeqnoValidator(newMockPeerMetadataStore()))
+			return WithDefaultValidator(NewBasicSeqnoValidator(newMockPeerMetadataStore(), slog.Default()))
 		},
 		func(i int) Option {
 			return WithSeenMessagesTTL(time.Nanosecond)


### PR DESCRIPTION
related to https://github.com/libp2p/go-libp2p/issues/3362.

- Changes all logging to be structured.
- Removes the global logger. This is really nice for tests since you can now see which ID a log line belongs to.
- Adds a sub-logger just for RPC messages. In my experience the RPC messages are the only thing I need to debug issues. It's nice to have the structured log there I can use easily without having to futz around with tracers.
- Implements the LogValuer interface for the RPC pb type. In practice it's much easier to update this implementation than it is to maintain a separate trace protobuf system.

Currently inlines an internal `gologshim.go` package to maintain ipfs/go-log environment variable compatibility. Once https://github.com/libp2p/go-libp2p/pull/3364 is merged, we can use the gologshim package in go-libp2p.