### PR TITLE
Include from in the RecvRPC trace

### DIFF
--- a/gossip_tracer.go
+++ b/gossip_tracer.go
@@ -174,7 +174,7 @@ func (gt *gossipTracer) Leave(topic string)                   {}
 func (gt *gossipTracer) Graft(p peer.ID, topic string)        {}
 func (gt *gossipTracer) Prune(p peer.ID, topic string)        {}
 func (gt *gossipTracer) DuplicateMessage(msg *Message)        {}
-func (gt *gossipTracer) RecvRPC(rpc *RPC)                     {}
+func (gt *gossipTracer) RecvRPC(rpc *RPC, p peer.ID)          {}
 func (gt *gossipTracer) SendRPC(rpc *RPC, p peer.ID)          {}
 func (gt *gossipTracer) DropRPC(rpc *RPC, p peer.ID)          {}
 func (gt *gossipTracer) UndeliverableMessage(msg *Message)    {}

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -3051,7 +3051,7 @@ type mockRawTracer struct {
 	onRecvRPC func(*RPC)
 }
 
-func (m *mockRawTracer) RecvRPC(rpc *RPC) {
+func (m *mockRawTracer) RecvRPC(rpc *RPC, p peer.ID) {
 	if m.onRecvRPC != nil {
 		m.onRecvRPC(rpc)
 	}

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -449,7 +449,7 @@ func (pg *peerGater) DuplicateMessage(msg *Message) {
 
 func (pg *peerGater) ThrottlePeer(p peer.ID) {}
 
-func (pg *peerGater) RecvRPC(rpc *RPC) {}
+func (pg *peerGater) RecvRPC(rpc *RPC, p peer.ID) {}
 
 func (pg *peerGater) SendRPC(rpc *RPC, p peer.ID) {}
 

--- a/pubsub.go
+++ b/pubsub.go
@@ -1345,7 +1345,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 		}
 	}
 
-	p.tracer.RecvRPC(rpc)
+	p.tracer.RecvRPC(rpc, rpc.from)
 
 	subs := rpc.GetSubscriptions()
 	if len(subs) != 0 && p.subFilter != nil {

--- a/score.go
+++ b/score.go
@@ -834,7 +834,7 @@ func (ps *peerScore) DuplicateMessage(msg *Message) {
 
 func (ps *peerScore) ThrottlePeer(p peer.ID) {}
 
-func (ps *peerScore) RecvRPC(rpc *RPC) {}
+func (ps *peerScore) RecvRPC(rpc *RPC, p peer.ID) {}
 
 func (ps *peerScore) SendRPC(rpc *RPC, p peer.ID) {}
 

--- a/tag_tracer.go
+++ b/tag_tracer.go
@@ -261,7 +261,7 @@ func (t *tagTracer) RejectMessage(msg *Message, reason string) {
 
 func (t *tagTracer) RemovePeer(peer.ID)                {}
 func (t *tagTracer) ThrottlePeer(p peer.ID)            {}
-func (t *tagTracer) RecvRPC(rpc *RPC)                  {}
+func (t *tagTracer) RecvRPC(rpc *RPC, p peer.ID)       {}
 func (t *tagTracer) SendRPC(rpc *RPC, p peer.ID)       {}
 func (t *tagTracer) DropRPC(rpc *RPC, p peer.ID)       {}
 func (t *tagTracer) UndeliverableMessage(msg *Message) {}

--- a/trace.go
+++ b/trace.go
@@ -49,7 +49,7 @@ type RawTracer interface {
 	// ThrottlePeer is invoked when a peer is throttled by the peer gater.
 	ThrottlePeer(p peer.ID)
 	// RecvRPC is invoked when an incoming RPC is received.
-	RecvRPC(rpc *RPC)
+	RecvRPC(rpc *RPC, from peer.ID)
 	// SendRPC is invoked when a RPC is sent.
 	SendRPC(rpc *RPC, p peer.ID)
 	// DropRPC is invoked when an outbound RPC is dropped, typically because of a queue full.
@@ -247,13 +247,13 @@ func (t *pubsubTracer) RemovePeer(p peer.ID) {
 	t.tracer.Trace(evt)
 }
 
-func (t *pubsubTracer) RecvRPC(rpc *RPC) {
+func (t *pubsubTracer) RecvRPC(rpc *RPC, p peer.ID) {
 	if t == nil {
 		return
 	}
 
 	for _, tr := range t.raw {
-		tr.RecvRPC(rpc)
+		tr.RecvRPC(rpc, p)
 	}
 
 	if t.tracer == nil {


### PR DESCRIPTION
allows applications to attribute the RPC to a peer.