### PR TITLE
Fix leak around different lifecycles of inbound vs outbound streams.

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -54,23 +54,49 @@ func (p *PubSub) getHelloPacket() *RPC {
 
 func (p *PubSub) handleNewStream(s network.Stream) {
 	peer := s.Conn().RemotePeer()
-
-	p.inboundStreamsMx.Lock()
-	other, dup := p.inboundStreams[peer]
-	if dup {
-		p.logger.Debug("duplicate inbound stream from; resetting other stream", "peer", peer)
-		other.Reset()
-	}
-	p.inboundStreams[peer] = s
-	p.inboundStreamsMx.Unlock()
+	done := make(chan struct{})
+	sentNewStream := false
 
 	defer func() {
 		p.inboundStreamsMx.Lock()
-		if p.inboundStreams[peer] == s {
+		if p.inboundStreams[peer].s == s {
 			delete(p.inboundStreams, peer)
 		}
 		p.inboundStreamsMx.Unlock()
+
+		if sentNewStream {
+			select {
+			case p.incoming <- incomingUnion{kind: incomingKindClosedStream, s: s}:
+			case <-p.ctx.Done():
+			}
+		}
+
+		close(done)
 	}()
+
+	p.inboundStreamsMx.Lock()
+	prev, hasPrev := p.inboundStreams[peer]
+	p.inboundStreams[peer] = inboundHandler{s: s, done: done}
+	p.inboundStreamsMx.Unlock()
+
+	if hasPrev {
+		p.logger.Debug("duplicate inbound stream; replacing handler", "peer", peer)
+		prev.s.Reset()
+		select {
+		case <-prev.done:
+		case <-p.ctx.Done():
+			return
+		}
+	}
+
+	select {
+	case p.incoming <- incomingUnion{kind: incomingKindNewStream, s: s}:
+		sentNewStream = true
+	case <-p.ctx.Done():
+		// Close is useless because the other side isn't reading.
+		s.Reset()
+		return
+	}
 
 	r := msgio.NewVarintReaderSize(s, p.maxMessageSize)
 	for {
@@ -111,7 +137,10 @@ func (p *PubSub) handleNewStream(s network.Stream) {
 
 		rpc.from = peer
 		select {
-		case p.incoming <- rpc:
+		case p.incoming <- incomingUnion{
+			kind: incomingKindRPC,
+			rpc:  rpc,
+		}:
 		case <-p.ctx.Done():
 			// Close is useless because the other side isn't reading.
 			s.Reset()

--- a/extensions.go
+++ b/extensions.go
@@ -7,6 +7,7 @@ import (
 	"github.com/libp2p/go-libp2p-pubsub/partialmessages"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 )
 
 type PeerExtensions struct {
@@ -125,6 +126,16 @@ func (es *extensionsState) HandleRPC(rpc *RPC) error {
 	return es.extensionsHandleRPC(rpc)
 }
 
+func (es *extensionsState) OnNewIncomingStream(peer.ID, protocol.ID) {
+}
+
+func (es *extensionsState) OnClosedIncomingStream(id peer.ID, _ protocol.ID) {
+	delete(es.peerExtensions, id)
+	if len(es.peerExtensions) == 0 {
+		es.peerExtensions = make(map[peer.ID]PeerExtensions)
+	}
+}
+
 func (es *extensionsState) AddPeer(id peer.ID, helloPacket *RPC) *RPC {
 	// Send our extensions as the first message.
 	helloPacket = es.myExtensions.ExtendRPC(helloPacket)
@@ -144,10 +155,6 @@ func (es *extensionsState) RemovePeer(id peer.ID) {
 	if recvdExt && sentExt {
 		// Add peer was previously called, so we need to call remove peer
 		es.extensionsRemovePeer(id)
-	}
-	delete(es.peerExtensions, id)
-	if len(es.peerExtensions) == 0 {
-		es.peerExtensions = make(map[peer.ID]PeerExtensions)
 	}
 	delete(es.sentExtensions, id)
 	if len(es.sentExtensions) == 0 {

--- a/floodsub.go
+++ b/floodsub.go
@@ -41,6 +41,9 @@ func (fs *FloodSubRouter) Attach(p *PubSub) {
 	fs.tracer = p.tracer
 }
 
+func (fs *FloodSubRouter) OnNewIncomingStream(peer.ID, protocol.ID)    {}
+func (fs *FloodSubRouter) OnClosedIncomingStream(peer.ID, protocol.ID) {}
+
 func (fs *FloodSubRouter) AddPeer(p peer.ID, proto protocol.ID, hello *RPC) *RPC {
 	fs.tracer.AddPeer(p, proto)
 	return hello

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -750,6 +750,14 @@ func (gs *GossipSubRouter) manageAddrBook() {
 	}
 }
 
+func (gs *GossipSubRouter) OnNewIncomingStream(peer.ID, protocol.ID) {}
+
+func (gs *GossipSubRouter) OnClosedIncomingStream(pid peer.ID, proto protocol.ID) {
+	if gs.feature(GossipSubFeatureExtensions, proto) {
+		gs.extensions.OnClosedIncomingStream(pid, proto)
+	}
+}
+
 func (gs *GossipSubRouter) AddPeer(p peer.ID, proto protocol.ID, helloPacket *RPC) *RPC {
 	gs.logger.Debug("PEERUP: Add new peer using protocol", "peer", p, "protocol", proto)
 	gs.tracer.AddPeer(p, proto)

--- a/gossipsub_peer_lifecycle_test.go
+++ b/gossipsub_peer_lifecycle_test.go
@@ -1,0 +1,251 @@
+package pubsub
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-msgio"
+)
+
+// lifecycleSkeletonGossipsub is a minimal gossipsub peer for testing peer
+// lifecycle edge cases. It manages two streams:
+//
+//   - Stream A (inbound): the stream the local peer opened to us.
+//     The local writes RPCs on it; handlePeerDead reads from it.
+//
+//   - Stream B (outbound): the stream we opened back to the local.
+//     We write RPCs on it; the local's handleNewStream reads from it.
+type lifecycleSkeletonGossipsub struct {
+	h      skeletonHost
+	outRPC <-chan *pb.RPC // RPCs received from local (read from stream A)
+	inRPC  chan<- *pb.RPC // RPCs to send to local (written to stream B)
+
+	ready      chan struct{}
+	remotePeer peer.ID
+
+	// closeInbound signals the stream A reader to exit and close the stream.
+	closeInbound chan struct{}
+}
+
+func newLifecycleSkeletonGossipsub(ctx context.Context, h skeletonHost) *lifecycleSkeletonGossipsub {
+	recvRPC := make(chan *pb.RPC, 16)
+	sendRPC := make(chan *pb.RPC, 16)
+
+	skel := &lifecycleSkeletonGossipsub{
+		h:            h,
+		outRPC:       recvRPC,
+		inRPC:        sendRPC,
+		ready:        make(chan struct{}),
+		closeInbound: make(chan struct{}),
+	}
+
+	var once sync.Once
+
+	h.SetStreamHandler(GossipSubID_v13, func(s network.Stream) {
+		first := false
+		once.Do(func() {
+			first = true
+			skel.remotePeer = s.Conn().RemotePeer()
+
+			// Open stream B back to the local peer for sending RPCs.
+			outboundStream, err := h.NewStream(context.Background(), skel.remotePeer, GossipSubID_v13)
+			if err != nil {
+				panic(err)
+			}
+			writeCtx, cancel := context.WithCancel(ctx)
+			close(skel.ready)
+
+			go func() {
+				defer outboundStream.Close()
+				defer cancel()
+				w := msgio.NewVarintWriter(outboundStream)
+				for {
+					select {
+					case <-writeCtx.Done():
+						return
+					case r := <-sendRPC:
+						b, err := r.Marshal()
+						if err != nil {
+							panic(err)
+						}
+						if err := w.WriteMsg(b); err != nil {
+							return
+						}
+					}
+				}
+			}()
+		})
+
+		if !first {
+			return
+		}
+
+		// When closeInbound is signaled, reset stream A from a separate
+		// goroutine. This interrupts ReadMsg below AND causes
+		// handlePeerDead's s.Read() on the local side to return an error
+		// → notifyPeerDead → handleDeadPeers.
+		go func() {
+			<-skel.closeInbound
+			s.Reset()
+		}()
+
+		// Read RPCs from the local peer on stream A.
+		r := msgio.NewVarintReaderSize(s, DefaultMaxMessageSize)
+		for {
+			msgbytes, err := r.ReadMsg()
+			if err != nil {
+				r.ReleaseMsg(msgbytes)
+				return
+			}
+			if len(msgbytes) == 0 {
+				continue
+			}
+			rpc := new(pb.RPC)
+			err = rpc.Unmarshal(msgbytes)
+			r.ReleaseMsg(msgbytes)
+			if err != nil {
+				return
+			}
+			recvRPC <- rpc
+		}
+	})
+
+	return skel
+}
+
+func (s *lifecycleSkeletonGossipsub) WaitReady(t *testing.T) {
+	t.Helper()
+	select {
+	case <-s.ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for skeleton to be ready")
+	}
+}
+
+// CloseInbound resets stream A (the one the local opened to us) and removes
+// the stream handler so the local's reconnect attempt fails.
+// Stream B (our outbound) stays open for sending RPCs.
+func (s *lifecycleSkeletonGossipsub) CloseInbound() {
+	close(s.closeInbound)
+	s.h.RemoveStreamHandler(GossipSubID_v13)
+}
+
+// skeletonHost is the subset of host.Host used by the skeleton.
+type skeletonHost interface {
+	ID() peer.ID
+	SetStreamHandler(protocol.ID, network.StreamHandler)
+	RemoveStreamHandler(protocol.ID)
+	NewStream(ctx context.Context, p peer.ID, pids ...protocol.ID) (network.Stream, error)
+}
+
+// TestNoLeakFromDisconnectedPeer demonstrates the race condition where:
+//  1. Two peers are connected. The local runs full gossipsub, the remote
+//     runs the skeleton for manual control.
+//  2. The remote resets stream A (the local's outbound stream) and removes
+//     its stream handler. handlePeerDead fires on the local side.
+//     handleDeadPeers removes the peer, sees the connection is still alive,
+//     and tries to reconnect — but the reconnect fails because the remote
+//     no longer has a stream handler. The peer ends up fully removed.
+//  3. The remote sends a subscription RPC on stream B (still open).
+//     handleNewStream on the local reads it and pushes it onto ps.incoming.
+//  4. The remote disconnects.
+//  5. The processLoop picks up the stale RPC and re-adds the disconnected
+//     peer to the topic subscription map — leaked state never cleaned up.
+func TestNoLeakFromDisconnectedPeer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hosts := getDefaultHosts(t, 2)
+	localHost := hosts[0]
+	remoteHost := hosts[1]
+
+	ps := getGossipsub(ctx, localHost, WithMessageSignaturePolicy(StrictNoSign))
+	gs := ps.rt.(*GossipSubRouter)
+
+	skel := newLifecycleSkeletonGossipsub(ctx, remoteHost)
+
+	connect(t, localHost, remoteHost)
+	skel.WaitReady(t)
+
+	// Wait for local gossipsub to fully add the remote peer.
+	waitForCond := func(desc string, cond func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			ch := make(chan bool, 1)
+			ps.eval <- func() { ch <- cond() }
+			if <-ch {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out: %s", desc)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	waitForCond("peer added", func() bool {
+		_, inPeers := ps.peers[remoteHost.ID()]
+		_, inRouter := gs.peers[remoteHost.ID()]
+		return inPeers && inRouter
+	})
+
+	topic := "test-topic"
+
+	// --- Step 1: Remote resets stream A and blocks reconnection. ---
+	skel.CloseInbound()
+
+	// Wait for the local to fully remove the peer. handleDeadPeers removes
+	// it, tries to reconnect (fails because handler is gone), and newPeerError
+	// cleans up ps.peers.
+	waitForCond("peer removed", func() bool {
+		_, inPeers := ps.peers[remoteHost.ID()]
+		_, inGossipsub := gs.peers[remoteHost.ID()]
+		return !inPeers && !inGossipsub
+	})
+
+	// --- Step 2: Remote sends a subscription RPC on stream B. ---
+	skel.inRPC <- &pb.RPC{
+		Subscriptions: []*pb.RPC_SubOpts{
+			{
+				Topicid:   proto.String(topic),
+				Subscribe: proto.Bool(true),
+			},
+		},
+	}
+
+	// Give time for the RPC to be read by handleNewStream and processed.
+	time.Sleep(500 * time.Millisecond)
+
+	// --- Step 3: Remote disconnects. ---
+	remoteHost.Network().ClosePeer(localHost.ID())
+
+	// Wait for the disconnect to fully propagate through the local's
+	// processLoop. Any dead-peer handling from the closed connection will
+	// have completed by then.
+	time.Sleep(time.Second)
+
+	// --- Step 4: Observe leaked state. ---
+	// The peer is not in ps.peers (it was removed and the reconnect failed),
+	// but the stale RPC re-added it to ps.topics. Since the peer is not in
+	// ps.peers, handleDeadPeers will never clean it up — it checks ps.peers
+	// first and skips unknown peers. This is permanently leaked state.
+	checkDone := make(chan struct{})
+	ps.eval <- func() {
+		defer close(checkDone)
+
+		_, inPeers := ps.peers[remoteHost.ID()]
+		_, inTopics := ps.topics[topic][remoteHost.ID()]
+
+		if inPeers || inTopics {
+			t.Error("BUG: disconnected peer has leaked topic subscription state that will never be cleaned up")
+		}
+	}
+	<-checkDone
+}

--- a/pubsub.go
+++ b/pubsub.go
@@ -88,7 +88,7 @@ type PubSub struct {
 	peerOutboundQueueSize int
 
 	// incoming messages from other peers
-	incoming chan *RPC
+	incoming chan incomingUnion
 
 	// addSub is a control channel for us to add and remove subscriptions
 	addSub chan *addSubReq
@@ -168,7 +168,7 @@ type PubSub struct {
 	peers map[peer.ID]*rpcQueue
 
 	inboundStreamsMx sync.Mutex
-	inboundStreams   map[peer.ID]network.Stream
+	inboundStreams   map[peer.ID]inboundHandler
 
 	seenMessages    timecache.TimeCache
 	seenMsgTTL      time.Duration
@@ -214,6 +214,8 @@ type PubSubRouter interface {
 	AddPeer(peer.ID, protocol.ID, *RPC) *RPC
 	// RemovePeer notifies the router that a peer has been disconnected.
 	RemovePeer(peer.ID)
+	OnNewIncomingStream(peer.ID, protocol.ID)
+	OnClosedIncomingStream(peer.ID, protocol.ID)
 	// EnoughPeers returns whether the router needs more peers before it's ready to publish new records.
 	// Suggested (if greater than 0) is a suggested number of peers that the router should need.
 	EnoughPeers(topic string, suggested int) bool
@@ -264,6 +266,31 @@ type Message struct {
 
 func (m *Message) GetFrom() peer.ID {
 	return peer.ID(m.Message.GetFrom())
+}
+
+// inboundHandler tracks an active inbound stream handler. The done channel is
+// closed when the handler exits, allowing successive handlers for the same peer
+// to serialize their newStream/closedStream notifications.
+type inboundHandler struct {
+	s    network.Stream
+	done chan struct{}
+}
+
+type incomingKind uint8
+
+const (
+	incomingKindRPC = iota
+	incomingKindNewStream
+	incomingKindClosedStream
+)
+
+// incomingUnion wraps the different messages the incoming stream handler can
+// send. We want these kinds of messages to be serialized.
+type incomingUnion struct {
+	rpc *RPC // only set when kind == RPC
+	// s is only set when kind == NewStream or kind == ClosedStream
+	s    network.Stream
+	kind incomingKind
 }
 
 type RPC struct {
@@ -521,7 +548,7 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		signID:                h.ID(),
 		signKey:               nil,
 		signPolicy:            StrictSign,
-		incoming:              make(chan *RPC, 32),
+		incoming:              make(chan incomingUnion, 32),
 		newPeers:              make(chan struct{}, 1),
 		newPeersPend:          make(map[peer.ID]struct{}),
 		newPeerStream:         make(chan peerOutgoingStream),
@@ -547,7 +574,7 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		myRelays:              make(map[string]int),
 		topics:                make(map[string]map[peer.ID]peerTopicState),
 		peers:                 make(map[peer.ID]*rpcQueue),
-		inboundStreams:        make(map[peer.ID]network.Stream),
+		inboundStreams:        make(map[peer.ID]inboundHandler),
 		blacklist:             NewMapBlacklist(),
 		blacklistPeer:         make(chan peer.ID),
 		seenMsgTTL:            TimeCacheDuration,
@@ -918,9 +945,17 @@ func (p *PubSub) processLoop(ctx context.Context) {
 				peers = append(peers, p)
 			}
 			preq.resp <- peers
-		case rpc := <-p.incoming:
-			p.handleIncomingRPC(rpc)
-
+		case in := <-p.incoming:
+			switch in.kind {
+			case incomingKindRPC:
+				p.handleIncomingRPC(in.rpc)
+			case incomingKindNewStream:
+				p.rt.OnNewIncomingStream(
+					in.s.Conn().RemotePeer(), in.s.Protocol())
+			case incomingKindClosedStream:
+				p.onClosedIncomingStream(
+					in.s.Conn().RemotePeer(), in.s.Protocol())
+			}
 		case msg := <-p.sendMsg:
 			p.publishMessage(msg)
 
@@ -944,12 +979,7 @@ func (p *PubSub) processLoop(ctx context.Context) {
 			if ok {
 				q.Close()
 				delete(p.peers, pid)
-				for t, tmap := range p.topics {
-					if _, ok := tmap[pid]; ok {
-						delete(tmap, pid)
-						p.notifyLeave(t, pid)
-					}
-				}
+				p.clearPeerFromTopicsState(pid)
 				p.rt.RemovePeer(pid)
 			}
 
@@ -995,6 +1025,22 @@ func (p *PubSub) handlePendingPeers() {
 	}
 }
 
+func (p *PubSub) onClosedIncomingStream(pid peer.ID, proto protocol.ID) {
+	// This topic state is made when a peer sends us messages. If they close the
+	// incoming stream, we must clear their state or risk leaking memory.
+	p.clearPeerFromTopicsState(pid)
+	p.rt.OnClosedIncomingStream(pid, proto)
+}
+
+func (p *PubSub) clearPeerFromTopicsState(pid peer.ID) {
+	for t, tmap := range p.topics {
+		if _, ok := tmap[pid]; ok {
+			delete(tmap, pid)
+			p.notifyLeave(t, pid)
+		}
+	}
+}
+
 func (p *PubSub) handleDeadPeers() {
 	p.peerDeadPrioLk.Lock()
 
@@ -1016,13 +1062,7 @@ func (p *PubSub) handleDeadPeers() {
 		q.Close()
 		delete(p.peers, pid)
 
-		for t, tmap := range p.topics {
-			if _, ok := tmap[pid]; ok {
-				delete(tmap, pid)
-				p.notifyLeave(t, pid)
-			}
-		}
-
+		p.clearPeerFromTopicsState(pid)
 		p.rt.RemovePeer(pid)
 
 		if p.host.Network().Connectedness(pid) == network.Connected {

--- a/randomsub.go
+++ b/randomsub.go
@@ -45,6 +45,9 @@ func (rs *RandomSubRouter) Attach(p *PubSub) {
 	rs.tracer = p.tracer
 }
 
+func (rs *RandomSubRouter) OnNewIncomingStream(peer.ID, protocol.ID)    {}
+func (rs *RandomSubRouter) OnClosedIncomingStream(peer.ID, protocol.ID) {}
+
 func (rs *RandomSubRouter) AddPeer(p peer.ID, proto protocol.ID, hello *RPC) *RPC {
 	rs.tracer.AddPeer(p, proto)
 	rs.peers[p] = proto


### PR DESCRIPTION
In certain cases peer state may be leaked if the state is created on incoming messages and only cleared when our outbound stream is closed.