### PR TITLE
chore: bump go 1.25

### DIFF
--- a/backoff_test.go
+++ b/backoff_test.go
@@ -34,7 +34,7 @@ func TestBackoff_Update(t *testing.T) {
 		t.Fatalf("invalid initialization: %v, \t, %s", d, err)
 	}
 
-	for i := 0; i < maxBackoffAttempts-1; i++ {
+	for i := range maxBackoffAttempts-1 {
 		got, err := b.updateAndGet(id1)
 		if err != nil {
 			t.Fatalf("unexpected error post update: %s", err)
@@ -90,7 +90,7 @@ func TestBackoff_Clean(t *testing.T) {
 	maxBackoffAttempts := 100 // setting attempts to a high number hence testing cleanup logic.
 	b := newBackoff(ctx, size, cleanupInterval, maxBackoffAttempts)
 
-	for i := 0; i < size; i++ {
+	for i := range size {
 		id := peer.ID(fmt.Sprintf("peer-%d", i))
 		_, err := b.updateAndGet(id)
 		if err != nil {

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -34,7 +34,7 @@ func TestBackoff_Update(t *testing.T) {
 		t.Fatalf("invalid initialization: %v, \t, %s", d, err)
 	}
 
-	for i := range maxBackoffAttempts-1 {
+	for i := range maxBackoffAttempts - 1 {
 		got, err := b.updateAndGet(id1)
 		if err != nil {
 			t.Fatalf("unexpected error post update: %s", err)

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -197,7 +197,7 @@ func TestSimpleDiscovery(t *testing.T) {
 	}
 
 	// Try random peers sending messages and make sure they are received
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d the flooooooood %d", i, i))
 
 		owner := rand.Intn(len(psubs))
@@ -264,14 +264,14 @@ func TestGossipSubDiscoveryAfterBootstrap(t *testing.T) {
 		waitUntilGossipsubMeshCount(ps, topic, partitionSize-1)
 	}
 
-	for i := 0; i < partitionSize; i++ {
+	for i := range partitionSize {
 		if _, err := server1.Advertise("floodsub:"+topic, *host.InfoFromHost(hosts[i+partitionSize]), ttl); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// test the mesh
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := rand.Intn(numHosts)

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -162,7 +162,7 @@ func TestBasicFloodsub(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d the flooooooood %d", i, i))
 
 		owner := mrand.Intn(len(psubs))
@@ -972,7 +972,7 @@ func TestMessageSender(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		for j := 0; j < 100; j++ {
 			msg := []byte(fmt.Sprintf("%d sent %d", i, j))
 
@@ -1143,7 +1143,7 @@ func TestPubsubWithAssortedOptions(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i].Publish("test", msg)
 

--- a/fuzz_helpers_test.go
+++ b/fuzz_helpers_test.go
@@ -46,7 +46,7 @@ func generateControl(data []byte, limit int) *pb.ControlMessage {
 	ctl := &pb.ControlMessage{}
 
 	ctl.Iwant = make([]*pb.ControlIWant, 0, numIWANTMsgs)
-	for i := 0; i < numIWANTMsgs; i++ {
+	for i := range numIWANTMsgs {
 		msgSize := int(generateU16(&data)) % limit
 		msgCount := int(generateU16(&data)) % limit
 		ctl.Iwant = append(ctl.Iwant, &pb.ControlIWant{})
@@ -60,7 +60,7 @@ func generateControl(data []byte, limit int) *pb.ControlMessage {
 	}
 
 	ctl.Ihave = make([]*pb.ControlIHave, 0, numIHAVEMsgs)
-	for i := 0; i < numIHAVEMsgs; i++ {
+	for i := range numIHAVEMsgs {
 		msgSize := int(generateU16(&data)) % limit
 		msgCount := int(generateU16(&data)) % limit
 		topicSize := int(generateU16(&data)) % limit
@@ -78,7 +78,7 @@ func generateControl(data []byte, limit int) *pb.ControlMessage {
 
 	numGraft := int(generateU16(&data)) % limit
 	ctl.Graft = make([]*pb.ControlGraft, 0, numGraft)
-	for i := 0; i < numGraft; i++ {
+	for range numGraft {
 		topicSize := int(generateU16(&data)) % limit
 		topic := string(make([]byte, topicSize))
 		ctl.Graft = append(ctl.Graft, &pb.ControlGraft{TopicID: &topic})
@@ -89,7 +89,7 @@ func generateControl(data []byte, limit int) *pb.ControlMessage {
 
 	numPrune := int(generateU16(&data)) % limit
 	ctl.Prune = make([]*pb.ControlPrune, 0, numPrune)
-	for i := 0; i < numPrune; i++ {
+	for range numPrune {
 		topicSize := int(generateU16(&data)) % limit
 		topic := string(make([]byte, topicSize))
 		ctl.Prune = append(ctl.Prune, &pb.ControlPrune{TopicID: &topic})
@@ -107,7 +107,7 @@ func generateRPC(data []byte, limit int) *RPC {
 
 	msgCount := int(generateU16(&data)) % (limit / 2)
 	rpc.Publish = make([]*pb.Message, 0, msgCount)
-	for i := 0; i < msgCount; i++ {
+	for range msgCount {
 		msg := generateMessage(data, limit)
 
 		sizeTester.Publish = []*pb.Message{msg}
@@ -122,7 +122,7 @@ func generateRPC(data []byte, limit int) *RPC {
 
 	subCount := int(generateU16(&data)) % (limit / 2)
 	rpc.Subscriptions = make([]*pb.RPC_SubOpts, 0, subCount)
-	for i := 0; i < subCount; i++ {
+	for range subCount {
 		sub := generateSub(data, limit)
 
 		sizeTester.Subscriptions = []*pb.RPC_SubOpts{sub}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-libp2p-pubsub
 
-go 1.22
+go 1.23
 
 require (
 	github.com/benbjohnson/clock v1.3.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-libp2p-pubsub
 
-go 1.24
+go 1.25
 
 require (
 	github.com/benbjohnson/clock v1.3.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-libp2p-pubsub
 
-go 1.25
+go 1.22
 
 require (
 	github.com/benbjohnson/clock v1.3.5

--- a/gossip_tracer_test.go
+++ b/gossip_tracer_test.go
@@ -19,7 +19,7 @@ func TestBrokenPromises(t *testing.T) {
 	peerC := peer.ID("C")
 
 	var mids []string
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		m := makeTestMessage(i)
 		m.From = []byte(peerA)
 		mid := DefaultMsgIdFn(m)
@@ -73,7 +73,7 @@ func TestNoBrokenPromises(t *testing.T) {
 
 	var msgs []*pb.Message
 	var mids []string
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		m := makeTestMessage(i)
 		m.From = []byte(peerA)
 		msgs = append(msgs, m)

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1,6 +1,7 @@
 package pubsub
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"log/slog"
 	"math/rand"
 	"slices"
-	"cmp"
 	"time"
 
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -9,7 +9,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"slices"
-	"sort"
+	"cmp"
 	"time"
 
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
@@ -704,7 +704,7 @@ func (gs *GossipSubRouter) Attach(p *PubSub) {
 }
 
 func (gs *GossipSubRouter) manageAddrBook() {
-	sub, err := gs.p.host.EventBus().Subscribe([]interface{}{
+	sub, err := gs.p.host.EventBus().Subscribe([]any{
 		&event.EvtPeerIdentificationCompleted{},
 		&event.EvtPeerConnectednessChanged{},
 	})
@@ -1709,8 +1709,8 @@ func (gs *GossipSubRouter) heartbeat() {
 
 			// sort by score (but shuffle first for the case we don't use the score)
 			shufflePeers(plst)
-			sort.Slice(plst, func(i, j int) bool {
-				return score(plst[i]) > score(plst[j])
+			slices.SortFunc(plst, func(a, b peer.ID) int {
+				return cmp.Compare(score(b), score(a))
 			})
 
 			// We keep the first D_score peers by score and the remaining up to D randomly
@@ -1805,8 +1805,8 @@ func (gs *GossipSubRouter) heartbeat() {
 
 			// now compute the median peer score in the mesh
 			plst := peerMapToList(peers)
-			sort.Slice(plst, func(i, j int) bool {
-				return score(plst[i]) < score(plst[j])
+			slices.SortFunc(plst, func(a, b peer.ID) int {
+				return cmp.Compare(score(a), score(b))
 			})
 			medianIndex := len(peers) / 2
 			medianScore := scores[plst[medianIndex]]

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -683,7 +683,7 @@ func (gs *GossipSubRouter) Attach(p *PubSub) {
 	go gs.heartbeatTimer()
 
 	// start the PX connectors
-	for i := 0; i < gs.params.Connectors; i++ {
+	for range gs.params.Connectors {
 		go gs.connector()
 	}
 

--- a/gossipsub_connmgr_test.go
+++ b/gossipsub_connmgr_test.go
@@ -59,7 +59,7 @@ func TestGossipsubConnTagMessageDeliveries(t *testing.T) {
 	honestHosts := make([]host.Host, nHonest)
 	honestPeers := make(map[peer.ID]struct{})
 
-	for i := 0; i < nHonest; i++ {
+	for i := range nHonest {
 		var err error
 		connmgrs[i], err = connmgr.NewConnManager(nHonest, connLimit,
 			connmgr.WithGracePeriod(0),
@@ -118,7 +118,7 @@ func TestGossipsubConnTagMessageDeliveries(t *testing.T) {
 	// have all the hosts publish enough messages to ensure that they get some delivery credit
 	nMessages := GossipSubConnTagMessageDeliveryCap * 2
 	for _, ps := range psubs {
-		for i := 0; i < nMessages; i++ {
+		for range nMessages {
 			ps.Publish(topic, []byte("hello"))
 		}
 	}

--- a/gossipsub_spam_test.go
+++ b/gossipsub_spam_test.go
@@ -207,7 +207,7 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					time.Sleep(20 * time.Millisecond)
 
 					// Send a bunch of IHAVEs
-					for i := 0; i < 3*GossipSubMaxIHaveLength; i++ {
+					for i := range 3*GossipSubMaxIHaveLength {
 						ihavelst := []string{"someid" + strconv.Itoa(i)}
 						ihave := []*pb.ControlIHave{{TopicID: sub.Topicid, MessageIDs: ihavelst}}
 						orpc := rpcWithControl(nil, ihave, nil, nil, nil, nil)
@@ -237,7 +237,7 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					}
 
 					// Send a bunch of IHAVEs
-					for i := 0; i < 3*GossipSubMaxIHaveLength; i++ {
+					for i := range 3*GossipSubMaxIHaveLength {
 						ihavelst := []string{"someid" + strconv.Itoa(i+100)}
 						ihave := []*pb.ControlIHave{{TopicID: sub.Topicid, MessageIDs: ihavelst}}
 						orpc := rpcWithControl(nil, ihave, nil, nil, nil, nil)
@@ -718,7 +718,7 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 
 					// Send a bunch of messages with no signature (these will
 					// fail validation and reduce the attacker's score)
-					for i := 0; i < 100; i++ {
+					for i := range 100 {
 						msg := &pb.Message{
 							Data:  []byte("some data" + strconv.Itoa(i)),
 							Topic: &mytopic,
@@ -848,7 +848,7 @@ func TestGossipsubAttackSpamIDONTWANT(t *testing.T) {
 					// Generate a message and send IDONTWANT to the middle peer
 					data := make([]byte, 16)
 					var mid string
-					for i := 0; i < 1+GossipSubMaxIDontWantMessages; i++ {
+					for range 1+GossipSubMaxIDontWantMessages {
 						rand.Read(data)
 						mid = msgID(&pb.Message{Data: data})
 						writeMsg(&pb.RPC{
@@ -924,7 +924,7 @@ func TestGossipsubHandleIDontwantSpam(t *testing.T) {
 	}
 	exceededIDWLength := GossipSubMaxIDontWantLength + 1
 	var idwIds []string
-	for i := 0; i < exceededIDWLength; i++ {
+	for i := range exceededIDWLength {
 		idwIds = append(idwIds, fmt.Sprintf("idontwant-%d", i))
 	}
 	rPid := hosts[1].ID()

--- a/gossipsub_spam_test.go
+++ b/gossipsub_spam_test.go
@@ -207,7 +207,7 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					time.Sleep(20 * time.Millisecond)
 
 					// Send a bunch of IHAVEs
-					for i := range 3*GossipSubMaxIHaveLength {
+					for i := range 3 * GossipSubMaxIHaveLength {
 						ihavelst := []string{"someid" + strconv.Itoa(i)}
 						ihave := []*pb.ControlIHave{{TopicID: sub.Topicid, MessageIDs: ihavelst}}
 						orpc := rpcWithControl(nil, ihave, nil, nil, nil, nil)
@@ -237,7 +237,7 @@ func TestGossipsubAttackSpamIHAVE(t *testing.T) {
 					}
 
 					// Send a bunch of IHAVEs
-					for i := range 3*GossipSubMaxIHaveLength {
+					for i := range 3 * GossipSubMaxIHaveLength {
 						ihavelst := []string{"someid" + strconv.Itoa(i+100)}
 						ihave := []*pb.ControlIHave{{TopicID: sub.Topicid, MessageIDs: ihavelst}}
 						orpc := rpcWithControl(nil, ihave, nil, nil, nil, nil)
@@ -848,7 +848,7 @@ func TestGossipsubAttackSpamIDONTWANT(t *testing.T) {
 					// Generate a message and send IDONTWANT to the middle peer
 					data := make([]byte, 16)
 					var mid string
-					for range 1+GossipSubMaxIDontWantMessages {
+					for range 1 + GossipSubMaxIDontWantMessages {
 						rand.Read(data)
 						mid = msgID(&pb.Message{Data: data})
 						writeMsg(&pb.RPC{

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -123,7 +123,7 @@ func TestSparseGossipsub(t *testing.T) {
 	// wait for heartbeats to build mesh
 	time.Sleep(time.Second * 2)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := mrand.Intn(len(psubs))
@@ -164,7 +164,7 @@ func TestDenseGossipsub(t *testing.T) {
 	// wait for heartbeats to build mesh
 	time.Sleep(time.Second * 2)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := mrand.Intn(len(psubs))
@@ -205,7 +205,7 @@ func TestGossipsubFanout(t *testing.T) {
 	// wait for heartbeats to build mesh
 	time.Sleep(time.Second * 2)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := 0
@@ -233,7 +233,7 @@ func TestGossipsubFanout(t *testing.T) {
 	// wait for a heartbeat
 	time.Sleep(time.Second * 1)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := 0
@@ -274,7 +274,7 @@ func TestGossipsubFanoutMaintenance(t *testing.T) {
 	// wait for heartbeats to build mesh
 	time.Sleep(time.Second * 2)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := 0
@@ -313,7 +313,7 @@ func TestGossipsubFanoutMaintenance(t *testing.T) {
 
 	time.Sleep(time.Second * 2)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := 0
@@ -359,7 +359,7 @@ func TestGossipsubFanoutExpiry(t *testing.T) {
 	// wait for heartbeats to build mesh
 	time.Sleep(time.Second * 2)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := 0
@@ -418,7 +418,7 @@ func TestGossipsubGossip(t *testing.T) {
 	// wait for heartbeats to build mesh
 	time.Sleep(time.Second * 2)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := mrand.Intn(len(psubs))
@@ -476,7 +476,7 @@ func TestGossipsubGossipPiggyback(t *testing.T) {
 	// wait for heartbeats to build mesh
 	time.Sleep(time.Second * 2)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := mrand.Intn(len(psubs))
@@ -537,7 +537,7 @@ func TestGossipsubGossipPropagation(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := 0
@@ -568,7 +568,7 @@ func TestGossipsubGossipPropagation(t *testing.T) {
 	}
 
 	var collect [][]byte
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		for _, sub := range msgs2 {
 			got, err := sub.Next(ctx)
 			if err != nil {
@@ -578,7 +578,7 @@ func TestGossipsubGossipPropagation(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 		gotit := false
 		for j := 0; j < len(collect); j++ {
@@ -623,7 +623,7 @@ func TestGossipsubPrune(t *testing.T) {
 	// wait a bit to take effect
 	time.Sleep(time.Millisecond * 100)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := mrand.Intn(len(psubs))
@@ -720,7 +720,7 @@ func TestGossipsubPruneBackoffTime(t *testing.T) {
 		t.Errorf("missing too many backoffs: %v", missingBackoffs)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		// Don't publish from host 0, since everyone should have pruned it.
@@ -766,7 +766,7 @@ func TestGossipsubGraft(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := mrand.Intn(len(psubs))
@@ -815,7 +815,7 @@ func TestGossipsubRemovePeer(t *testing.T) {
 	// wait a heartbeat
 	time.Sleep(time.Second * 1)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := 5 + mrand.Intn(len(psubs)-5)
@@ -844,7 +844,7 @@ func TestGossipsubGraftPruneRetry(t *testing.T) {
 
 	var topics []string
 	var msgs [][]*Subscription
-	for i := 0; i < 35; i++ {
+	for i := range 35 {
 		topic := fmt.Sprintf("topic%d", i)
 		topics = append(topics, topic)
 
@@ -913,7 +913,7 @@ func TestGossipsubControlPiggyback(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		owner := mrand.Intn(len(psubs))
-		for i := 0; i < 10000; i++ {
+		for range 10000 {
 			msg := []byte("background flooooood")
 			psubs[owner].Publish("flood", msg)
 		}
@@ -927,7 +927,7 @@ func TestGossipsubControlPiggyback(t *testing.T) {
 	// in the background flood
 	var topics []string
 	var msgs [][]*Subscription
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		topic := fmt.Sprintf("topic%d", i)
 		topics = append(topics, topic)
 
@@ -990,7 +990,7 @@ func TestMixedGossipsub(t *testing.T) {
 	// wait for heartbeats to build mesh
 	time.Sleep(time.Second * 2)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 
 		owner := mrand.Intn(len(psubs))
@@ -1172,7 +1172,7 @@ func TestGossipsubStarTopology(t *testing.T) {
 	}
 
 	// send a message from each peer and assert it was propagated
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i].Publish("test", msg)
 
@@ -1268,7 +1268,7 @@ func TestGossipsubStarTopologyWithSignedPeerRecords(t *testing.T) {
 	}
 
 	// send a message from each peer and assert it was propagated
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i].Publish("test", msg)
 
@@ -1311,7 +1311,7 @@ func TestGossipsubDirectPeers(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// publish some messages
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i].Publish("test", msg)
 
@@ -1332,7 +1332,7 @@ func TestGossipsubDirectPeers(t *testing.T) {
 	}
 
 	// publish some messages
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i].Publish("test", msg)
 
@@ -1455,7 +1455,7 @@ func TestGossipsubDirectPeersFanout(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// h2 publishes some messages to build a fanout
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[2].Publish("test", msg)
 
@@ -1540,7 +1540,7 @@ func TestGossipsubFloodPublish(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// send a message from the star and assert it was received
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[0].Publish("test", msg)
 
@@ -1666,7 +1666,7 @@ func TestGossipsubNegativeScore(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i%20].Publish("test", msg)
 		time.Sleep(20 * time.Millisecond)
@@ -1993,7 +1993,7 @@ func TestGossipsubOpportunisticGrafting(t *testing.T) {
 	}
 
 	// publish a bunch of messages from the real hosts
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i%10].Publish("test", msg)
 		time.Sleep(20 * time.Millisecond)
@@ -2248,7 +2248,7 @@ func TestGossipsubPeerScoreInspect(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i%2].Publish("test", msg)
 		time.Sleep(20 * time.Millisecond)
@@ -2407,7 +2407,7 @@ func TestGossipsubRPCFragmentation(t *testing.T) {
 	// publish a bunch of fairly large messages from the real host
 	nMessages := 1000
 	msgSize := 20000
-	for i := 0; i < nMessages; i++ {
+	for range nMessages {
 		msg := make([]byte, msgSize)
 		crand.Read(msg)
 		ps.Publish("test", msg)
@@ -2590,7 +2590,7 @@ func TestFragmentRPCFunction(t *testing.T) {
 		},
 	}
 	rpc.Publish = make([]*pb.Message, nMessages)
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		rpc.Publish[i] = mkMsg(msgSize)
 	}
 	results, err = fragmentRPC(rpc, limit)
@@ -2659,7 +2659,7 @@ func TestFragmentRPCFunction(t *testing.T) {
 	msgsPerTopic := 100 // enough that a single IHAVE or IWANT will exceed the limit
 	rpc.Control.Ihave = make([]*pb.ControlIHave, nTopics)
 	rpc.Control.Iwant = make([]*pb.ControlIWant, nTopics)
-	for i := 0; i < nTopics; i++ {
+	for i := range nTopics {
 		messageIds := make([]string, msgsPerTopic)
 		for m := 0; m < msgsPerTopic; m++ {
 			mid := make([]byte, messageIdSize)
@@ -2971,7 +2971,7 @@ func TestGossipsubIdontwantSend(t *testing.T) {
 					time.Sleep(100 * time.Millisecond)
 
 					// Publish messages from the first peer
-					for i := 0; i < 10; i++ {
+					for range 10 {
 						publishMsg()
 					}
 				}()
@@ -3294,7 +3294,7 @@ func TestGossipsubIdontwantNonMesh(t *testing.T) {
 					time.Sleep(100 * time.Millisecond)
 
 					// Publish messages from the first peer
-					for i := 0; i < 10; i++ {
+					for range 10 {
 						publishMsg()
 					}
 				}()
@@ -3382,7 +3382,7 @@ func TestGossipsubIdontwantIncompat(t *testing.T) {
 					time.Sleep(100 * time.Millisecond)
 
 					// Publish messages from the first peer
-					for i := 0; i < 10; i++ {
+					for range 10 {
 						publishMsg()
 					}
 				}()
@@ -3470,7 +3470,7 @@ func TestGossipsubIdontwantSmallMessage(t *testing.T) {
 					time.Sleep(100 * time.Millisecond)
 
 					// Publish messages from the first peer
-					for i := 0; i < 10; i++ {
+					for range 10 {
 						publishMsg()
 					}
 				}()
@@ -3704,7 +3704,7 @@ func TestGossipsubPruneMeshCorrectly(t *testing.T) {
 	params.Dhi = 8
 
 	psubs := make([]*PubSub, 9)
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		psubs[i] = getGossipsub(ctx, hosts[i],
 			WithGossipSubParams(params),
 			WithMessageIdFn(msgID))
@@ -3760,7 +3760,7 @@ func TestRoundRobinMessageIDScheduler(t *testing.T) {
 		var strategy RoundRobinMessageIDScheduler
 
 		peers := make([]peer.ID, numPeers)
-		for i := 0; i < int(numPeers); i++ {
+		for i := range int(numPeers) {
 			peers[i] = peer.ID(fmt.Sprintf("peer%d", i))
 		}
 
@@ -3804,7 +3804,7 @@ func TestRoundRobinMessageIDScheduler(t *testing.T) {
 		// 2.
 		seen := make(map[string]bool)
 		expected := make(map[string]bool)
-		for i := 0; i < int(numMessages); i++ {
+		for i := range int(numMessages) {
 			expected[fmt.Sprintf("msg%d", i)] = true
 		}
 
@@ -3908,7 +3908,7 @@ func TestMessageBatchPublish(t *testing.T) {
 
 			var batch MessageBatch
 			var wg sync.WaitGroup
-			for i := 0; i < numMessages; i++ {
+			for i := range numMessages {
 				msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
 				if concurrentAdd {
 					wg.Add(1)
@@ -4014,7 +4014,7 @@ func BenchmarkSplitRPCLargeMessages(b *testing.B) {
 		const numRPCs = 30
 		const msgSize = 50 * 1024
 		rpc := &RPC{}
-		for i := 0; i < numRPCs; i++ {
+		for range numRPCs {
 			addToRPC(rpc, 20, msgSize+r.Intn(100))
 		}
 
@@ -4030,7 +4030,7 @@ func BenchmarkSplitRPCLargeMessages(b *testing.B) {
 		const numRPCs = 2
 		const msgSize = DefaultMaxMessageSize - 100
 		rpc := &RPC{}
-		for i := 0; i < numRPCs; i++ {
+		for range numRPCs {
 			addToRPC(rpc, 1, msgSize)
 		}
 

--- a/mcache_test.go
+++ b/mcache_test.go
@@ -17,11 +17,11 @@ func TestMessageCache(t *testing.T) {
 		msgs[i] = makeTestMessage(i)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mcache.Put(&Message{Message: msgs[i]})
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mid := msgID(msgs[i])
 		m, ok := mcache.Get(mid)
 		if !ok {
@@ -38,7 +38,7 @@ func TestMessageCache(t *testing.T) {
 		t.Fatalf("Expected 10 gossip IDs; got %d", len(gids))
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mid := msgID(msgs[i])
 		if mid != gids[i] {
 			t.Fatalf("GossipID mismatch for message %d", i)
@@ -50,7 +50,7 @@ func TestMessageCache(t *testing.T) {
 		mcache.Put(&Message{Message: msgs[i]})
 	}
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		mid := msgID(msgs[i])
 		m, ok := mcache.Get(mid)
 		if !ok {
@@ -67,7 +67,7 @@ func TestMessageCache(t *testing.T) {
 		t.Fatalf("Expected 20 gossip IDs; got %d", len(gids))
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mid := msgID(msgs[i])
 		if mid != gids[10+i] {
 			t.Fatalf("GossipID mismatch for message %d", i)
@@ -105,7 +105,7 @@ func TestMessageCache(t *testing.T) {
 		t.Fatalf("Expected 50 messages in the cache; got %d", len(mcache.msgs))
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mid := msgID(msgs[i])
 		_, ok := mcache.Get(mid)
 		if ok {
@@ -130,7 +130,7 @@ func TestMessageCache(t *testing.T) {
 		t.Fatalf("Expected 30 gossip IDs; got %d", len(gids))
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mid := msgID(msgs[50+i])
 		if mid != gids[i] {
 			t.Fatalf("GossipID mismatch for message %d", i)

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
-	"sort"
+	"cmp"
+	"slices"
 	"sync"
 	"time"
 
@@ -314,8 +315,8 @@ func (pg *peerGater) getPeerIP(p peer.ID) string {
 			}
 			streams[c.ID()] = len(c.GetStreams())
 		}
-		sort.Slice(conns, func(i, j int) bool {
-			return streams[conns[i].ID()] > streams[conns[j].ID()]
+		slices.SortFunc(conns, func(a, b network.Conn) int {
+			return cmp.Compare(streams[b.ID()], streams[a.ID()])
 		})
 		return connToIP(conns[0])
 	}

--- a/peer_gater.go
+++ b/peer_gater.go
@@ -1,11 +1,11 @@
 package pubsub
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
 	"math/rand"
-	"cmp"
 	"slices"
 	"sync"
 	"time"

--- a/peer_gater_test.go
+++ b/peer_gater_test.go
@@ -59,7 +59,7 @@ func TestPeerGater(t *testing.T) {
 		t.Fatal("expected AcceptAll")
 	}
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		pg.RejectMessage(msg, RejectValidationIgnored)
 		pg.RejectMessage(msg, RejectValidationFailed)
 	}
@@ -75,7 +75,7 @@ func TestPeerGater(t *testing.T) {
 		t.Fatal("expected AcceptControl")
 	}
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		pg.DeliverMessage(msg)
 	}
 
@@ -90,7 +90,7 @@ func TestPeerGater(t *testing.T) {
 		t.Fatal("expected to accept at least once")
 	}
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		pg.decayStats()
 	}
 

--- a/peer_notify.go
+++ b/peer_notify.go
@@ -12,7 +12,7 @@ import (
 func (ps *PubSub) watchForNewPeers(ctx context.Context) {
 	// We don't bother subscribing to "connectivity" events because we always run identify after
 	// every new connection.
-	sub, err := ps.host.EventBus().Subscribe([]interface{}{
+	sub, err := ps.host.EventBus().Subscribe([]any{
 		&event.EvtPeerIdentificationCompleted{},
 		&event.EvtPeerProtocolsUpdated{},
 	})

--- a/pubsub.go
+++ b/pubsub.go
@@ -258,7 +258,7 @@ type Message struct {
 	*pb.Message
 	ID            string
 	ReceivedFrom  peer.ID
-	ValidatorData interface{}
+	ValidatorData any
 	Local         bool
 }
 

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -13,7 +13,7 @@ import (
 func getDefaultHosts(t *testing.T, n int) []host.Host {
 	var out []host.Host
 
-	for i := 0; i < n; i++ {
+	for range n {
 		h, err := libp2p.New(libp2p.ResourceManager(&network.NullResourceManager{}))
 		if err != nil {
 			t.Fatal(err)

--- a/randomsub_test.go
+++ b/randomsub_test.go
@@ -57,7 +57,7 @@ func TestRandomsubSmall(t *testing.T) {
 	time.Sleep(time.Second)
 
 	count := 0
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i].Publish("test", msg)
 
@@ -94,7 +94,7 @@ func TestRandomsubBig(t *testing.T) {
 	time.Sleep(time.Second)
 
 	count := 0
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i].Publish("test", msg)
 
@@ -133,7 +133,7 @@ func TestRandomsubMixed(t *testing.T) {
 	time.Sleep(time.Second)
 
 	count := 0
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 		psubs[i].Publish("test", msg)
 

--- a/score.go
+++ b/score.go
@@ -154,7 +154,7 @@ type TopicScoreSnapshot struct {
 //     components for debugging peer scoring.
 //
 // This option must be passed _after_ the WithPeerScore option.
-func WithPeerScoreInspect(inspect interface{}, period time.Duration) Option {
+func WithPeerScoreInspect(inspect any, period time.Duration) Option {
 	return func(ps *PubSub) error {
 		gs, ok := ps.rt.(*GossipSubRouter)
 		if !ok {

--- a/score_test.go
+++ b/score_test.go
@@ -108,7 +108,7 @@ func TestScoreFirstMessageDeliveries(t *testing.T) {
 
 	// deliver a bunch of messages from peer A
 	nMessages := 100
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		pbMsg := makeTestMessage(i)
 		pbMsg.Topic = &mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -148,7 +148,7 @@ func TestScoreFirstMessageDeliveriesCap(t *testing.T) {
 
 	// deliver a bunch of messages from peer A
 	nMessages := 100
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		pbMsg := makeTestMessage(i)
 		pbMsg.Topic = &mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -188,7 +188,7 @@ func TestScoreFirstMessageDeliveriesDecay(t *testing.T) {
 
 	// deliver a bunch of messages from peer A
 	nMessages := 100
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		pbMsg := makeTestMessage(i)
 		pbMsg.Topic = &mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -205,7 +205,7 @@ func TestScoreFirstMessageDeliveriesDecay(t *testing.T) {
 
 	// refreshing the scores applies the decay param
 	decayIntervals := 10
-	for i := 0; i < decayIntervals; i++ {
+	for range decayIntervals {
 		ps.refreshScores()
 		expected *= topicScoreParams.FirstMessageDeliveriesDecay
 	}
@@ -268,7 +268,7 @@ func TestScoreMeshMessageDeliveries(t *testing.T) {
 	// and duplicates outside the window from peer C.
 	nMessages := 100
 	wg := sync.WaitGroup{}
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		pbMsg := makeTestMessage(i)
 		pbMsg.Topic = &mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -338,7 +338,7 @@ func TestScoreMeshMessageDeliveriesDecay(t *testing.T) {
 
 	// deliver messages from peer A
 	nMessages := 40
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		pbMsg := makeTestMessage(i)
 		pbMsg.Topic = &mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -355,7 +355,7 @@ func TestScoreMeshMessageDeliveriesDecay(t *testing.T) {
 
 	// we need to refresh enough times for the decay to bring us below the threshold
 	decayedDeliveryCount := float64(nMessages) * topicScoreParams.MeshMessageDeliveriesDecay
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		ps.refreshScores()
 		decayedDeliveryCount *= topicScoreParams.MeshMessageDeliveriesDecay
 	}
@@ -412,7 +412,7 @@ func TestScoreMeshFailurePenalty(t *testing.T) {
 
 	// deliver messages from peer A. peer B does nothing
 	nMessages := 100
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		pbMsg := makeTestMessage(i)
 		pbMsg.Topic = &mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -472,7 +472,7 @@ func TestScoreInvalidMessageDeliveries(t *testing.T) {
 	ps.Graft(peerA, mytopic)
 
 	nMessages := 100
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		pbMsg := makeTestMessage(i)
 		pbMsg.Topic = &mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -509,7 +509,7 @@ func TestScoreInvalidMessageDeliveriesDecay(t *testing.T) {
 	ps.Graft(peerA, mytopic)
 
 	nMessages := 100
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		pbMsg := makeTestMessage(i)
 		pbMsg.Topic = &mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -524,7 +524,7 @@ func TestScoreInvalidMessageDeliveriesDecay(t *testing.T) {
 	}
 
 	// refresh scores a few times to apply decay
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ps.refreshScores()
 		expected *= math.Pow(topicScoreParams.InvalidMessageDeliveriesDecay, 2)
 	}
@@ -946,7 +946,7 @@ func TestScoreRecapTopicParams(t *testing.T) {
 
 	// deliver a bunch of messages from peer A, with duplicates within the window from peer B,
 	nMessages := 100
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		pbMsg := makeTestMessage(i)
 		pbMsg.Topic = &mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -1028,7 +1028,7 @@ func TestScoreResetTopicParams(t *testing.T) {
 
 	// reject a bunch of messages
 	nMessages := 100
-	for i := 0; i < nMessages; i++ {
+	for i := range nMessages {
 		pbMsg := makeTestMessage(i)
 		pbMsg.Topic = &mytopic
 		msg := Message{ReceivedFrom: peerA, Message: pbMsg}

--- a/tag_tracer_test.go
+++ b/tag_tracer_test.go
@@ -190,7 +190,7 @@ func TestTagTracerDeliveryTagsNearFirst(t *testing.T) {
 
 	tt.Join(topic)
 
-	for i := range GossipSubConnTagMessageDeliveryCap+5 {
+	for i := range GossipSubConnTagMessageDeliveryCap + 5 {
 		msg := &Message{
 			ReceivedFrom: p,
 			Message: &pb.Message{

--- a/tag_tracer_test.go
+++ b/tag_tracer_test.go
@@ -99,7 +99,7 @@ func TestTagTracerDeliveryTags(t *testing.T) {
 	tt.Join(topic1)
 	tt.Join(topic2)
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		// deliver only 5 messages to topic 2 (less than the cap)
 		topic := &topic1
 		if i < 5 {
@@ -190,7 +190,7 @@ func TestTagTracerDeliveryTagsNearFirst(t *testing.T) {
 
 	tt.Join(topic)
 
-	for i := 0; i < GossipSubConnTagMessageDeliveryCap+5; i++ {
+	for i := range GossipSubConnTagMessageDeliveryCap+5 {
 		msg := &Message{
 			ReceivedFrom: p,
 			Message: &pb.Message{

--- a/timecache/first_seen_cache_test.go
+++ b/timecache/first_seen_cache_test.go
@@ -18,13 +18,13 @@ func TestFirstSeenCacheFound(t *testing.T) {
 
 func TestFirstSeenCacheExpire(t *testing.T) {
 	tc := newFirstSeenCacheWithSweepInterval(time.Second, time.Second)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		tc.Add(fmt.Sprint(i))
 		time.Sleep(time.Millisecond * 100)
 	}
 
 	time.Sleep(2 * time.Second)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if tc.Has(fmt.Sprint(i)) {
 			t.Fatalf("should have dropped this key: %s from the cache already", fmt.Sprint(i))
 		}

--- a/timecache/last_seen_cache_test.go
+++ b/timecache/last_seen_cache_test.go
@@ -18,13 +18,13 @@ func TestLastSeenCacheFound(t *testing.T) {
 
 func TestLastSeenCacheExpire(t *testing.T) {
 	tc := newLastSeenCacheWithSweepInterval(time.Second, time.Second)
-	for i := 0; i < 11; i++ {
+	for i := range 11 {
 		tc.Add(fmt.Sprint(i))
 		time.Sleep(time.Millisecond * 100)
 	}
 
 	time.Sleep(2 * time.Second)
-	for i := 0; i < 11; i++ {
+	for i := range 11 {
 		if tc.Has(fmt.Sprint(i)) {
 			t.Fatalf("should have dropped this key: %s from the cache already", fmt.Sprint(i))
 		}

--- a/topic_test.go
+++ b/topic_test.go
@@ -299,7 +299,7 @@ func TestSubscriptionJoinNotification(t *testing.T) {
 	}
 
 	wg := sync.WaitGroup{}
-	for i := 0; i < numHosts; i++ {
+	for i := range numHosts {
 		peersFound := make(map[peer.ID]struct{})
 		topicPeersFound[i] = peersFound
 		evt := evts[i]
@@ -354,7 +354,7 @@ func TestSubscriptionLeaveNotification(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 
 	wg := sync.WaitGroup{}
-	for i := 0; i < numHosts; i++ {
+	for i := range numHosts {
 		peersFound := make(map[peer.ID]struct{})
 		topicPeersFound[i] = peersFound
 		evt := evts[i]
@@ -573,7 +573,7 @@ func TestTopicRelay(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		msg := []byte("message")
 
 		owner := rand.Intn(len(topics))
@@ -1010,7 +1010,7 @@ func TestTopicRelayPublishWithKey(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		msg := []byte("message")
 
 		owner := rand.Intn(len(topics))

--- a/trace_test.go
+++ b/trace_test.go
@@ -98,7 +98,7 @@ func testWithTracer(t *testing.T, tracer EventTracer) {
 	time.Sleep(5 * time.Second)
 
 	// publish some messages
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		if i%7 == 0 {
 			psubs[i].Publish("test", []byte("invalid!"))
 		} else {

--- a/validation.go
+++ b/validation.go
@@ -112,7 +112,7 @@ type validatorImpl struct {
 // async request to add a topic validators
 type addValReq struct {
 	topic    string
-	validate interface{}
+	validate any
 	timeout  time.Duration
 	throttle int
 	inline   bool
@@ -140,7 +140,7 @@ func newValidation() *validation {
 func (v *validation) Start(p *PubSub) {
 	v.p = p
 	v.tracer = p.tracer
-	for i := 0; i < v.validateWorkers; i++ {
+	for range v.validateWorkers {
 		go v.validateWorker()
 	}
 }
@@ -452,7 +452,7 @@ func (v *validation) validateTopic(vals []*validatorImpl, src peer.ID, msg *Mess
 
 	result := ValidationAccept
 loop:
-	for i := 0; i < rcount; i++ {
+	for range rcount {
 		switch <-rch {
 		case ValidationAccept:
 		case ValidationReject:

--- a/validation_builtin_test.go
+++ b/validation_builtin_test.go
@@ -77,7 +77,7 @@ func testBasicSeqnoValidator(t *testing.T, ttl time.Duration) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg := []byte(fmt.Sprintf("%d the flooooooood %d", i, i))
 
 		owner := rng.Intn(len(psubs))
@@ -125,7 +125,7 @@ func TestBasicSeqnoValidatorReplay(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := []byte(fmt.Sprintf("%d the flooooooood %d", i, i))
 
 		owner := rng.Intn(len(psubs))
@@ -254,7 +254,7 @@ func (r *replayActor) send(p peer.ID, rpc *pb.RPC) {
 
 func (r *replayActor) replay(msg *pb.Message) {
 	// replay the message 10 times to a random subset of peers
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		delay := time.Duration(1+rng.Intn(20)) * time.Millisecond
 		time.Sleep(delay)
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -318,7 +318,7 @@ func TestValidateAssortedOptions(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := []byte(fmt.Sprintf("message %d", i))
 
 		psubs[i].Publish("test1", msg)


### PR DESCRIPTION
Bumps the minimum Go version from 1.24 to 1.25 and applies idiomatic Go 1.22+ patterns across the codebase.
