### PR TITLE
Elevate log level to Warn for message drops due to full buffers

### DIFF
--- a/floodsub.go
+++ b/floodsub.go
@@ -93,7 +93,7 @@ func (fs *FloodSubRouter) Publish(msg *Message) {
 
 		err := q.Push(out, false)
 		if err != nil {
-			fs.p.logger.Info("dropping message to peer: queue full", "peer", pid)
+			fs.p.logger.Warn("dropping message to peer: queue full", "peer", pid)
 			fs.tracer.DropRPC(out, pid)
 			// Drop it. The peer is too slow.
 			continue

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1568,7 +1568,7 @@ func (gs *GossipSubRouter) sendRPC(p peer.ID, out *RPC, urgent bool) {
 }
 
 func (gs *GossipSubRouter) doDropRPC(rpc *RPC, p peer.ID, reason string) {
-	gs.logger.Debug("dropping message to peer", "peer", p, "reason", reason)
+	gs.logger.Warn("dropping message to peer", "peer", p, "reason", reason)
 	gs.tracer.DropRPC(rpc, p)
 	// push control messages that need to be retried
 	ctl := rpc.GetControl()

--- a/pubsub.go
+++ b/pubsub.go
@@ -1213,7 +1213,7 @@ func (p *PubSub) announce(topic string, sub bool) {
 	for pid, peer := range p.peers {
 		err := peer.Push(out, false)
 		if err != nil {
-			p.logger.Info("Can't send announce message to peer: queue full; scheduling retry", "peer", pid)
+			p.logger.Warn("Can't send announce message to peer: queue full; scheduling retry", "peer", pid)
 			p.tracer.DropRPC(out, pid)
 			go p.announceRetry(pid, topic, sub)
 			continue
@@ -1266,7 +1266,7 @@ func (p *PubSub) doAnnounceRetry(pid peer.ID, topic string, sub bool) {
 	out := rpcWithSubs(subopt)
 	err := peer.Push(out, false)
 	if err != nil {
-		p.logger.Info("Can't send announce message to peer: queue full; scheduling retry", "peer", pid)
+		p.logger.Warn("Can't send announce message to peer: queue full; scheduling retry", "peer", pid)
 		p.tracer.DropRPC(out, pid)
 		go p.announceRetry(pid, topic, sub)
 		return
@@ -1284,7 +1284,7 @@ func (p *PubSub) notifySubs(msg *Message) {
 		case f.ch <- msg:
 		default:
 			p.tracer.UndeliverableMessage(msg)
-			p.logger.Info("Can't deliver message to subscription for topic; subscriber too slow", "topic", topic)
+			p.logger.Warn("Can't deliver message to subscription for topic; subscriber too slow", "topic", topic)
 		}
 	}
 }

--- a/randomsub.go
+++ b/randomsub.go
@@ -154,7 +154,7 @@ func (rs *RandomSubRouter) Publish(msg *Message) {
 
 		err := q.Push(out, false)
 		if err != nil {
-			rs.p.logger.Info("dropping message to peer: queue full", "peer", p)
+			rs.p.logger.Warn("dropping message to peer: queue full", "peer", p)
 			rs.tracer.DropRPC(out, p)
 			continue
 		}

--- a/validation.go
+++ b/validation.go
@@ -260,7 +260,7 @@ func (v *validation) Push(src peer.ID, msg *Message) bool {
 		select {
 		case v.validateQ <- &validateReq{vals, src, msg}:
 		default:
-			v.p.logger.Debug("message validation throttled: queue full; dropping message from peer", "peer", src)
+			v.p.logger.Warn("message validation throttled: queue full; dropping message from peer", "peer", src)
 			v.tracer.RejectMessage(msg, RejectValidationQueueFull)
 		}
 		return false


### PR DESCRIPTION
## Summary

- Elevates log level from `Info`/`Debug` to `Warn` for all log messages related to message drops due to full buffers/queues
- Fixes #472

## Changes

When messages or RPCs are dropped because a buffer or queue is full, the log messages now use `Warn` instead of `Info` or `Debug`. This makes it immediately visible to operators when message loss occurs due to backpressure, without requiring them to scan `Info`-level logs.

Before this change, a user filling their subscription buffer faster than they were consuming it would only see an `Info`-level log line, which is easy to miss in production. This addresses the issue reported in #472.

