### PR TITLE
Add Rpc.From()

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -276,6 +276,10 @@ type RPC struct {
 	from peer.ID
 }
 
+func (rpc *RPC) From() peer.ID {
+	return rpc.from
+}
+
 // LogValue implements slog.LogValuer.
 func (rpc *RPC) LogValue() slog.Value {
 	// Messages


### PR DESCRIPTION
Alternative to #665 that doesn't break existing tracers. I think I have a preference for this one.