### PR TITLE
fix: make peerFeedback return during shutdown

### DIFF
--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -2395,6 +2395,41 @@ func TestGossipsubPeerFeedback(t *testing.T) {
 	})
 }
 
+func TestGossipsubPeerFeedbackCancelled(t *testing.T) {
+	synctestTest(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		hosts := getDefaultHosts(t, 1)
+		psub := getGossipsub(ctx, hosts[0])
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		defer close(release)
+
+		psub.eval <- func() {
+			close(entered)
+			<-release
+		}
+		<-entered
+		cancel()
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- psub.PeerFeedback("test", hosts[0].ID(), PeerFeedbackUsefulMessage)
+		}()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("expected context canceled error, got %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("PeerFeedback blocked after pubsub context cancellation")
+		}
+	})
+}
+
 func TestGossipsubPeerScoreResetTopicParams(t *testing.T) {
 	// this test exercises the code path sof peer score inspection
 	synctestTest(t, func(t *testing.T) {

--- a/pubsub.go
+++ b/pubsub.go
@@ -1806,7 +1806,7 @@ func (p *PubSub) PeerFeedback(topic string, peer peer.ID, kind PeerFeedbackKind)
 	if !ok {
 		return errors.New("peer feedback is only supported by GossipSub")
 	}
-	p.eval <- func() {
+	feedback := func() {
 		if gs.score == nil {
 			return
 		}
@@ -1818,6 +1818,11 @@ func (p *PubSub) PeerFeedback(topic string, peer peer.ID, kind PeerFeedbackKind)
 		case PeerFeedbackInvalidMessage:
 			gs.score.markInvalidMessageDelivery(peer, topic)
 		}
+	}
+	select {
+	case p.eval <- feedback:
+	case <-p.ctx.Done():
+		return p.ctx.Err()
 	}
 	return nil
 }


### PR DESCRIPTION
## Issue

This PR fixes a shutdown hang in `PeerFeedback`.

`PeerFeedback` is a public API that applications can use to report whether a peer provided useful or invalid data. GossipSub uses that feedback to update peer scoring. Internally, the method schedules the scoring update by sending a function to the PubSub process loop through `p.eval`.

Before this change, that send did not check whether PubSub was shutting down. Since `p.eval` is unbuffered, the call depends on the process loop being alive and ready to receive. Once the PubSub context is cancelled, the process loop exits and no longer reads from `p.eval`. If application code calls `PeerFeedback` at that point, the call can block forever.

This is a realistic shutdown race. For example, an application using partial messages may still be finishing message assembly, cleanup, or delayed feedback while PubSub is already stopping. In that case, the goroutine calling `PeerFeedback` can be leaked, and any shutdown path waiting on that goroutine can hang.

## Fix

This change makes `PeerFeedback` respect the PubSub context when scheduling work on the process loop.

During normal operation, feedback is still sent through `p.eval` exactly as before. If the PubSub context is cancelled before the feedback can be scheduled, `PeerFeedback` now returns `p.ctx.Err()` instead of blocking. This matches the cancellation pattern already used by other process-loop calls in the codebase.

The fix is intentionally small. It does not add buffering, extra goroutines, or new locking. It only adds the missing `ctx.Done()` case around the existing `p.eval` send.

## Tests

This PR adds `TestGossipsubPeerFeedbackCancelled`.

The test reproduces the old failure mode in a deterministic way. It occupies the PubSub process loop, cancels the PubSub context, and then calls `PeerFeedback`. Before this change, that call could block on the unbuffered `p.eval` send. With this fix, it returns `context.Canceled`.

The existing `TestGossipsubPeerFeedback` still covers the normal path and verifies that peer feedback continues to update scoring when PubSub is running.
