### PR TITLE
partialmsgs: Change Gossip Callback to have application call PublishPartial

### DIFF
--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -4556,10 +4556,6 @@ func (m *minimalTestPartialMessage) GroupID() []byte {
 	return m.Group
 }
 
-func noOpPublishActions(peerStates map[peer.ID]peerState, peerRequestsPartial func(peer.ID) bool) iter.Seq2[peer.ID, partialmessages.PublishAction] {
-	return func(yield func(peer.ID, partialmessages.PublishAction) bool) {}
-}
-
 func (m *minimalTestPartialMessage) publishActions(peerStates map[peer.ID]peerState, peerRequestsPartial func(peer.ID) bool) iter.Seq2[peer.ID, partialmessages.PublishAction] {
 	myPartsMeta := m.PartsMetadata()
 	return func(yield func(peer.ID, partialmessages.PublishAction) bool) {
@@ -4634,12 +4630,12 @@ func TestPartialMessages(t *testing.T) {
 	for i := range partialExt {
 		partialExt[i] = &partialmessages.PartialMessagesExtension[peerState]{
 			Logger: logger.With("id", i),
-			GossipActions: func(topic string, groupID []byte) partialmessages.PublishActionsFn[peerState] {
+			OnEmitGossip: func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
 				pm := partialMessageStore[i][topic+string(groupID)]
 				if pm == nil {
-					return noOpPublishActions
+					return
 				}
-				return pm.publishActions
+				partialExt[i].PublishPartial(topic, groupID, pm.publishActions)
 			},
 			OnIncomingRPC: func(from peer.ID, peerStates map[peer.ID]peerState, rpc *pb.PartialMessagesExtension) error {
 				peerState := peerStates[from]
@@ -4761,12 +4757,12 @@ func TestPeerSupportsPartialMessages(t *testing.T) {
 	for i := range partialExt {
 		partialExt[i] = &partialmessages.PartialMessagesExtension[peerState]{
 			Logger: logger.With("id", i),
-			GossipActions: func(topic string, groupID []byte) partialmessages.PublishActionsFn[peerState] {
+			OnEmitGossip: func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
 				pm := partialMessageStore[i][topic+string(groupID)]
 				if pm == nil {
-					return noOpPublishActions
+					return
 				}
-				return pm.publishActions
+				partialExt[i].PublishPartial(topic, groupID, pm.publishActions)
 			},
 			OnIncomingRPC: func(from peer.ID, peerStates map[peer.ID]peerState, rpc *pb.PartialMessagesExtension) error {
 				peerState := peerStates[from]
@@ -4958,12 +4954,12 @@ func TestSkipPublishingToPeersRequestingPartialMessages(t *testing.T) {
 	for i := range partialExt {
 		partialExt[i] = &partialmessages.PartialMessagesExtension[peerState]{
 			Logger: logger,
-			GossipActions: func(topic string, groupID []byte) partialmessages.PublishActionsFn[peerState] {
+			OnEmitGossip: func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
 				pm := partialMessageStore[i][topic+string(groupID)]
 				if pm == nil {
-					return noOpPublishActions
+					return
 				}
-				return pm.publishActions
+				partialExt[i].PublishPartial(topic, groupID, pm.publishActions)
 			},
 			OnIncomingRPC: func(from peer.ID, peerStates map[peer.ID]peerState, rpc *pb.PartialMessagesExtension) error {
 				peerState := peerStates[from]
@@ -5119,12 +5115,12 @@ func TestPairwiseInteractionWithPartialMessages(t *testing.T) {
 				}
 				partialExt[i] = &partialmessages.PartialMessagesExtension[peerState]{
 					Logger: logger.With("id", i),
-					GossipActions: func(topic string, groupID []byte) partialmessages.PublishActionsFn[peerState] {
+					OnEmitGossip: func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
 						pm := partialMessageStore[i][topic+string(groupID)]
 						if pm == nil {
-							return noOpPublishActions
+							return
 						}
-						return pm.publishActions
+						partialExt[i].PublishPartial(topic, groupID, pm.publishActions)
 					},
 					OnIncomingRPC: func(from peer.ID, peerStates map[peer.ID]peerState, rpc *pb.PartialMessagesExtension) error {
 						peerState := peerStates[from]
@@ -5288,8 +5284,7 @@ func TestNoIDONTWANTWithPartialMessage(t *testing.T) {
 			return []Option{
 				WithPartialMessagesExtension(
 					&partialmessages.PartialMessagesExtension[peerState]{
-						GossipActions: func(topic string, groupID []byte) partialmessages.PublishActionsFn[peerState] {
-							return noOpPublishActions
+						OnEmitGossip: func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
 						},
 						Logger: slog.Default(),
 						OnIncomingRPC: func(from peer.ID, peerStates map[peer.ID]peerState, rpc *pb.PartialMessagesExtension) error {

--- a/partialmessages/partialmsgs.go
+++ b/partialmessages/partialmsgs.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"iter"
 	"log/slog"
-	"maps"
 
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -64,10 +63,13 @@ func (s *partialMessageStatePerGroupPerTopic[P]) remotePeerInitiated() bool {
 type PartialMessagesExtension[PeerState any] struct {
 	Logger *slog.Logger
 
-	// GossipActions is called when gossiping to peers on the given topic and
-	// groupID. It should return a PublishActionsFn to be used for sending
+	// OnEmitGossip is called when the application should send gossip to the given
+	// peers. The application SHOULD call PublishPartial to send partial
 	// messages to these peers.
-	GossipActions func(topic string, groupID []byte) PublishActionsFn[PeerState]
+	//
+	// The Application may persist some state in the peerStates map. The peers
+	// to gossip to will have a zero-value PeerState in the map.
+	OnEmitGossip func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]PeerState)
 
 	// OnIncomingRPC is called whenever we receive an encoded
 	// partial message from a peer. This function MUST be fast and non-blocking.
@@ -158,8 +160,8 @@ func (e *PartialMessagesExtension[PeerState]) Init(router Router) error {
 	if e.OnIncomingRPC == nil {
 		return errors.New("field OnIncomingRPC must be set")
 	}
-	if e.GossipActions == nil {
-		return errors.New("field GossipActions must be set")
+	if e.OnEmitGossip == nil {
+		return errors.New("field OnEmitGossip must be set")
 	}
 
 	if e.PeerInitiatedGroupLimitPerTopic == 0 {
@@ -284,30 +286,17 @@ func (e *PartialMessagesExtension[PeerState]) EmitGossip(topic string, peers []p
 		if gState.remotePeerInitiated() {
 			continue
 		}
-		var newGossipPeerCount int
+		untrackedPeers := make([]peer.ID, 0, len(peers))
 		for _, p := range peers {
-			if _, ok := gState.peerState[p]; !ok {
-				newGossipPeerCount++
+			_, ok := gState.peerState[p]
+			if !ok {
+				var newState PeerState
+				gState.peerState[p] = newState
+				untrackedPeers = append(untrackedPeers, p)
 			}
 		}
-		if newGossipPeerCount > 0 {
-			// We only emit gossip for peers not already in our group state.
-			// Peers in the group state are handled the same as mesh peers.
-			peerStates := make(map[peer.ID]PeerState, newGossipPeerCount)
-			for _, p := range peers {
-				var newState PeerState
-				peerStates[p] = newState
-			}
-			publishActions := e.GossipActions(topic, []byte(group))(
-				peerStates,
-				func(p peer.ID) bool {
-					return e.router.PeerRequestsPartial(p, topic)
-				})
-			maps.Copy(gState.peerState, peerStates)
-			err := e.publish(topic, []byte(group), publishActions)
-			if err != nil {
-				e.Logger.Error("Failed to publish gossip message", "topic", topic, "group", group, "error", err)
-			}
+		if len(untrackedPeers) > 0 {
+			e.OnEmitGossip(topic, []byte(group), untrackedPeers, gState.peerState)
 		}
 	}
 }

--- a/partialmessages/partialmsgs_test.go
+++ b/partialmessages/partialmsgs_test.go
@@ -241,10 +241,6 @@ func (pm *testPartialMessage) shouldRequest(partsMetadata []byte) bool {
 	return iWant.Cmp(&zero) != 0
 }
 
-func noOpPublishActions(peerStates map[peer.ID]peerState, peerRequestsPartial func(peer.ID) bool) iter.Seq2[peer.ID, PublishAction] {
-	return func(yield func(peer.ID, PublishAction) bool) {}
-}
-
 func (pm *testPartialMessage) publishActions(peerStates map[peer.ID]peerState, peerRequestsPartial func(peer.ID) bool) iter.Seq2[peer.ID, PublishAction] {
 	myPartsMeta := pm.PartsMetadata()
 	return func(yield func(peer.ID, PublishAction) bool) {
@@ -386,12 +382,12 @@ func createPeers(t *testing.T, topic string, n int, nonMesh bool) *testPeers {
 		// Create handler
 		handler = &PartialMessagesExtension[peerState]{
 			Logger: slog.Default().With("id", i),
-			GossipActions: func(topic string, groupID []byte) PublishActionsFn[peerState] {
+			OnEmitGossip: func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
 				pm := testPeers.partialMessages[currentPeer][topic][string(groupID)]
 				if pm == nil {
-					return noOpPublishActions
+					return
 				}
-				return pm.publishActions
+				handler.PublishPartial(topic, groupID, pm.publishActions)
 			},
 			OnIncomingRPC: func(from peer.ID, peerStates map[peer.ID]peerState, rpc *pubsub_pb.PartialMessagesExtension) error {
 				// Handle incoming partial message data - use testPeers to track state
@@ -1081,22 +1077,20 @@ func TestGossipDelivery(t *testing.T) {
 		}
 	}
 
-	gossipForPeer := func(selfID peer.ID) func(topic string, groupID []byte) PublishActionsFn[peerState] {
-		return func(topic string, groupID []byte) PublishActionsFn[peerState] {
+	gossipForPeer := func(selfID peer.ID, selfHandler **PartialMessagesExtension[peerState]) func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
+		return func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
 			pm := partialMessages[selfID][topic][string(groupID)]
 			if pm == nil {
-				return func(peerStates map[peer.ID]peerState, peerRequestsPartial func(peer.ID) bool) iter.Seq2[peer.ID, PublishAction] {
-					return func(yield func(peer.ID, PublishAction) bool) {}
-				}
+				return
 			}
-			return pm.publishActions
+			(*selfHandler).PublishPartial(topic, groupID, pm.publishActions)
 		}
 	}
 
 	// Create h1 handler
 	h1Handler = &PartialMessagesExtension[peerState]{
 		Logger:             slog.Default().With("id", "h1"),
-		GossipActions:      gossipForPeer(h1ID),
+		OnEmitGossip:       gossipForPeer(h1ID, &h1Handler),
 		OnIncomingRPC:      gossipOnIncomingRPC(h1ID, &h1Handler),
 		GroupTTLByHeatbeat: 5,
 	}
@@ -1105,7 +1099,7 @@ func TestGossipDelivery(t *testing.T) {
 	// Create h2 handler
 	h2Handler = &PartialMessagesExtension[peerState]{
 		Logger:             slog.Default().With("id", "h2"),
-		GossipActions:      gossipForPeer(h2ID),
+		OnEmitGossip:       gossipForPeer(h2ID, &h2Handler),
 		OnIncomingRPC:      gossipOnIncomingRPC(h2ID, &h2Handler),
 		GroupTTLByHeatbeat: 5,
 	}
@@ -1192,8 +1186,7 @@ func TestPeerInitiatedCounter(t *testing.T) {
 	}
 	handler := PartialMessagesExtension[peerState]{
 		Logger: slog.Default(),
-		GossipActions: func(topic string, groupID []byte) PublishActionsFn[peerState] {
-			return noOpPublishActions
+		OnEmitGossip: func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
 		},
 		OnIncomingRPC: func(from peer.ID, peerStates map[peer.ID]peerState, rpc *pubsub_pb.PartialMessagesExtension) error {
 			if rpc.PartsMetadata != nil {
@@ -1321,8 +1314,7 @@ func FuzzPeerInitiatedCounter(f *testing.F) {
 
 		handler := PartialMessagesExtension[peerState]{
 			Logger: slog.Default(),
-			GossipActions: func(topic string, groupID []byte) PublishActionsFn[peerState] {
-				return noOpPublishActions
+			OnEmitGossip: func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
 			},
 			OnIncomingRPC: func(from peer.ID, peerStates map[peer.ID]peerState, rpc *pubsub_pb.PartialMessagesExtension) error {
 				if rpc.PartsMetadata != nil {


### PR DESCRIPTION
Instead of returning a PublishActionsFn. It makes things clearer in terms of when the PublishActionsFn's returned iterator is used. More specifically, the PublishPartial function only calls PublishFunctionsFn within its scope. The old gossip callback would call PublishActionsFn after the callback returned.

The old style made it awkward to know when gossipsub was done with the PublishActionsFn reference.

The change also consolidates similar code which is nice.