### PR TITLE
fix logic of omitting IDONTWANT to peers that support partial messages

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -864,7 +864,7 @@ func (gs *GossipSubRouter) Preprocess(from peer.ID, msgs []*Message) {
 				// We don't send IDONTWANT to the peer that sent us the messages
 				continue
 			}
-			if gs.iSupportSendingPartial(topic) && gs.peerRequestsPartial(p, topic) {
+			if gs.iRequestPartial(topic) && gs.peerSupportsSendingPartial(p, topic) {
 				// Don't send IDONTWANT to peers that are using partial messages
 				// for this topic
 				continue


### PR DESCRIPTION
IDONTWANT is to tell peers not to send us a message. We should omit it if we requested a partial messages and the peer supports sending us partial messages. We omit it because we don't expect to get full messages from this peer anyways.