### PR TITLE
[Do Not Merge]: Notes to upgrade/replace the MergePartsMetadata API for request bitmasks

### DIFF
--- a/partialmessages/partialmsgs.go
+++ b/partialmessages/partialmsgs.go
@@ -287,6 +287,9 @@ func (e *PartialMessagesExtension) PublishPartial(topic string, partial Message,
 			pState.partsMetadata = e.MergePartsMetadata(topic, pState.partsMetadata, eagerPartsMeta)
 		}
 
+		// Maybe a better API for both the above Merges is peerState = MergeForOutgoingRPC(existing peerState struct, partsMetadata to send)
+		// Or we let partial.PartialMessageBytes/EagerPartialMessageBytes return the updated parts metadata/peerState.
+
 		// Only send parts metadata if it was different then before
 		if pState.sentPartsMetadata == nil || !bytes.Equal(myPartsMeta, pState.sentPartsMetadata) {
 			log.Debug("Including parts metadata")


### PR DESCRIPTION
I think we need to upgrade/replace the MergePartsMetadata API so we can update the requests bitmask correctly for the updated PartsMetadata container specified in https://github.com/ethereum/consensus-specs/pull/4558.

This PR has some comments on how we can do it.