### PR TITLE
Don't process stale RPCs

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -899,8 +899,13 @@ func (gs *GossipSubRouter) Preprocess(from peer.ID, msgs []*Message) {
 
 func (gs *GossipSubRouter) HandleRPC(rpc *RPC) {
 	err := gs.extensions.HandleRPC(rpc)
+	peerProto, ok := gs.peers[rpc.from]
 	if err != nil {
+	if !ok {
 		gs.logger.Warn("error in handling RPC", "from", rpc.from, "err", err)
+		// Happens if the peer is no longer connected but we are processing a stale RPC
+		return
+	}
 	}
 
 	ctl := rpc.GetControl()

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -898,14 +898,16 @@ func (gs *GossipSubRouter) Preprocess(from peer.ID, msgs []*Message) {
 }
 
 func (gs *GossipSubRouter) HandleRPC(rpc *RPC) {
-	err := gs.extensions.HandleRPC(rpc)
 	peerProto, ok := gs.peers[rpc.from]
-	if err != nil {
 	if !ok {
-		gs.logger.Warn("error in handling RPC", "from", rpc.from, "err", err)
 		// Happens if the peer is no longer connected but we are processing a stale RPC
 		return
 	}
+	if gs.feature(GossipSubFeatureExtensions, peerProto) {
+		err := gs.extensions.HandleRPC(rpc)
+		if err != nil {
+			gs.logger.Warn("error in handling RPC", "from", rpc.from, "err", err)
+		}
 	}
 
 	ctl := rpc.GetControl()


### PR DESCRIPTION
There's a subtle race condition where we end up handling an RPC from a disconnected peer if they disconnect after queuing an RPC to the `p.incoming` channel and we process the disconnect event before the queued RPC.

One example of this showing up was incorrectly flagging duplicate extension messages, which was observed in production. Consider the following sequence:
1. Peer sends a message, queued in `p.incoming`
2. Peer disconnects.
3. pubsub handles the disconnect.
4. clears `es.peerExtensions`
5. pubsub handles queued `p.incoming`
6. sets `es.peerExtensions` in response to receiving a "first" rpc.
7. peer reconnects and sends an extensions control message, pubsub penalizes the peer for sending duplicate extensions control.

Since this is so timing dependent, it's quite hard to have a test for this. In production it mostly shows up when the server is overloaded with other work (at 100% cpu).