### PR TITLE
fix gossip when topic has only partial message peers

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -2024,18 +2024,6 @@ func (gs *GossipSubRouter) sendGraftPrune(tograft, toprune map[peer.ID][]string,
 // of this topic.
 func (gs *GossipSubRouter) emitGossip(topic string, exclude map[peer.ID]struct{}) {
 	mids := gs.mcache.GetGossipIDs(topic)
-	if len(mids) == 0 {
-		return
-	}
-
-	// shuffle to emit in random order
-	shuffleStrings(mids)
-
-	// if we are emitting more than GossipSubMaxIHaveLength mids, truncate the list
-	if len(mids) > gs.params.MaxIHaveLength {
-		// we do the truncation (with shuffling) per peer below
-		gs.logger.Debug("too many messages for gossip; will truncate IHAVE list", "messageCount", len(mids))
-	}
 
 	// Send gossip to GossipFactor peers above threshold, with a minimum of D_lazy.
 	// First we collect the peers above gossipThreshold that are not in the exclude set
@@ -2064,28 +2052,40 @@ func (gs *GossipSubRouter) emitGossip(topic string, exclude map[peer.ID]struct{}
 	}
 	peers = peers[:target]
 
-	// avoid a reallocation to collect peers that requested partial messages.
-	partialMessagePeers := peers[:0]
+	nextPartial := 0
+	iSupportPartial := gs.iSupportSendingPartial(topic)
+	// split peers inplace into partial and non partial.
+	for i, p := range peers {
+		if iSupportPartial && gs.peerRequestsPartial(p, topic) {
+			peers[i], peers[nextPartial] = peers[nextPartial], peers[i]
+			nextPartial++
+		}
+	}
+	partialMessagePeers := peers[:nextPartial]
+	peers = peers[nextPartial:]
 
 	// Emit the IHAVE gossip to the selected peers.
-	for _, p := range peers {
-		peerMids := mids
+	if len(peers) > 0 && len(mids) > 0 {
+		// shuffle to emit in random order
+		shuffleStrings(mids)
+
+		// truncation is done after shuffling per peer below
 		if len(mids) > gs.params.MaxIHaveLength {
-			// we do this per peer so that we emit a different set for each peer.
-			// we have enough redundancy in the system that this will significantly increase the message
-			// coverage when we do truncate.
-			peerMids = make([]string, gs.params.MaxIHaveLength)
-			shuffleStrings(mids)
-			copy(peerMids, mids)
+			gs.logger.Debug("too many messages for gossip; will truncate IHAVE list", "messageCount", len(mids))
 		}
 
-		if gs.iSupportSendingPartial(topic) && gs.peerRequestsPartial(p, topic) {
-			partialMessagePeers = append(partialMessagePeers, p)
-			// We should send the peer partial messages for gossip instead
-			continue
+		for _, p := range peers {
+			peerMids := mids
+			if len(mids) > gs.params.MaxIHaveLength {
+				// we do this per peer so that we emit a different set for each peer.
+				// we have enough redundancy in the system that this will significantly increase the message
+				// coverage when we do truncate.
+				peerMids = make([]string, gs.params.MaxIHaveLength)
+				shuffleStrings(mids)
+				copy(peerMids, mids)
+			}
+			gs.enqueueGossip(p, &pb.ControlIHave{TopicID: &topic, MessageIDs: peerMids})
 		}
-
-		gs.enqueueGossip(p, &pb.ControlIHave{TopicID: &topic, MessageIDs: peerMids})
 	}
 
 	if len(partialMessagePeers) > 0 {

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -4836,6 +4836,138 @@ func TestPartialMessages(t *testing.T) {
 	})
 }
 
+// TestPartialMessagesEmitGossipWhenAllPeersPartial verifies that emitGossip
+// still drives the partial messages extension's EmitGossip when all gossip
+// candidates are partial-message peers and the regular mcache for the topic is
+// empty. Previously, emitGossip returned early on an empty mcache, so the
+// partial-message gossip path was never exercised in that case.
+func TestPartialMessagesEmitGossipWhenAllPeersPartial(t *testing.T) {
+	synctestTest(t, func(t *testing.T) {
+		topic := "test-topic"
+		// Use enough hosts that, after mesh formation, every peer still has
+		// non-mesh peers in its gossip candidate set. emitGossip excludes mesh
+		// peers, so with too few hosts the loop has nothing to gossip to.
+		const hostCount = 30
+		hosts := getDefaultHosts(t, hostCount)
+		psubs := make([]*PubSub, 0, len(hosts))
+
+		gossipsubCtx, closeGossipsub := context.WithCancel(context.Background())
+		go func() {
+			<-gossipsubCtx.Done()
+			for _, h := range hosts {
+				h.Close()
+			}
+		}()
+
+		partialExt := make([]*partialmessages.PartialMessagesExtension[peerState], hostCount)
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		partialMessageStore := make([]map[string]*minimalTestPartialMessage, hostCount)
+		for i := range hostCount {
+			partialMessageStore[i] = make(map[string]*minimalTestPartialMessage)
+		}
+
+		// Counts per-host OnEmitGossip invocations. emitGossip runs on the
+		// gossipsub goroutine inside the synctest bubble, so atomic ops are used
+		// for safety even though the bubble serializes.
+		var emitGossipCalls [hostCount]atomic.Int64
+
+		for i := range partialExt {
+			partialExt[i] = &partialmessages.PartialMessagesExtension[peerState]{
+				Logger: logger.With("id", i),
+				OnEmitGossip: func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]peerState) {
+					emitGossipCalls[i].Add(1)
+					pm := partialMessageStore[i][topic+string(groupID)]
+					if pm == nil {
+						return
+					}
+					partialExt[i].PublishPartial(topic, groupID, pm.publishActions)
+				},
+				OnIncomingRPC: func(from peer.ID, peerStates map[peer.ID]peerState, rpc *pb.PartialMessagesExtension) error {
+					peerState := peerStates[from]
+					groupID := rpc.GroupID
+					pm, ok := partialMessageStore[i][topic+string(groupID)]
+					if !ok {
+						pm = &minimalTestPartialMessage{
+							Group: groupID,
+						}
+						partialMessageStore[i][topic+string(groupID)] = pm
+					}
+					if rpc.PartsMetadata != nil {
+						peerState.recvd = bitmap.Merge(peerState.recvd, rpc.PartsMetadata)
+					}
+					prevMeta := slices.Clone(pm.PartsMetadata())
+					shouldRepublish := pm.onIncomingRPC(from, rpc)
+					if !bytes.Equal(prevMeta, pm.PartsMetadata()) {
+						peerState.sent = bitmap.Merge(peerState.sent, pm.PartsMetadata())
+					}
+					peerStates[from] = peerState
+					if shouldRepublish {
+						go PublishPartial(psubs[i], topic, pm.GroupID(), pm.publishActions)
+					}
+					return nil
+				},
+			}
+		}
+
+		for i, h := range hosts {
+			psub := getGossipsub(gossipsubCtx, h, WithPartialMessagesExtension(partialExt[i]))
+			topic, err := psub.Join(topic, RequestPartialMessages())
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = topic.Subscribe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			psubs = append(psubs, psub)
+		}
+
+		denseConnect(t, hosts)
+		time.Sleep(2 * time.Second)
+
+		group := []byte("test-group")
+		msg1 := &minimalTestPartialMessage{
+			Group: group,
+			Parts: [2][]byte{
+				[]byte("Hello"),
+				[]byte("World"),
+			},
+		}
+		partialMessageStore[0][topic+string(group)] = msg1
+		err := PublishPartial(psubs[0], topic, msg1.GroupID(), msg1.publishActions)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Allow several heartbeats to fire so emitGossip runs on every host.
+		// The regular mcache stays empty (we never call pubsub.Publish for this
+		// topic), so the partial-message gossip path is the only way
+		// OnEmitGossip can fire.
+		time.Sleep(5 * time.Second)
+
+		closeGossipsub()
+		time.Sleep(1 * time.Second)
+
+		for i, msgStore := range partialMessageStore {
+			if len(msgStore) == 0 {
+				t.Errorf("Host %d is missing the partial message", i)
+			}
+			for _, partialMessage := range msgStore {
+				if !partialMessage.complete() {
+					t.Errorf("expected complete message, but %v is incomplete", partialMessage)
+				}
+			}
+		}
+
+		for i := range hostCount {
+			if got := emitGossipCalls[i].Load(); got == 0 {
+				t.Errorf("host %d: expected OnEmitGossip to be called at least once when all peers are partial-message capable, got 0", i)
+			}
+		}
+	})
+}
+
 func TestPeerSupportsPartialMessages(t *testing.T) {
 	// N peers connected in a ring:
 	// peer 0 requests partial messages


### PR DESCRIPTION
Remove the early return. We may have messages for our partial message peers. 

I think strictly speaking this isn't a bug, because you're supposed to publish full messages when you publish partial messages. But there's no need to have that assumption in this part of the code. 
 
The test is Claude generated. 