### PR TITLE
fix: cap peer score delivery records

### DIFF
--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -2395,6 +2395,57 @@ func TestGossipsubPeerFeedback(t *testing.T) {
 	})
 }
 
+func TestGossipsubScoreDeliveryRecordCap(t *testing.T) {
+	synctestTest(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		const topic = "delivery-record-cap"
+		const recordCap = 3
+
+		hosts := getDefaultHosts(t, 2)
+		sender := getGossipsub(ctx, hosts[0])
+		receiver := getGossipsub(ctx, hosts[1],
+			WithPeerScore(
+				&PeerScoreParams{
+					AppSpecificScore:  func(peer.ID) float64 { return 0 },
+					DecayInterval:     time.Second,
+					DecayToZero:       0.01,
+					DeliveryRecordCap: recordCap,
+				},
+				&PeerScoreThresholds{
+					GossipThreshold:   -1,
+					PublishThreshold:  -10,
+					GraylistThreshold: -100,
+				}))
+
+		connect(t, hosts[0], hosts[1])
+
+		sub, err := receiver.Subscribe(topic)
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(50 * time.Millisecond)
+
+		for i := range 10 {
+			msg := []byte(fmt.Sprintf("message %d", i))
+			if err := sender.Publish(topic, msg); err != nil {
+				t.Fatal(err)
+			}
+			assertReceive(t, sub, msg)
+		}
+
+		score := receiver.rt.(*GossipSubRouter).score
+		score.Lock()
+		recordCount := len(score.deliveries.records)
+		score.Unlock()
+
+		if recordCount != recordCap {
+			t.Fatalf("expected %d delivery records, got %d", recordCap, recordCount)
+		}
+	})
+}
+
 func TestGossipsubPeerScoreResetTopicParams(t *testing.T) {
 	// this test exercises the code path sof peer score inspection
 	synctestTest(t, func(t *testing.T) {

--- a/score.go
+++ b/score.go
@@ -15,6 +15,10 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
+// DefaultDeliveryRecordCap is the default maximum number of message delivery
+// records retained by peer scoring.
+const DefaultDeliveryRecordCap = 1 << 20
+
 type peerStats struct {
 	// true if the peer is currently connected
 	connected bool
@@ -94,6 +98,7 @@ var _ RawTracer = (*peerScore)(nil)
 
 type messageDeliveries struct {
 	seenMsgTTL time.Duration
+	recordCap  int
 
 	records map[string]*deliveryRecord
 
@@ -190,11 +195,15 @@ func newPeerScore(params *PeerScoreParams, logger *slog.Logger) *peerScore {
 	if seenMsgTTL == 0 {
 		seenMsgTTL = TimeCacheDuration
 	}
+	recordCap := params.DeliveryRecordCap
+	if recordCap == 0 {
+		recordCap = DefaultDeliveryRecordCap
+	}
 	return &peerScore{
 		params:     params,
 		peerStats:  make(map[peer.ID]*peerStats),
 		peerIPs:    make(map[string]map[peer.ID]struct{}),
-		deliveries: &messageDeliveries{seenMsgTTL: seenMsgTTL, records: make(map[string]*deliveryRecord)},
+		deliveries: &messageDeliveries{seenMsgTTL: seenMsgTTL, recordCap: recordCap, records: make(map[string]*deliveryRecord)},
 		idGen:      newMsgIdGenerator(),
 		logger:     logger,
 	}
@@ -712,6 +721,9 @@ func (ps *peerScore) DeliverMessage(msg *Message) {
 	ps.markFirstMessageDelivery(msg.ReceivedFrom, msg.GetTopic())
 
 	drec := ps.deliveries.getRecord(ps.idGen.ID(msg))
+	if drec == nil {
+		return
+	}
 
 	// defensive check that this is the first delivery trace -- delivery status should be unknown
 	if drec.status != deliveryUnknown {
@@ -763,6 +775,17 @@ func (ps *peerScore) RejectMessage(msg *Message, reason string) {
 	}
 
 	drec := ps.deliveries.getRecord(ps.idGen.ID(msg))
+	if drec == nil {
+		switch reason {
+		case RejectValidationThrottled:
+			fallthrough
+		case RejectValidationIgnored:
+			return
+		default:
+			ps.markInvalidMessageDelivery(msg.ReceivedFrom, msg.GetTopic())
+			return
+		}
+	}
 
 	// defensive check that this is the first rejection trace -- delivery status should be unknown
 	if drec.status != deliveryUnknown {
@@ -803,6 +826,9 @@ func (ps *peerScore) DuplicateMessage(msg *Message) {
 	defer ps.Unlock()
 
 	drec := ps.deliveries.getRecord(ps.idGen.ID(msg))
+	if drec == nil {
+		return
+	}
 
 	_, ok := drec.peers[msg.ReceivedFrom]
 	if ok {
@@ -842,11 +868,19 @@ func (ps *peerScore) DropRPC(rpc *RPC, p peer.ID) {}
 
 func (ps *peerScore) UndeliverableMessage(msg *Message) {}
 
-// message delivery records
+// getRecord returns the delivery record for id. It returns nil when creating a
+// new record would exceed the configured delivery record cap.
 func (d *messageDeliveries) getRecord(id string) *deliveryRecord {
 	rec, ok := d.records[id]
 	if ok {
 		return rec
+	}
+
+	if d.recordCap > 0 && len(d.records) >= d.recordCap {
+		d.gc()
+		if len(d.records) >= d.recordCap {
+			return nil
+		}
 	}
 
 	now := time.Now()

--- a/score_params.go
+++ b/score_params.go
@@ -112,6 +112,10 @@ type PeerScoreParams struct {
 
 	// time to remember a message delivery for. Default to global TimeCacheDuration if 0.
 	SeenMsgTTL time.Duration
+
+	// DeliveryRecordCap is the maximum number of message delivery records to
+	// retain. If 0, DefaultDeliveryRecordCap is used.
+	DeliveryRecordCap int
 }
 
 type TopicScoreParams struct {
@@ -183,6 +187,10 @@ func (p *PeerScoreParams) validate() error {
 		if p.TopicScoreCap < 0 || isInvalidNumber(p.TopicScoreCap) {
 			return fmt.Errorf("invalid topic score cap; must be positive (or 0 for no cap) and a valid number")
 		}
+	}
+
+	if p.DeliveryRecordCap < 0 {
+		return fmt.Errorf("invalid delivery record cap; must be >= 0")
 	}
 
 	// check that we have an app specific score; the weight can be anything (but expected positive)

--- a/score_params_test.go
+++ b/score_params_test.go
@@ -407,6 +407,16 @@ func testPeerScoreParamsValidationWithInvalidParams(t *testing.T, skipAtomicVali
 		t.Fatal("expected validation error")
 	}
 
+	if (&PeerScoreParams{
+		SkipAtomicValidation: skipAtomicValidation,
+		DeliveryRecordCap:    -1,
+		AppSpecificScore:     appScore,
+		DecayInterval:        time.Second,
+		DecayToZero:          0.01,
+	}).validate() == nil {
+		t.Fatal("expected validation error")
+	}
+
 	if skipAtomicValidation {
 		if (&PeerScoreParams{
 			SkipAtomicValidation: skipAtomicValidation,
@@ -611,6 +621,7 @@ func TestPeerScoreParamsValidation_ValidParams_AtomicValidation(t *testing.T) {
 		AppSpecificScore:            appScore,
 		DecayInterval:               time.Second,
 		DecayToZero:                 0.01,
+		DeliveryRecordCap:           1024,
 		IPColocationFactorWeight:    -1,
 		IPColocationFactorThreshold: 1,
 		BehaviourPenaltyWeight:      -1,

--- a/score_test.go
+++ b/score_test.go
@@ -705,6 +705,68 @@ func TestScoreRejectMessageDeliveries(t *testing.T) {
 	})
 }
 
+func TestScoreDeliveryRecordCap(t *testing.T) {
+	synctestTest(t, func(t *testing.T) {
+		topic := "mytopic"
+		peerA := peer.ID("A")
+		params := &PeerScoreParams{
+			AppSpecificScore:  func(peer.ID) float64 { return 0 },
+			Topics:            make(map[string]*TopicScoreParams),
+			DeliveryRecordCap: 3,
+			SeenMsgTTL:        time.Minute,
+		}
+		params.Topics[topic] = &TopicScoreParams{
+			TopicWeight:                    1,
+			TimeInMeshQuantum:              time.Second,
+			InvalidMessageDeliveriesWeight: -1,
+			InvalidMessageDeliveriesDecay:  1,
+		}
+
+		ps := newPeerScore(params, slog.Default())
+		ps.OnNewOutboundStream(peerA, "myproto")
+
+		for i := range 10 {
+			pbMsg := makeTestMessage(i)
+			pbMsg.Topic = &topic
+			msg := Message{ReceivedFrom: peerA, Message: pbMsg}
+			ps.ValidateMessage(&msg)
+		}
+
+		if len(ps.deliveries.records) != params.DeliveryRecordCap {
+			t.Fatalf("expected %d delivery records, got %d", params.DeliveryRecordCap, len(ps.deliveries.records))
+		}
+
+		pbMsg := makeTestMessage(10)
+		pbMsg.Topic = &topic
+		msg := Message{ReceivedFrom: peerA, Message: pbMsg}
+		ps.RejectMessage(&msg, RejectValidationFailed)
+
+		if score := ps.Score(peerA); score != -1 {
+			t.Fatalf("expected invalid delivery score after cap is reached, got %f", score)
+		}
+		if len(ps.deliveries.records) != params.DeliveryRecordCap {
+			t.Fatalf("expected %d delivery records after capped reject, got %d", params.DeliveryRecordCap, len(ps.deliveries.records))
+		}
+
+		for entry := ps.deliveries.head; entry != nil; entry = entry.next {
+			entry.expire = time.Now().Add(-time.Second)
+		}
+		ps.deliveries.gc()
+		if len(ps.deliveries.records) != 0 {
+			t.Fatalf("expected delivery records to expire, got %d", len(ps.deliveries.records))
+		}
+
+		pbMsg = makeTestMessage(11)
+		pbMsg.Topic = &topic
+		msg = Message{ReceivedFrom: peerA, Message: pbMsg}
+		ps.ValidateMessage(&msg)
+
+		if len(ps.deliveries.records) != 1 {
+			t.Fatalf("expected delivery record after capacity is available, got %d", len(ps.deliveries.records))
+		}
+	})
+}
+
 func TestScoreApplicationScore(t *testing.T) {
 	// Create parameters with reasonable default values
 	synctestTest(t, func(t *testing.T) {


### PR DESCRIPTION
## Issue

This PR adds a count limit to the message delivery records kept by peer scoring.

Peer scoring keeps a short-lived delivery record for each message ID it is tracking. These records are used while a message moves through validation, and they help account for duplicate deliveries, near-first deliveries, valid messages, invalid messages, ignored messages, and throttled validation. Today those records expire after `SeenMsgTTL`, but there is no count-based limit on how many can exist during that TTL window.

That means memory use can grow with the rate of unique messages that reach validation or delivery tracing. This is not a permanent leak, because the records are eventually removed by delivery-record GC. The issue is the active window: on a busy topic, or under adversarial traffic, peers can keep sending unique messages and cause the delivery-record map to grow until those records age out.

For production nodes with peer scoring enabled, this creates a resource-scaling problem. Memory use is bounded by time, but not by volume. A high enough message rate during `SeenMsgTTL` can still create a large number of retained records.

## Fix

This change adds a configurable cap for peer score delivery records.

`PeerScoreParams` now has a `DeliveryRecordCap` field. If it is left as zero, peer scoring uses `DefaultDeliveryRecordCap`. When the delivery-record table reaches the cap, `getRecord` first runs GC to clear any expired records. If the table is still full after that, it does not allocate a new tracking record for the new message ID.

Existing tracked records continue to work as before. The fix also keeps direct scoring behavior where possible: first-message delivery scoring still runs before delivery-record tracking, and validation-failed messages still penalize the sender even when the record table is full. What gets skipped at capacity is the extra per-message tracking used for duplicate and near-first delivery accounting.

This keeps memory bounded without adding new goroutines, changing message delivery behavior, or blocking the validation path. Operators that expect very high message throughput can raise the cap through score params.

## Tests

This PR adds coverage at both the score layer and the GossipSub layer.

`TestScoreDeliveryRecordCap` checks the delivery-record table directly. It verifies that the table does not grow beyond the configured cap, that invalid-message scoring still applies when the cap is full, and that new records can be created again after old records expire and GC runs.

`TestGossipsubScoreDeliveryRecordCap` drives the same behavior through real GossipSub publish and subscribe flow with peer scoring enabled. It publishes more unique messages than the configured cap, verifies those messages are still delivered, and checks that the peer score delivery-record table remains capped.

The peer score parameter validation tests were also updated so negative caps are rejected and valid configured caps are accepted.