### PR TITLE
Use fanout for publish if mesh is empty even if we are subscribed to a topic

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1364,7 +1364,7 @@ func (gs *GossipSubRouter) rpcs(msg *Message) iter.Seq2[peer.ID, *RPC] {
 
 			// gossipsub peers
 			gmap, ok := gs.mesh[topic]
-			if !ok {
+			if !ok || len(gmap) == 0 {
 				// we are not in the mesh for topic, use fanout peers
 				gmap, ok = gs.fanout[topic]
 				if !ok || len(gmap) == 0 {
@@ -1477,7 +1477,11 @@ func (gs *GossipSubRouter) Join(topic string) {
 			return !direct && !doBackOff && gs.score.Score(p) >= 0
 		})
 		gmap = peerListToMap(peers)
-		gs.mesh[topic] = gmap
+		// It is possible that we do not have any peers subscribed to this topic yet so continue fanout
+		// to ensure that messages we publish in the intermin are not lost
+		if len(gmap) > 0 {
+			gs.mesh[topic] = gmap
+		}
 	}
 
 	for p := range gmap {

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1389,7 +1389,7 @@ func (gs *GossipSubRouter) rpcs(msg *Message) iter.Seq2[peer.ID, *RPC] {
 
 			// gossipsub peers
 			gmap, ok := gs.mesh[topic]
-			if !ok {
+			if !ok || len(gmap) == 0 {
 				// we are not in the mesh for topic, use fanout peers
 				gmap = gs.getFanoutPeersForPublishing(topic)
 			}
@@ -1489,7 +1489,11 @@ func (gs *GossipSubRouter) Join(topic string) {
 			return !direct && !doBackOff && gs.score.Score(p) >= 0
 		})
 		gmap = peerListToMap(peers)
-		gs.mesh[topic] = gmap
+		// It is possible that we do not have any peers subscribed to this topic yet so continue fanout
+		// to ensure that messages we publish in the intermin are not lost
+		if len(gmap) > 0 {
+			gs.mesh[topic] = gmap
+		}
 	}
 
 	for p := range gmap {

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1388,9 +1388,10 @@ func (gs *GossipSubRouter) rpcs(msg *Message) iter.Seq2[peer.ID, *RPC] {
 			}
 
 			// gossipsub peers
-			gmap, ok := gs.mesh[topic]
-			if !ok || len(gmap) == 0 {
-				// we are not in the mesh for topic, use fanout peers
+			gmap := gs.mesh[topic]
+			if len(gmap) == 0 {
+				// we are not in the mesh for topic or our mesh is empty
+				// use fanout peers for publishing
 				gmap = gs.getFanoutPeersForPublishing(topic)
 			}
 
@@ -1489,11 +1490,7 @@ func (gs *GossipSubRouter) Join(topic string) {
 			return !direct && !doBackOff && gs.score.Score(p) >= 0
 		})
 		gmap = peerListToMap(peers)
-		// It is possible that we do not have any peers subscribed to this topic yet so continue fanout
-		// to ensure that messages we publish in the intermin are not lost
-		if len(gmap) > 0 {
-			gs.mesh[topic] = gmap
-		}
+		gs.mesh[topic] = gmap
 	}
 
 	for p := range gmap {


### PR DESCRIPTION
If a peer subscribes to a topic when it has not yet seen any other peers for the topic, it will set the mesh to an empty map.

Now say another peer comes in and subscribes to the topic. But, it has not been grafted yet and has yet to be added to the mesh. However, it is now added to the list of peers subscribed to a given topic.

Now, if the first peer does a Publish -> we see that the mesh exists and so don't do a fanout. However, the mesh is empty which means that the peer above never sees the message. 

Later, on a heartbeat, the second peer gets grafted but it's too late.