### PR TITLE
Refactor parts metadata

### DIFF
--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -4510,14 +4510,10 @@ func (m *minimalTestPartialMessage) GroupID() []byte {
 	return m.Group
 }
 
-func (m *minimalTestPartialMessage) EagerPartialMessageBytes() ([]byte, partialmessages.PartsMetadata, error) {
-	// Return nil to indicate no eager push data
-	return nil, nil, nil
-}
-
-func (m *minimalTestPartialMessage) PartialMessageBytes(peerPartsMetadata partialmessages.PartsMetadata) ([]byte, partialmessages.PartsMetadata, error) {
+func (m *minimalTestPartialMessage) PartialMessageBytes(from peer.ID, peerPartsMetadata partialmessages.PartsMetadata) ([]byte, partialmessages.PartsMetadata, error) {
 	if peerPartsMetadata == nil || len(peerPartsMetadata.Encode()) == 0 {
-		return nil, nil, errors.New("invalid metadata")
+		// No eager push data for this test implementation
+		return nil, nil, nil
 	}
 	peerHas := partialmessages.Bitmap(peerPartsMetadata.Encode())
 
@@ -4806,7 +4802,7 @@ func TestPeerSupportsPartialMessages(t *testing.T) {
 				if pm.onIncomingRPC(from, rpc) {
 					go psubs[i].PublishPartialMessage(topic, pm, partialmessages.PublishOptions{})
 					if pm.complete() {
-						encoded, _, _ := pm.PartialMessageBytes(partialmessages.Bitmap([]byte{0}))
+						encoded, _, _ := pm.PartialMessageBytes("", partialmessages.Bitmap([]byte{0}))
 						go func() {
 							err := psubs[i].Publish(topic, encoded)
 							if err != nil {
@@ -4889,7 +4885,7 @@ func TestPeerSupportsPartialMessages(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			encoded, _, err := fullMsg.PartialMessageBytes(partialmessages.Bitmap([]byte{0}))
+			encoded, _, err := fullMsg.PartialMessageBytes("", partialmessages.Bitmap([]byte{0}))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -5211,7 +5207,7 @@ func TestPairwiseInteractionWithPartialMessages(t *testing.T) {
 
 				partialMessageStore[i][topic+string(group)] = msg1
 
-				encoded, _, err := msg1.PartialMessageBytes(partialmessages.Bitmap([]byte{0}))
+				encoded, _, err := msg1.PartialMessageBytes("", partialmessages.Bitmap([]byte{0}))
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/libp2p/go-libp2p-pubsub/internal/gologshim"
 	"github.com/libp2p/go-libp2p-pubsub/partialmessages"
-	"github.com/libp2p/go-libp2p-pubsub/partialmessages/bitmap"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-msgio"
@@ -4462,13 +4461,13 @@ func (m *minimalTestPartialMessage) complete() bool {
 
 // PartsMetadata implements partialmessages.PartialMessage.
 func (m *minimalTestPartialMessage) PartsMetadata() partialmessages.PartsMetadata {
-	out := make(bitmap.Bitmap, 1)
+	out := make(partialmessages.Bitmap, 1)
 	for i := range m.Parts {
 		if len(m.Parts[i]) > 0 {
-			out.Set(i)
+			partialmessages.Bitmap(out).Set(i)
 		}
 	}
-	return partialmessages.PartsMetadata(out)
+	return out
 }
 
 func (m *minimalTestPartialMessage) extendFromEncodedPartialMessage(_ peer.ID, data []byte) (extended bool) {
@@ -4494,7 +4493,7 @@ func (m *minimalTestPartialMessage) onIncomingRPC(from peer.ID, rpc *pb.PartialM
 	// Only do these checks if we didn't extend our partial message.
 	// Since, otherwise, we simply publish again to all peers.
 	if len(rpc.PartsMetadata) > 0 {
-		iHave := m.PartsMetadata()[0]
+		iHave := m.PartsMetadata().Encode()[0]
 		iWant := ^iHave
 
 		peerHas := rpc.PartsMetadata[0]
@@ -4516,11 +4515,11 @@ func (m *minimalTestPartialMessage) EagerPartialMessageBytes() ([]byte, partialm
 	return nil, nil, nil
 }
 
-func (m *minimalTestPartialMessage) PartialMessageBytes(peerPartsMetadata partialmessages.PartsMetadata) ([]byte, error) {
-	if len(peerPartsMetadata) == 0 {
-		return nil, errors.New("invalid metadata")
+func (m *minimalTestPartialMessage) PartialMessageBytes(peerPartsMetadata partialmessages.PartsMetadata) ([]byte, partialmessages.PartsMetadata, error) {
+	if peerPartsMetadata == nil || len(peerPartsMetadata.Encode()) == 0 {
+		return nil, nil, errors.New("invalid metadata")
 	}
-	peerHas := bitmap.Bitmap(peerPartsMetadata)
+	peerHas := partialmessages.Bitmap(peerPartsMetadata.Encode())
 
 	var temp minimalTestPartialMessage
 	temp.Group = m.Group
@@ -4532,14 +4531,18 @@ func (m *minimalTestPartialMessage) PartialMessageBytes(peerPartsMetadata partia
 	}
 
 	if temp.Parts[0] == nil && temp.Parts[1] == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	b, err := json.Marshal(temp)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return b, nil
+
+	// Return merged metadata (what peer will have after receiving this)
+	merged := m.PartsMetadata().Clone()
+	merged.Merge(peerPartsMetadata)
+	return b, merged, nil
 }
 
 func (m *minimalTestPartialMessage) shouldRequest(_ peer.ID, peerHasMetadata []byte) bool {
@@ -4547,7 +4550,7 @@ func (m *minimalTestPartialMessage) shouldRequest(_ peer.ID, peerHasMetadata []b
 		return false
 	}
 	peerHas := peerHasMetadata[0]
-	iWant := ^m.PartsMetadata()[0]
+	iWant := ^m.PartsMetadata().Encode()[0]
 	return iWant&peerHas != 0
 }
 
@@ -4558,7 +4561,15 @@ type minimalTestPartialMessageChecker struct {
 }
 
 func (m *minimalTestPartialMessageChecker) MergePartsMetadata(left, right partialmessages.PartsMetadata) partialmessages.PartsMetadata {
-	return partialmessages.MergeBitmap(left, right)
+	if left == nil {
+		if right == nil {
+			return nil
+		}
+		return right.Clone()
+	}
+	merged := left.Clone()
+	merged.Merge(right)
+	return merged
 }
 
 // EmptyMessage implements partialmessages.InvariantChecker.
@@ -4651,8 +4662,8 @@ func TestPartialMessages(t *testing.T) {
 				// have some basic fast rules here.
 				return nil
 			},
-			MergePartsMetadata: func(_ string, left, right partialmessages.PartsMetadata) partialmessages.PartsMetadata {
-				return partialmessages.MergeBitmap(left, right)
+			DecodePartsMetadata: func(_ peer.ID, rpc *pb.PartialMessagesExtension) (partialmessages.PartsMetadata, error) {
+				return partialmessages.Bitmap(rpc.PartsMetadata), nil
 			},
 			OnIncomingRPC: func(from peer.ID, rpc *pb.PartialMessagesExtension) error {
 				groupID := rpc.GroupID
@@ -4769,8 +4780,8 @@ func TestPeerSupportsPartialMessages(t *testing.T) {
 				// have some basic fast rules here.
 				return nil
 			},
-			MergePartsMetadata: func(_ string, left, right partialmessages.PartsMetadata) partialmessages.PartsMetadata {
-				return partialmessages.MergeBitmap(left, right)
+			DecodePartsMetadata: func(_ peer.ID, rpc *pb.PartialMessagesExtension) (partialmessages.PartsMetadata, error) {
+				return partialmessages.Bitmap(rpc.PartsMetadata), nil
 			},
 			OnIncomingRPC: func(from peer.ID, rpc *pb.PartialMessagesExtension) error {
 				if from == hosts[1].ID() {
@@ -4795,7 +4806,7 @@ func TestPeerSupportsPartialMessages(t *testing.T) {
 				if pm.onIncomingRPC(from, rpc) {
 					go psubs[i].PublishPartialMessage(topic, pm, partialmessages.PublishOptions{})
 					if pm.complete() {
-						encoded, _ := pm.PartialMessageBytes(partialmessages.PartsMetadata([]byte{0}))
+						encoded, _, _ := pm.PartialMessageBytes(partialmessages.Bitmap([]byte{0}))
 						go func() {
 							err := psubs[i].Publish(topic, encoded)
 							if err != nil {
@@ -4878,7 +4889,7 @@ func TestPeerSupportsPartialMessages(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			encoded, err := fullMsg.PartialMessageBytes(partialmessages.PartsMetadata([]byte{0}))
+			encoded, _, err := fullMsg.PartialMessageBytes(partialmessages.Bitmap([]byte{0}))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -4955,8 +4966,8 @@ func TestSkipPublishingToPeersRequestingPartialMessages(t *testing.T) {
 			ValidateRPC: func(from peer.ID, rpc *pb.PartialMessagesExtension) error {
 				return nil
 			},
-			MergePartsMetadata: func(_ string, left, right partialmessages.PartsMetadata) partialmessages.PartsMetadata {
-				return partialmessages.MergeBitmap(left, right)
+			DecodePartsMetadata: func(_ peer.ID, rpc *pb.PartialMessagesExtension) (partialmessages.PartsMetadata, error) {
+				return partialmessages.Bitmap(rpc.PartsMetadata), nil
 			},
 			OnIncomingRPC: func(from peer.ID, rpc *pb.PartialMessagesExtension) error {
 				topicID := rpc.GetTopicID()
@@ -5107,8 +5118,8 @@ func TestPairwiseInteractionWithPartialMessages(t *testing.T) {
 						// have some basic fast rules here.
 						return nil
 					},
-					MergePartsMetadata: func(_ string, left, right partialmessages.PartsMetadata) partialmessages.PartsMetadata {
-						return partialmessages.MergeBitmap(left, right)
+					DecodePartsMetadata: func(_ peer.ID, rpc *pb.PartialMessagesExtension) (partialmessages.PartsMetadata, error) {
+						return partialmessages.Bitmap(rpc.PartsMetadata), nil
 					},
 					OnIncomingRPC: func(from peer.ID, rpc *pb.PartialMessagesExtension) error {
 						if tc.hostSupport[i] == PeerSupportsPartialMessages && len(rpc.PartialMessage) > 0 {
@@ -5200,7 +5211,7 @@ func TestPairwiseInteractionWithPartialMessages(t *testing.T) {
 
 				partialMessageStore[i][topic+string(group)] = msg1
 
-				encoded, err := msg1.PartialMessageBytes(partialmessages.PartsMetadata([]byte{0}))
+				encoded, _, err := msg1.PartialMessageBytes(partialmessages.Bitmap([]byte{0}))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -5262,8 +5273,8 @@ func TestNoIDONTWANTWithPartialMessage(t *testing.T) {
 			return []Option{
 				WithPartialMessagesExtension(
 					&partialmessages.PartialMessagesExtension{
-						MergePartsMetadata: func(topic string, left, right partialmessages.PartsMetadata) partialmessages.PartsMetadata {
-							return partialmessages.MergeBitmap(left, right)
+						DecodePartsMetadata: func(_ peer.ID, rpc *pb.PartialMessagesExtension) (partialmessages.PartsMetadata, error) {
+							return partialmessages.Bitmap(rpc.PartsMetadata), nil
 						},
 						Logger:        slog.Default(),
 						OnIncomingRPC: func(from peer.ID, rpc *pb.PartialMessagesExtension) error { return nil },

--- a/partialmessages/bitmap.go
+++ b/partialmessages/bitmap.go
@@ -1,7 +1,8 @@
-package bitmap
+package partialmessages
 
 import (
 	"math/bits"
+	"slices"
 )
 
 type Bitmap []byte
@@ -81,4 +82,46 @@ func (b Bitmap) Flip() {
 	for i := range b {
 		b[i] ^= 0xff
 	}
+}
+
+func (b Bitmap) Encode() []byte {
+	return []byte(slices.Clone(b))
+}
+
+func (b Bitmap) Clone() PartsMetadata {
+	if b == nil {
+		return Bitmap(nil)
+	}
+	clone := make(Bitmap, len(b))
+	copy(clone, b)
+	return clone
+}
+
+func (b Bitmap) Merge(other PartsMetadata) {
+	if other == nil {
+		return
+	}
+	if o, ok := other.(Bitmap); ok {
+		b.Or(o)
+	}
+}
+
+func (b Bitmap) IsSubset(other PartsMetadata) bool {
+	if other == nil {
+		return b.IsZero()
+	}
+	o, ok := other.(Bitmap)
+	if !ok {
+		return false
+	}
+	for i := range b {
+		var otherByte byte
+		if i < len(o) {
+			otherByte = o[i]
+		}
+		if b[i]&^otherByte != 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/partialmessages/invariants.go
+++ b/partialmessages/invariants.go
@@ -38,7 +38,7 @@ type InvariantChecker[P Message] interface {
 func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChecker[P]) {
 	extend := func(a, b P) (P, error) {
 		emptyParts := checker.EmptyMessage().PartsMetadata()
-		encodedB, _, err := b.PartialMessageBytes(emptyParts)
+		encodedB, _, err := b.PartialMessageBytes("", emptyParts)
 		if err != nil {
 			var out P
 			return out, err
@@ -66,7 +66,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 
 		recombined := checker.EmptyMessage()
 		for _, part := range parts {
-			b, _, err := part.PartialMessageBytes(recombined.PartsMetadata())
+			b, _, err := part.PartialMessageBytes("", recombined.PartsMetadata())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -88,7 +88,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		emptyMsgPartsMeta := emptyMessage.PartsMetadata()
 
 		// Empty message should not be able to fulfill any request
-		response, _, err := emptyMessage.PartialMessageBytes(emptyMsgPartsMeta)
+		response, _, err := emptyMessage.PartialMessageBytes("", emptyMsgPartsMeta)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -125,7 +125,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		emptyMsgPartsMeta := emptyMessage.PartsMetadata()
 
 		// Request all parts from the partial message
-		response1, _, err := parts[0].PartialMessageBytes(emptyMsgPartsMeta)
+		response1, _, err := parts[0].PartialMessageBytes("", emptyMsgPartsMeta)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -154,7 +154,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		}
 
 		// The remaining partial message should be able to fulfill the "rest" request
-		response2, _, err := remainingPartial.PartialMessageBytes(rest1)
+		response2, _, err := remainingPartial.PartialMessageBytes("", rest1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -197,7 +197,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 
 		// Request with empty metadata should return all available parts
 		emptyMeta := checker.EmptyMessage().PartsMetadata()
-		response, _, err := fullMessage.PartialMessageBytes(emptyMeta)
+		response, _, err := fullMessage.PartialMessageBytes("", emptyMeta)
 		rest := checker.MergePartsMetadata(emptyMeta, fullMessage.PartsMetadata())
 		if err != nil {
 			t.Fatal(err)
@@ -250,7 +250,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 			// Get the MissingParts() and have the full message fulfill the request
 			msgPartsMeta := testMsg.PartsMetadata()
 
-			response, _, err := fullMessage.PartialMessageBytes(msgPartsMeta)
+			response, _, err := fullMessage.PartialMessageBytes("", msgPartsMeta)
 			rest := checker.MergePartsMetadata(msgPartsMeta, fullMessage.PartsMetadata())
 			if err != nil {
 				t.Fatal(err)

--- a/partialmessages/invariants.go
+++ b/partialmessages/invariants.go
@@ -38,7 +38,7 @@ type InvariantChecker[P Message] interface {
 func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChecker[P]) {
 	extend := func(a, b P) (P, error) {
 		emptyParts := checker.EmptyMessage().PartsMetadata()
-		encodedB, err := b.PartialMessageBytes(emptyParts)
+		encodedB, _, err := b.PartialMessageBytes(emptyParts)
 		if err != nil {
 			var out P
 			return out, err
@@ -66,7 +66,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 
 		recombined := checker.EmptyMessage()
 		for _, part := range parts {
-			b, err := part.PartialMessageBytes(recombined.PartsMetadata())
+			b, _, err := part.PartialMessageBytes(recombined.PartsMetadata())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -88,7 +88,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		emptyMsgPartsMeta := emptyMessage.PartsMetadata()
 
 		// Empty message should not be able to fulfill any request
-		response, err := emptyMessage.PartialMessageBytes(emptyMsgPartsMeta)
+		response, _, err := emptyMessage.PartialMessageBytes(emptyMsgPartsMeta)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -99,7 +99,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		}
 
 		// The rest should be the same as the original request since nothing was fulfilled
-		if len(rest) == 0 && len(emptyMsgPartsMeta) > 0 {
+		if len(rest.Encode()) == 0 && len(emptyMsgPartsMeta.Encode()) > 0 {
 			t.Error("Empty message should return the full request as 'rest' when it cannot fulfill anything")
 		}
 	})
@@ -125,7 +125,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		emptyMsgPartsMeta := emptyMessage.PartsMetadata()
 
 		// Request all parts from the partial message
-		response1, err := parts[0].PartialMessageBytes(emptyMsgPartsMeta)
+		response1, _, err := parts[0].PartialMessageBytes(emptyMsgPartsMeta)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -137,10 +137,10 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		}
 
 		// Rest should be non-zero and different from original request since something was fulfilled
-		if len(rest1) == 0 {
+		if len(rest1.Encode()) == 0 {
 			t.Fatal("Rest should be non-zero when partial fulfillment occurred")
 		}
-		if bytes.Equal(rest1, emptyMsgPartsMeta) {
+		if bytes.Equal(rest1.Encode(), emptyMsgPartsMeta.Encode()) {
 			t.Fatalf("Rest should be different from original request since partial fulfillment occurred")
 		}
 
@@ -154,7 +154,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		}
 
 		// The remaining partial message should be able to fulfill the "rest" request
-		response2, err := remainingPartial.PartialMessageBytes(rest1)
+		response2, _, err := remainingPartial.PartialMessageBytes(rest1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -166,7 +166,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		}
 
 		// After fulfilling the rest, the metadata should be the same as full
-		if !bytes.Equal(rest2, fullMessage.PartsMetadata()) {
+		if !bytes.Equal(rest2.Encode(), fullMessage.PartsMetadata().Encode()) {
 			t.Errorf("After fulfilling all parts, the parts metadata should be the same as the full message, saw %v", rest2)
 		}
 
@@ -197,7 +197,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 
 		// Request with empty metadata should return all available parts
 		emptyMeta := checker.EmptyMessage().PartsMetadata()
-		response, err := fullMessage.PartialMessageBytes(emptyMeta)
+		response, _, err := fullMessage.PartialMessageBytes(emptyMeta)
 		rest := checker.MergePartsMetadata(emptyMeta, fullMessage.PartsMetadata())
 		if err != nil {
 			t.Fatal(err)
@@ -209,7 +209,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		}
 
 		// Should have no remaining parts since full message can fulfill everything
-		if !bytes.Equal(rest, fullMessage.PartsMetadata()) {
+		if !bytes.Equal(rest.Encode(), fullMessage.PartsMetadata().Encode()) {
 			t.Error("Full message should have no remaining parts when fulfilling empty metadata request")
 		}
 	})
@@ -224,7 +224,7 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 		fullMsgPartsMeta := fullMessage.PartsMetadata()
 
 		// Assert available parts is non-zero length
-		if len(fullMsgPartsMeta) == 0 {
+		if len(fullMsgPartsMeta.Encode()) == 0 {
 			t.Error("Full message should have non-zero available parts")
 		}
 
@@ -243,21 +243,21 @@ func TestPartialMessageInvariants[P Message](t *testing.T, checker InvariantChec
 
 		for i, testMsg := range testMessages {
 			// Assert that ShouldRequest returns true for the available parts
-			if !checker.ShouldRequest(testMsg, "", fullMsgPartsMeta) {
+			if !checker.ShouldRequest(testMsg, "", fullMsgPartsMeta.Encode()) {
 				t.Errorf("Message %d should request the available parts", i)
 			}
 
 			// Get the MissingParts() and have the full message fulfill the request
 			msgPartsMeta := testMsg.PartsMetadata()
 
-			response, err := fullMessage.PartialMessageBytes(msgPartsMeta)
+			response, _, err := fullMessage.PartialMessageBytes(msgPartsMeta)
 			rest := checker.MergePartsMetadata(msgPartsMeta, fullMessage.PartsMetadata())
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// Assert that the rest is nil
-			if !bytes.Equal(rest, fullMessage.PartsMetadata()) {
+			if !bytes.Equal(rest.Encode(), fullMessage.PartsMetadata().Encode()) {
 				t.Errorf("rest should be equal to fullMessage.PartsMetadata() for message %d", i)
 			}
 

--- a/partialmessages/partialmsgs.go
+++ b/partialmessages/partialmsgs.go
@@ -10,8 +10,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-// TODO: Add gossip fallback (pick random connected peers and send ihave/iwants)
-
 const minGroupTTL = 3
 
 // defaultPeerInitiatedGroupLimitPerTopic limits the total number (per topic) of

--- a/partialmessages/partialmsgs.go
+++ b/partialmessages/partialmsgs.go
@@ -258,7 +258,6 @@ func (e *PartialMessagesExtension) PublishPartial(topic string, partial Message,
 				continue
 			}
 			if len(pm) > 0 {
-				log.Debug("Respond to peer's IWant")
 				sendRPC = true
 				rpc.PartialMessage = pm
 				// Only update peer's parts metadata if we actually sent data

--- a/partialmessages/partialmsgs.go
+++ b/partialmessages/partialmsgs.go
@@ -1,13 +1,11 @@
 package partialmessages
 
 import (
-	"bytes"
 	"errors"
 	"iter"
 	"log/slog"
 	"slices"
 
-	"github.com/libp2p/go-libp2p-pubsub/partialmessages/bitmap"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -25,7 +23,26 @@ const defaultPeerInitiatedGroupLimitPerTopicPerPeer = 8
 
 // PartsMetadata returns metadata about the parts this partial message
 // contains and, possibly implicitly, the parts it wants.
-type PartsMetadata []byte
+//
+// The following invariant must be true for any implementation:
+//
+// Given that A and B are the same concrete type that implement PartsMetadata,
+//
+// A.Merge(B)
+// B.IsSubset(A) == true
+//
+// If A and B are separate concrete types, it may be impossible to merge them,
+// so IsSubset is not expected to return true.
+type PartsMetadata interface {
+	Encode() []byte
+	// Clone returns a deep clone
+	Clone() PartsMetadata
+	// Merge creates a union with the provided PartsMetadata.
+	// Merge(nil) is a no-op.
+	Merge(PartsMetadata)
+	// Returns true if the object is a subset of B.
+	IsSubset(B PartsMetadata) bool
+}
 
 // Message is a message that can be broken up into parts. It can be
 // complete, partially complete, or empty. It is up to the application to define
@@ -36,14 +53,14 @@ type Message interface {
 
 	// PartialMessageBytes takes the opaque parts metadata and returns an
 	// encoded partial message that fulfills as much of the request as possible.
-	PartialMessageBytes(partsMetadata PartsMetadata) (msg []byte, _ error)
+	PartialMessageBytes(partsMetadata PartsMetadata) (msg []byte, nextPartsMetadata PartsMetadata, _ error)
 
 	// EagerPartialMessageBytes returns an encoded partial message to be sent to
 	// peer whose parts metadata is unknown. It is valid for an implementation
 	// to return `nil, nil, nil` if it has no eager push data it would like to
 	// send. The returned partsMetadata should represent the parts the remote
 	// peer should have after decoding this message.
-	EagerPartialMessageBytes() (msg []byte, partsMetadata PartsMetadata, _ error)
+	EagerPartialMessageBytes() (msg []byte, nextPartsMetadata PartsMetadata, _ error)
 
 	PartsMetadata() PartsMetadata
 }
@@ -66,7 +83,7 @@ type partialMessageStatePerGroupPerTopic struct {
 	groupTTL    int
 	initiatedBy peer.ID // zero value if we initiated the group
 
-	myLastPartsMetadata []byte
+	myLastPartsMetadata PartsMetadata
 }
 
 func newPartialMessageStatePerTopicGroup(groupTTL int) *partialMessageStatePerGroupPerTopic {
@@ -89,29 +106,24 @@ func (s *partialMessageStatePerGroupPerTopic) clearPeerMetadata(peerID peer.ID) 
 	}
 }
 
-// MergeBitmap is a helper function for merging parts metadata if they are a
-// bitmap.
-func MergeBitmap(left, right PartsMetadata) PartsMetadata {
-	return PartsMetadata(bitmap.Merge(bitmap.Bitmap(left), bitmap.Bitmap(right)))
-}
-
 type PartialMessagesExtension struct {
 	Logger *slog.Logger
 
-	MergePartsMetadata func(topic string, left, right PartsMetadata) PartsMetadata
-
 	// OnIncomingRPC is called whenever we receive an encoded
-	// partial message from a peer. This func MUST be fast and non-blocking.
+	// partial message from a peer. This function MUST be fast and non-blocking.
 	// If you need to do slow work, dispatch the work to your own goroutine.
 	OnIncomingRPC func(from peer.ID, rpc *pb.PartialMessagesExtension) error
 
 	// ValidateRPC should be a fast function that performs some
-	// basic sanity checks on incoming RPC. For example:
+	// basic sanity checks on incoming RPC.
+	// Some example validations:
 	//   - Is this a known topic?
 	//   - Is the groupID well formed per application semantics?
-	//   - If this is a PartialIHAVE/PartialIWant, is the request metadata within
-	//     expected bounds?
 	ValidateRPC func(from peer.ID, rpc *pb.PartialMessagesExtension) error
+
+	// DecodePartsMetadata should return the decoded PartsMetadata from the RPC.
+	// The RPC is guaranteed to have partsMetadata set.
+	DecodePartsMetadata func(from peer.ID, rpc *pb.PartialMessagesExtension) (PartsMetadata, error)
 
 	// PeerInitiatedGroupLimitPerTopic limits the number of Group states all
 	// peers can initialize per topic. A group state is initialized by a peer if
@@ -186,13 +198,12 @@ func (e *PartialMessagesExtension) Init(router Router) error {
 	if e.ValidateRPC == nil {
 		return errors.New("field ValidateRPC must be set")
 	}
+	if e.DecodePartsMetadata == nil {
+		return errors.New("field DecodePartsMetadata must be set")
+	}
 	if e.OnIncomingRPC == nil {
 		return errors.New("field OnIncomingRPC must be set")
 	}
-	if e.MergePartsMetadata == nil {
-		return errors.New("field MergePartsMetadata must be set")
-	}
-
 	if e.PeerInitiatedGroupLimitPerTopic == 0 {
 		e.PeerInitiatedGroupLimitPerTopic = defaultPeerInitiatedGroupLimitPerTopic
 	}
@@ -208,7 +219,6 @@ func (e *PartialMessagesExtension) Init(router Router) error {
 
 func (e *PartialMessagesExtension) PublishPartial(topic string, partial Message, opts PublishOptions) error {
 	groupID := partial.GroupID()
-	myPartsMeta := partial.PartsMetadata()
 
 	state, err := e.groupState(topic, groupID, false, "")
 	if err != nil {
@@ -216,7 +226,10 @@ func (e *PartialMessagesExtension) PublishPartial(topic string, partial Message,
 	}
 
 	state.groupTTL = max(e.GroupTTLByHeatbeat, minGroupTTL)
-	state.myLastPartsMetadata = slices.Clone(myPartsMeta)
+
+	// Copy this defensively to avoid aliasing issues.
+	myPartsMeta := partial.PartsMetadata().Clone()
+	state.myLastPartsMetadata = myPartsMeta
 
 	var peers iter.Seq[peer.ID]
 	if len(opts.PublishToPeers) > 0 {
@@ -247,18 +260,21 @@ func (e *PartialMessagesExtension) PublishPartial(topic string, partial Message,
 		if requestedPartial && havePeersPartsMetadata {
 			// This peer has previously asked for a certain part. We'll give
 			// them what we can.
-			pm, err := partial.PartialMessageBytes(pState.partsMetadata)
+			pm, nextParts, err := partial.PartialMessageBytes(pState.partsMetadata)
 			if err != nil {
 				log.Warn("partial message extension failed to get partial message bytes", "error", err)
 				// Possibly a bad request, we'll delete the request as we will likely error next time we try to handle it
 				state.clearPeerMetadata(p)
 				continue
 			}
-			pState.partsMetadata = e.MergePartsMetadata(topic, pState.partsMetadata, myPartsMeta)
 			if len(pm) > 0 {
 				log.Debug("Respond to peer's IWant")
 				sendRPC = true
 				rpc.PartialMessage = pm
+				// Only update peer's parts metadata if we actually sent data
+				if nextParts != nil {
+					pState.partsMetadata = nextParts
+				}
 			}
 		}
 
@@ -269,17 +285,19 @@ func (e *PartialMessagesExtension) PublishPartial(topic string, partial Message,
 			log.Debug("Eager pushing")
 			sendRPC = true
 			rpc.PartialMessage = eagerData
-			// Merge the peer's empty partsMetadata with the parts we eagerly pushed.
-			// This tracks what has been sent to the peer and avoids sending duplicates.
-			pState.partsMetadata = e.MergePartsMetadata(topic, pState.partsMetadata, eagerPartsMeta)
+			pState.partsMetadata = eagerPartsMeta
 		}
 
 		// Only send parts metadata if it was different then before
-		if pState.sentPartsMetadata == nil || !bytes.Equal(myPartsMeta, pState.sentPartsMetadata) {
-			log.Debug("Including parts metadata")
+		if pState.sentPartsMetadata == nil || !myPartsMeta.IsSubset(pState.sentPartsMetadata) {
+			log.Debug("Including parts metadata", "sent parts", pState.sentPartsMetadata, "my parts", myPartsMeta)
 			sendRPC = true
-			pState.sentPartsMetadata = myPartsMeta
-			rpc.PartsMetadata = myPartsMeta
+			if pState.sentPartsMetadata == nil {
+				pState.sentPartsMetadata = myPartsMeta.Clone()
+			} else {
+				pState.sentPartsMetadata.Merge(myPartsMeta)
+			}
+			rpc.PartsMetadata = pState.sentPartsMetadata.Encode()
 		}
 
 		if sendRPC {
@@ -352,14 +370,14 @@ func (e *PartialMessagesExtension) EmitGossip(topic string, peers []peer.ID) {
 	}
 
 	for group, s := range topicState {
-		if s.remotePeerInitiated() || len(s.myLastPartsMetadata) == 0 {
+		if s.remotePeerInitiated() || s.myLastPartsMetadata == nil {
 			continue
 		}
 
 		rpc := &pb.PartialMessagesExtension{
 			TopicID:       &topic,
 			GroupID:       []byte(group),
-			PartsMetadata: s.myLastPartsMetadata,
+			PartsMetadata: s.myLastPartsMetadata.Encode(),
 		}
 
 		for _, peer := range peers {
@@ -369,8 +387,13 @@ func (e *PartialMessagesExtension) EmitGossip(topic string, peers []peer.ID) {
 				s.peerState[peer] = pState
 			}
 
-			if !bytes.Equal(rpc.PartsMetadata, pState.sentPartsMetadata) {
-				pState.sentPartsMetadata = rpc.PartsMetadata
+			if pState.sentPartsMetadata == nil || !s.myLastPartsMetadata.IsSubset(pState.sentPartsMetadata) {
+				pState.sentPartsMetadata = s.myLastPartsMetadata
+				if pState.sentPartsMetadata == nil {
+					pState.sentPartsMetadata = s.myLastPartsMetadata.Clone()
+				} else {
+					pState.sentPartsMetadata.Merge(s.myLastPartsMetadata)
+				}
 				e.sendRPC(peer, rpc)
 			}
 		}
@@ -386,8 +409,19 @@ func (e *PartialMessagesExtension) HandleRPC(from peer.ID, rpc *pb.PartialMessag
 	if rpc == nil {
 		return nil
 	}
-	if err := e.ValidateRPC(from, rpc); err != nil {
+
+	err := e.ValidateRPC(from, rpc)
+	if err != nil {
 		return err
+	}
+
+	var peerPartsMetadata PartsMetadata
+
+	if len(rpc.PartsMetadata) > 0 {
+		peerPartsMetadata, err = e.DecodePartsMetadata(from, rpc)
+		if err != nil {
+			return err
+		}
 	}
 	e.Logger.Debug("Received RPC", "from", from, "rpc", rpc)
 	topic := rpc.GetTopicID()
@@ -398,16 +432,21 @@ func (e *PartialMessagesExtension) HandleRPC(from peer.ID, rpc *pb.PartialMessag
 		return err
 	}
 
-	if rpc.PartsMetadata != nil {
-		pState, ok := state.peerState[from]
-		if !ok {
+	pState, peerStateOk := state.peerState[from]
+	if peerPartsMetadata != nil {
+		if !peerStateOk {
+			peerStateOk = true
 			pState = &peerState{}
 			state.peerState[from] = pState
 		}
-		pState.partsMetadata = e.MergePartsMetadata(rpc.GetTopicID(), pState.partsMetadata, rpc.PartsMetadata)
+		if pState.partsMetadata == nil {
+			pState.partsMetadata = peerPartsMetadata
+		} else {
+			pState.partsMetadata.Merge(peerPartsMetadata)
+		}
 	}
 
-	if pState, ok := state.peerState[from]; ok && len(pState.sentPartsMetadata) > 0 && len(rpc.PartialMessage) > 0 {
+	if peerStateOk && pState.sentPartsMetadata != nil && pState.partsMetadata != nil && len(rpc.PartialMessage) > 0 {
 		// We have previously sent this peer our parts metadata and they have
 		// sent us a partial message. We can update the peer's view of our parts
 		// by merging our parts and their parts.
@@ -415,10 +454,15 @@ func (e *PartialMessagesExtension) HandleRPC(from peer.ID, rpc *pb.PartialMessag
 		// This works if they are responding to our request or
 		// if they send data eagerly. In the latter case, they will update our
 		// view when they receive our parts metadata.
-		pState.sentPartsMetadata = e.MergePartsMetadata(rpc.GetTopicID(), pState.sentPartsMetadata, pState.partsMetadata)
+		pState.sentPartsMetadata.Merge(pState.partsMetadata)
 	}
 
-	return e.OnIncomingRPC(from, rpc)
+	err = e.OnIncomingRPC(from, rpc)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type peerInitiatedGroupCounterState struct {

--- a/partialmessages/partialmsgs.go
+++ b/partialmessages/partialmsgs.go
@@ -53,14 +53,13 @@ type Message interface {
 
 	// PartialMessageBytes takes the opaque parts metadata and returns an
 	// encoded partial message that fulfills as much of the request as possible.
-	PartialMessageBytes(partsMetadata PartsMetadata) (msg []byte, nextPartsMetadata PartsMetadata, _ error)
-
-	// EagerPartialMessageBytes returns an encoded partial message to be sent to
-	// peer whose parts metadata is unknown. It is valid for an implementation
-	// to return `nil, nil, nil` if it has no eager push data it would like to
-	// send. The returned partsMetadata should represent the parts the remote
-	// peer should have after decoding this message.
-	EagerPartialMessageBytes() (msg []byte, nextPartsMetadata PartsMetadata, _ error)
+	//
+	// partsMetadata is nil if the node has not seen it's peer's partsMetadata,
+	// applications can still eagerly push data in this case.
+	//
+	// The returned partsMetadata should represent the parts the remote peer
+	// should have after decoding this message.
+	PartialMessageBytes(remote peer.ID, partsMetadata PartsMetadata) (msg []byte, nextPartsMetadata PartsMetadata, _ error)
 
 	PartsMetadata() PartsMetadata
 }
@@ -238,10 +237,6 @@ func (e *PartialMessagesExtension) PublishPartial(topic string, partial Message,
 		peers = e.peersToPublishTo(topic, state)
 	}
 
-	eagerData, eagerPartsMeta, err := partial.EagerPartialMessageBytes()
-	if err != nil {
-		return err
-	}
 	for p := range peers {
 		log := e.Logger.With("peer", p)
 		requestedPartial := e.router.PeerRequestsPartial(p, topic)
@@ -255,12 +250,9 @@ func (e *PartialMessagesExtension) PublishPartial(topic string, partial Message,
 			state.peerState[p] = pState
 		}
 
-		havePeersPartsMetadata := pState.partsMetadata != nil
-		// Try to fulfill any wants from the peer
-		if requestedPartial && havePeersPartsMetadata {
-			// This peer has previously asked for a certain part. We'll give
-			// them what we can.
-			pm, nextParts, err := partial.PartialMessageBytes(pState.partsMetadata)
+		if requestedPartial {
+			// This peer requested partial messages, we'll give them what we can
+			pm, nextParts, err := partial.PartialMessageBytes(p, pState.partsMetadata)
 			if err != nil {
 				log.Warn("partial message extension failed to get partial message bytes", "error", err)
 				// Possibly a bad request, we'll delete the request as we will likely error next time we try to handle it
@@ -276,16 +268,6 @@ func (e *PartialMessagesExtension) PublishPartial(topic string, partial Message,
 					pState.partsMetadata = nextParts
 				}
 			}
-		}
-
-		// Only send the eager push to the peer if:
-		//   - we don't have the peer's parts metadata
-		//   - we have something to eager push
-		if requestedPartial && !havePeersPartsMetadata && len(eagerData) > 0 {
-			log.Debug("Eager pushing")
-			sendRPC = true
-			rpc.PartialMessage = eagerData
-			pState.partsMetadata = eagerPartsMeta
 		}
 
 		// Only send parts metadata if it was different then before

--- a/partialmessages/partialmsgs_test.go
+++ b/partialmessages/partialmsgs_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/libp2p/go-libp2p-pubsub/internal/merkle"
-	"github.com/libp2p/go-libp2p-pubsub/partialmessages/bitmap"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -152,13 +151,13 @@ func (pm *testPartialMessage) complete() bool {
 
 // AvailableParts returns a bitmap of available parts
 func (pm *testPartialMessage) PartsMetadata() PartsMetadata {
-	out := bitmap.NewBitmapWithOnesCount(testPartialMessageLeaves)
+	out := NewBitmapWithOnesCount(testPartialMessageLeaves)
 	for i, part := range pm.Parts {
 		if len(part) == 0 {
 			out.Clear(i)
 		}
 	}
-	return PartsMetadata(out)
+	return Bitmap(out)
 }
 
 func (pm *testPartialMessage) extendFromEncodedPartialMessage(_ peer.ID, data []byte) (extended bool) {
@@ -220,7 +219,7 @@ func (pm *testPartialMessage) GroupID() []byte {
 
 func (pm *testPartialMessage) shouldRequest(partsMetadata []byte) bool {
 	var myParts big.Int
-	myParts.SetBytes(pm.PartsMetadata())
+	myParts.SetBytes(pm.PartsMetadata().Encode())
 	var zero big.Int
 
 	var peerHas big.Int
@@ -262,8 +261,8 @@ func (pm *testPartialMessage) EagerPartialMessageBytes() ([]byte, PartsMetadata,
 }
 
 // PartialMessageBytes implements Message.
-func (pm *testPartialMessage) PartialMessageBytes(metadata PartsMetadata) ([]byte, error) {
-	peerHas := bitmap.Bitmap(metadata)
+func (pm *testPartialMessage) PartialMessageBytes(metadata PartsMetadata) ([]byte, PartsMetadata, error) {
+	peerHas := Bitmap(metadata.Encode())
 
 	var added bool
 	var tempMessage testPartialMessage
@@ -285,15 +284,17 @@ func (pm *testPartialMessage) PartialMessageBytes(metadata PartsMetadata) ([]byt
 	}
 
 	if !added {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	b, err := json.Marshal(tempMessage)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return b, nil
+	merged := pm.PartsMetadata().Clone()
+	merged.Merge(metadata)
+	return b, merged, nil
 }
 
 type testPartialMessageChecker struct {
@@ -301,7 +302,9 @@ type testPartialMessageChecker struct {
 }
 
 func (t *testPartialMessageChecker) MergePartsMetadata(left, right PartsMetadata) PartsMetadata {
-	return MergeBitmap(left, right)
+	m := left.Clone()
+	m.Merge(right)
+	return m
 }
 
 // EmptyMessage implements InvariantChecker.
@@ -460,8 +463,8 @@ func createPeers(t *testing.T, topic string, n int, nonMesh bool) *testPeers {
 		// Create handler
 		handler = &PartialMessagesExtension{
 			Logger: slog.Default().With("id", i),
-			MergePartsMetadata: func(_ string, left, right PartsMetadata) PartsMetadata {
-				return MergeBitmap(left, right)
+			DecodePartsMetadata: func(_ peer.ID, rpc *pubsub_pb.PartialMessagesExtension) (PartsMetadata, error) {
+				return Bitmap(rpc.PartsMetadata), nil
 			},
 			OnIncomingRPC: func(from peer.ID, rpc *pubsub_pb.PartialMessagesExtension) error {
 				// Handle incoming partial message data - use testPeers to track state
@@ -488,9 +491,9 @@ func createPeers(t *testing.T, topic string, n int, nonMesh bool) *testPeers {
 				recvdNewData := pm.extendFromEncodedPartialMessage(from, rpc.PartialMessage)
 
 				if recvdNewData {
-					newParts := bitmap.Bitmap(pm.PartsMetadata())
-					newParts.Xor(bitmap.Bitmap(beforeParts))
-					pm.republish(pm, PartsMetadata(newParts))
+					newParts := Bitmap(pm.PartsMetadata().Encode())
+					newParts.Xor(Bitmap(beforeParts.Encode()))
+					pm.republish(pm, Bitmap(newParts))
 					return nil
 				}
 
@@ -499,7 +502,7 @@ func createPeers(t *testing.T, topic string, n int, nonMesh bool) *testPeers {
 				peerHasUsefulData := pm.shouldRequest(rpc.PartsMetadata)
 
 				var iHave big.Int
-				iHave.SetBytes(pm.PartsMetadata())
+				iHave.SetBytes(pm.PartsMetadata().Encode())
 
 				var peerHas big.Int
 				peerHas.SetBytes(rpc.PartsMetadata)
@@ -803,7 +806,7 @@ func TestPartialMessages(t *testing.T) {
 
 		emptyMsg := &testPartialMessage{}
 		emptyMetadata := emptyMsg.PartsMetadata()
-		if bytes.Equal(peers.network.pendingMsgs[peers.peers[0]][0].rpc.PartsMetadata, emptyMetadata) {
+		if bytes.Equal(peers.network.pendingMsgs[peers.peers[0]][0].rpc.PartsMetadata, emptyMetadata.Encode()) {
 			t.Fatal("h2 request should not be the same as an empty message")
 		}
 
@@ -863,7 +866,7 @@ func TestPartialMessages(t *testing.T) {
 
 		emptyMsg := &testPartialMessage{}
 		emptyMetadata := emptyMsg.PartsMetadata()
-		if bytes.Equal(peers.network.pendingMsgs[peers.peers[0]][0].rpc.PartsMetadata, emptyMetadata) {
+		if bytes.Equal(peers.network.pendingMsgs[peers.peers[0]][0].rpc.PartsMetadata, emptyMetadata.Encode()) {
 			t.Fatal("h2 metadata should not be the same as an empty message's metadata")
 		}
 
@@ -1112,8 +1115,8 @@ func TestGossipDelivery(t *testing.T) {
 	// Create h1 handler
 	h1Handler = &PartialMessagesExtension{
 		Logger: slog.Default().With("id", "h1"),
-		MergePartsMetadata: func(_ string, left, right PartsMetadata) PartsMetadata {
-			return MergeBitmap(left, right)
+		DecodePartsMetadata: func(_ peer.ID, rpc *pubsub_pb.PartialMessagesExtension) (PartsMetadata, error) {
+			return Bitmap(rpc.PartsMetadata), nil
 		},
 		OnIncomingRPC: func(from peer.ID, rpc *pubsub_pb.PartialMessagesExtension) error {
 			if partialMessages[h1ID][topic] == nil {
@@ -1144,8 +1147,8 @@ func TestGossipDelivery(t *testing.T) {
 	// Create h2 handler
 	h2Handler = &PartialMessagesExtension{
 		Logger: slog.Default().With("id", "h2"),
-		MergePartsMetadata: func(_ string, left, right PartsMetadata) PartsMetadata {
-			return MergeBitmap(left, right)
+		DecodePartsMetadata: func(_ peer.ID, rpc *pubsub_pb.PartialMessagesExtension) (PartsMetadata, error) {
+			return Bitmap(rpc.PartsMetadata), nil
 		},
 		OnIncomingRPC: func(from peer.ID, rpc *pubsub_pb.PartialMessagesExtension) error {
 			if partialMessages[h2ID][topic] == nil {
@@ -1258,8 +1261,8 @@ func TestPeerInitiatedCounter(t *testing.T) {
 	}
 	handler := PartialMessagesExtension{
 		Logger: slog.Default(),
-		MergePartsMetadata: func(topic string, left, right PartsMetadata) PartsMetadata {
-			return left
+		DecodePartsMetadata: func(_ peer.ID, rpc *pubsub_pb.PartialMessagesExtension) (PartsMetadata, error) {
+			return Bitmap(rpc.PartsMetadata), nil
 		},
 		OnIncomingRPC: func(from peer.ID, rpc *pubsub_pb.PartialMessagesExtension) error {
 			// Ignore for this test
@@ -1386,8 +1389,8 @@ func FuzzPeerInitiatedCounter(f *testing.F) {
 
 		handler := PartialMessagesExtension{
 			Logger: slog.Default(),
-			MergePartsMetadata: func(topic string, left, right PartsMetadata) PartsMetadata {
-				return left
+			DecodePartsMetadata: func(_ peer.ID, rpc *pubsub_pb.PartialMessagesExtension) (PartsMetadata, error) {
+				return Bitmap(rpc.PartsMetadata), nil
 			},
 			OnIncomingRPC: func(from peer.ID, rpc *pubsub_pb.PartialMessagesExtension) error {
 				// Ignore for this test


### PR DESCRIPTION
To optimize when we send PartsMetadata we need the metadata to do two
things:

- Get the union of two parts metadata.
- Return if one parts metadata is a subset of another.

This allows us to avoid sending our updated partsMetadata to the peer
that gave us new data, as they can infer our updatedPartsMetadata.