### PR TITLE
docfix: contribute.md in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ ps, err := pubsub.NewGossipSub(..., pubsub.WithEventTracer(tracer))
 
 Contributions welcome. Please check out [the issues](https://github.com/libp2p/go-libp2p-pubsub/issues).
 
-Check out our [contributing document](https://github.com/libp2p/community/blob/master/contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to multiformats are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+Check out our [contributing document](https://github.com/libp2p/community/blob/master/CONTRIBUTE.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to multiformats are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
 Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
 


### PR DESCRIPTION
Fix README contributing guide link to point to libp2p/community/CONTRIBUTE.md, preventing a 404 and directing contributors to the correct document.