### PR TITLE
Include peer we are sending to for EagerPartialMessageBytes

### DIFF
--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -4511,7 +4511,7 @@ func (m *minimalTestPartialMessage) GroupID() []byte {
 	return m.Group
 }
 
-func (m *minimalTestPartialMessage) EagerPartialMessageBytes() ([]byte, partialmessages.PartsMetadata, error) {
+func (m *minimalTestPartialMessage) EagerPartialMessageBytes(to peer.ID) ([]byte, partialmessages.PartsMetadata, error) {
 	// Return nil to indicate no eager push data
 	return nil, nil, nil
 }

--- a/partialmessages/partialmsgs_test.go
+++ b/partialmessages/partialmsgs_test.go
@@ -234,7 +234,7 @@ func (pm *testPartialMessage) shouldRequest(partsMetadata []byte) bool {
 }
 
 // EagerPartialMessageBytes implements Message.
-func (pm *testPartialMessage) EagerPartialMessageBytes() ([]byte, PartsMetadata, error) {
+func (pm *testPartialMessage) EagerPartialMessageBytes(to peer.ID) ([]byte, PartsMetadata, error) {
 	// Only eager push if explicitly requested (not for received messages)
 	if !pm.shouldEagerPush {
 		return nil, nil, nil


### PR DESCRIPTION
Allows applications to control the eager data depending on the destination peer.

Cell-Level Deltas in Ethereum for example, only need to send the PartialDataColumn header once per peer across any topics. This change enables that.