### PR TITLE
Limit control message size of RPCs

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -122,6 +122,15 @@ func (p *PubSub) handleNewStream(s network.Stream) {
 			continue
 		}
 
+		err = pb.ValidateRawRPCControlMessageSize(msgbytes, p.maxControlMessageSize)
+		if err != nil {
+			r.ReleaseMsg(msgbytes)
+			s.Reset()
+
+			p.rpcLogger.Warn("RPC's control message is too large. Disconnecting. If this is a mistake, you should increase `WithMaxControlMessageSize`", "peer", s.Conn().RemotePeer(), "err", err)
+			return
+		}
+
 		rpc := new(RPC)
 		err = proto.Unmarshal(msgbytes, &rpc.RPC)
 		r.ReleaseMsg(msgbytes)

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1555,15 +1555,21 @@ func (gs *GossipSubRouter) sendRPC(p peer.ID, out *RPC, urgent bool) {
 	}
 
 	controlSize := proto.Size(&controlMessage.RPC)
+	dropIfOversized := func(rpc *RPC) bool {
+		if !rpc.exceedsSizeLimits(gs.p.maxMessageSize, gs.p.maxControlMessageSize) {
+			return false
+		}
+		size := proto.Size(&rpc.RPC)
+		controlSize := controlRPCSize(rpc)
+		gs.doDropRPC(rpc, p, fmt.Sprintf("Dropping oversized RPC. Size: %d, limit: %d. Control size: %d, control limit: %d", size, gs.p.maxMessageSize, controlSize, gs.p.maxControlMessageSize))
+		return true
+	}
 	if controlSize > 0 {
-		if controlSize < gs.p.maxMessageSize {
+		if !controlMessage.exceedsSizeLimits(gs.p.maxMessageSize, gs.p.maxControlMessageSize) {
 			gs.doSendRPC(&controlMessage, p, q, urgent)
 		} else {
-			for rpc := range controlMessage.split(gs.p.maxMessageSize) {
-				if proto.Size(&rpc.RPC) > gs.p.maxMessageSize {
-					// This should only happen if a single control is above the max size.
-					size := proto.Size(&rpc.RPC)
-					gs.doDropRPC(rpc, p, fmt.Sprintf("Dropping oversized RPC. Size: %d, limit: %d. (Over by %d bytes)", size, gs.p.maxMessageSize, size-gs.p.maxMessageSize))
+			for rpc := range controlMessage.split(gs.p.maxMessageSize, gs.p.maxControlMessageSize) {
+				if dropIfOversized(rpc) {
 					continue
 				}
 				gs.doSendRPC(rpc, p, q, urgent)
@@ -1572,17 +1578,14 @@ func (gs *GossipSubRouter) sendRPC(p peer.ID, out *RPC, urgent bool) {
 	}
 
 	// If we're below the max message size, go ahead and send
-	if proto.Size(&out.RPC) < gs.p.maxMessageSize {
+	if !out.exceedsSizeLimits(gs.p.maxMessageSize, gs.p.maxControlMessageSize) {
 		gs.doSendRPC(out, p, q, urgent)
 		return
 	}
 
 	// Potentially split the RPC into multiple RPCs that are below the max message size
-	for rpc := range out.split(gs.p.maxMessageSize) {
-		if proto.Size(&rpc.RPC) > gs.p.maxMessageSize {
-			// This should only happen if a single message/control is above the maxMessageSize.
-			size := proto.Size(&rpc.RPC)
-			gs.doDropRPC(rpc, p, fmt.Sprintf("Dropping oversized RPC. Size: %d, limit: %d. (Over by %d bytes)", size, gs.p.maxMessageSize, size-gs.p.maxMessageSize))
+	for rpc := range out.split(gs.p.maxMessageSize, gs.p.maxControlMessageSize) {
+		if dropIfOversized(rpc) {
 			continue
 		}
 		gs.doSendRPC(rpc, p, q, urgent)

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -99,6 +99,26 @@ func getGossipsubsOptFn(ctx context.Context, hs []host.Host, optFn func(int, hos
 	return psubs
 }
 
+func TestConfigurableMaxControlMessageSize(t *testing.T) {
+	synctestTest(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		hosts := getDefaultHosts(t, 2)
+
+		defaultPubsub := getGossipsub(ctx, hosts[0])
+		if defaultPubsub.maxControlMessageSize != DefaultMaxControlMessageSize {
+			t.Fatalf("expected default max control message size %d, got %d", DefaultMaxControlMessageSize, defaultPubsub.maxControlMessageSize)
+		}
+
+		const maxControlMessageSize = 1234
+		configuredPubsub := getGossipsub(ctx, hosts[1], WithMaxControlMessageSize(maxControlMessageSize))
+		if configuredPubsub.maxControlMessageSize != maxControlMessageSize {
+			t.Fatalf("expected configured max control message size %d, got %d", maxControlMessageSize, configuredPubsub.maxControlMessageSize)
+		}
+	})
+}
+
 func TestSparseGossipsub(t *testing.T) {
 	synctestTest(t, func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -2696,7 +2696,7 @@ func validRPCSizes(slice []*RPC, limit int) bool {
 func TestFragmentRPCFunction(t *testing.T) {
 	synctestTest(t, func(t *testing.T) {
 		fragmentRPC := func(rpc *RPC, limit int) ([]*RPC, error) {
-			rpcs := slices.Collect(rpc.split(limit))
+			rpcs := slices.Collect(rpc.split(limit, limit))
 			if allValid := validRPCSizes(rpcs, limit); !allValid {
 				return rpcs, fmt.Errorf("RPC size exceeds limit")
 			}
@@ -2842,6 +2842,83 @@ func TestFragmentRPCFunction(t *testing.T) {
 			t.Fatalf("expected at least %d total RPCs (at least %d with control messages), got %d total", expectedRPCs, expectedCtrl, len(results))
 		}
 
+		// Control messages should split on the control limit even if the
+		// full RPC would fit within the RPC size limit.
+		rpc.Reset()
+		controlLimit := 256
+		maxRPCSize := limit * 8
+		messageIds := make([]string, 64)
+		for i := range messageIds {
+			mid := make([]byte, 16)
+			crand.Read(mid)
+			messageIds[i] = string(mid)
+		}
+		rpc.Control = &pb.ControlMessage{
+			Iwant:     []*pb.ControlIWant{{MessageIDs: messageIds}},
+			Idontwant: []*pb.ControlIDontWant{{MessageIDs: messageIds}},
+		}
+		results = slices.Collect(rpc.split(maxRPCSize, controlLimit))
+		if len(results) < 2 {
+			t.Fatalf("expected control message to be split by control limit, got %d RPCs", len(results))
+		}
+		var fragmentedMessageIds []string
+		var fragmentedIDontWantMessageIds []string
+		for _, r := range results {
+			if size := proto.Size(&r.RPC); size > maxRPCSize {
+				t.Fatalf("expected fragmented RPC to be below %d bytes, was %d", maxRPCSize, size)
+			}
+			if size := controlRPCSize(r); size > controlLimit {
+				t.Fatalf("expected fragmented control message to be below %d bytes, was %d", controlLimit, size)
+			}
+			for _, iwant := range r.Control.GetIwant() {
+				fragmentedMessageIds = append(fragmentedMessageIds, iwant.MessageIDs...)
+			}
+			for _, idontwant := range r.Control.GetIdontwant() {
+				fragmentedIDontWantMessageIds = append(fragmentedIDontWantMessageIds, idontwant.MessageIDs...)
+			}
+		}
+		if !slices.Equal(messageIds, fragmentedMessageIds) {
+			t.Fatal("expected fragmented IWANT control messages to contain the same message IDs as input")
+		}
+		if !slices.Equal(messageIds, fragmentedIDontWantMessageIds) {
+			t.Fatal("expected fragmented IDONTWANT control messages to contain the same message IDs as input")
+		}
+
+		rpc.Reset()
+		rpc.Subscriptions = make([]*pb.RPC_SubOpts, 32)
+		for i := range rpc.Subscriptions {
+			topic := fmt.Sprintf("subscription-topic-%d", i)
+			rpc.Subscriptions[i] = &pb.RPC_SubOpts{Topicid: &topic}
+		}
+		results = slices.Collect(rpc.split(maxRPCSize, controlLimit))
+		if len(results) < 2 {
+			t.Fatalf("expected subscriptions to be split by control limit, got %d RPCs", len(results))
+		}
+		var nSubscriptionsFragmented int
+		for _, r := range results {
+			if size := controlRPCSize(r); size > controlLimit {
+				t.Fatalf("expected fragmented subscriptions to be below %d bytes, was %d", controlLimit, size)
+			}
+			nSubscriptionsFragmented += len(r.Subscriptions)
+		}
+		if nSubscriptionsFragmented != len(rpc.Subscriptions) {
+			t.Fatalf("expected fragmented RPCs to contain same number of subscriptions as input, got %d / %d",
+				nSubscriptionsFragmented, len(rpc.Subscriptions))
+		}
+
+		rpc.Reset()
+		rpc.Partial = &pb.PartialMessagesExtension{PartialMessage: make([]byte, controlLimit*2)}
+		results = slices.Collect(rpc.split(maxRPCSize, controlLimit))
+		if len(results) != 1 {
+			t.Fatalf("expected partial message extension to be excluded from control limit, got %d RPCs", len(results))
+		}
+		if results[0].Partial == nil {
+			t.Fatal("expected partial message extension to be preserved")
+		}
+		if size := controlRPCSize(results[0]); size != 0 {
+			t.Fatalf("expected partial-only RPC control size to be 0, got %d", size)
+		}
+
 		// Test the pathological case where a single gossip message ID exceeds the limit.
 		// It should not be present in the fragmented messages, but smaller IDs should be
 		rpc.Reset()
@@ -2900,7 +2977,7 @@ func FuzzRPCSplit(f *testing.F) {
 		originalControl.append(&rpc.RPC)
 		mergedControl := compressedRPC{ihave: make(map[string][]string)}
 
-		for rpc := range rpc.split(maxSize) {
+		for rpc := range rpc.split(maxSize, maxSize) {
 			if proto.Size(&rpc.RPC) > maxSize {
 				t.Fatalf("invalid RPC size %v %d (max=%d)", rpc, proto.Size(&rpc.RPC), maxSize)
 			}
@@ -4184,7 +4261,7 @@ func BenchmarkSplitRPC(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rpc := rpcs[i%len(rpcs)]
-		rpc.split(maxSize)
+		rpc.split(maxSize, maxSize)
 	}
 }
 
@@ -4211,7 +4288,7 @@ func BenchmarkSplitRPCLargeMessages(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			for range rpc.split(DefaultMaxMessageSize) {
+			for range rpc.split(DefaultMaxMessageSize, DefaultMaxControlMessageSize) {
 
 			}
 		}
@@ -4228,7 +4305,7 @@ func BenchmarkSplitRPCLargeMessages(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			count := 0
-			for range rpc.split(DefaultMaxMessageSize) {
+			for range rpc.split(DefaultMaxMessageSize, DefaultMaxControlMessageSize) {
 				count++
 			}
 			if count != 2 {

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -4261,7 +4261,8 @@ func BenchmarkSplitRPC(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rpc := rpcs[i%len(rpcs)]
-		rpc.split(maxSize, maxSize)
+		for range rpc.split(maxSize, maxSize) {
+		}
 	}
 }
 

--- a/pb/validator.go
+++ b/pb/validator.go
@@ -29,15 +29,53 @@ func ValidateRawRPCControlMessageSize(msg []byte, maxControlMessageSize int) err
 		}
 
 		switch field {
-		case rpcPublishFieldNumber, rpcPartialFieldNumber:
+		case rpcPartialFieldNumber:
+			// There can only be a single partial message per rpc. So the
+			// overhead size is small per RPC.
+		case rpcPublishFieldNumber:
+			payloadLen, err := dataFieldLength(fieldValue)
+			if err != nil {
+				return err
+			}
+			// Add the message overhead as part of the control size
+			controlSize += tagLen + fieldLen - payloadLen
+
 		default:
 			controlSize += tagLen + fieldLen
-			if controlSize > maxControlMessageSize {
-				return fmt.Errorf("rpc control size exceeds max control message size: %d > %d", controlSize, maxControlMessageSize)
-			}
 		}
-
 		msg = fieldValue[fieldLen:]
+
+		if controlSize > maxControlMessageSize {
+			return fmt.Errorf("rpc control size exceeds max control message size: %d > %d", controlSize, maxControlMessageSize)
+		}
 	}
 	return nil
+}
+
+func dataFieldLength(msg []byte) (int, error) {
+	const dataFieldNumber protowire.Number = 2
+	msg, n := protowire.ConsumeBytes(msg)
+	if n < 0 {
+		return 0, protowire.ParseError(n)
+	}
+
+	for len(msg) > 0 {
+		field, typ, tagLen := protowire.ConsumeTag(msg)
+		if tagLen < 0 {
+			return 0, protowire.ParseError(tagLen)
+		}
+
+		fieldValue := msg[tagLen:]
+		fieldLen := protowire.ConsumeFieldValue(field, typ, fieldValue)
+		if fieldLen < 0 {
+			return 0, protowire.ParseError(fieldLen)
+		}
+		msg = fieldValue[fieldLen:]
+
+		if field == dataFieldNumber && typ == protowire.BytesType {
+			return fieldLen, nil
+		}
+	}
+
+	return 0, nil
 }

--- a/pb/validator.go
+++ b/pb/validator.go
@@ -1,0 +1,43 @@
+package pubsub_pb
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+const (
+	rpcPublishFieldNumber protowire.Number = 2
+	rpcPartialFieldNumber protowire.Number = 10
+)
+
+// ValidateRawRPCControlMessageSize validates that all non-publish,
+// non-PartialMessagesExtension fields in a raw RPC are no larger than
+// maxControlMessageSize.
+func ValidateRawRPCControlMessageSize(msg []byte, maxControlMessageSize int) error {
+	controlSize := 0
+	for len(msg) > 0 {
+		field, typ, tagLen := protowire.ConsumeTag(msg)
+		if tagLen < 0 {
+			return protowire.ParseError(tagLen)
+		}
+
+		fieldValue := msg[tagLen:]
+		fieldLen := protowire.ConsumeFieldValue(field, typ, fieldValue)
+		if fieldLen < 0 {
+			return protowire.ParseError(fieldLen)
+		}
+
+		switch field {
+		case rpcPublishFieldNumber, rpcPartialFieldNumber:
+		default:
+			controlSize += tagLen + fieldLen
+			if controlSize > maxControlMessageSize {
+				return fmt.Errorf("rpc control size exceeds max control message size: %d > %d", controlSize, maxControlMessageSize)
+			}
+		}
+
+		msg = fieldValue[fieldLen:]
+	}
+	return nil
+}

--- a/pb/validator_test.go
+++ b/pb/validator_test.go
@@ -1,0 +1,125 @@
+package pubsub_pb
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestValidateRawRPCControlMessageSizeRejectsOversizedControlField(t *testing.T) {
+	topic := strings.Repeat("x", 32)
+	msg := marshalTestMessage(t, &RPC{
+		Control: &ControlMessage{
+			Graft: []*ControlGraft{{TopicID: proto.String(topic)}},
+		},
+	})
+
+	if err := ValidateRawRPCControlMessageSize(msg, 8); err == nil {
+		t.Fatal("expected oversized control field error")
+	}
+}
+
+func TestValidateRawRPCControlMessageSizeRejectsCumulativeControlFields(t *testing.T) {
+	topic := strings.Repeat("x", 32)
+	control := marshalTestMessage(t, &ControlMessage{
+		Graft: []*ControlGraft{{TopicID: proto.String(topic)}},
+	})
+	msg := appendRawRPCControlField(nil, control)
+	msg = appendRawRPCControlField(msg, control)
+
+	if err := ValidateRawRPCControlMessageSize(msg, encodedRawRPCFieldSize(3, control)+1); err == nil {
+		t.Fatal("expected cumulative oversized control field error")
+	}
+}
+
+func TestValidateRawRPCControlMessageSizeRejectsCumulativeNonExemptFields(t *testing.T) {
+	topic := strings.Repeat("x", 32)
+	subscription := marshalTestMessage(t, &RPC_SubOpts{Topicid: proto.String(topic)})
+	control := marshalTestMessage(t, &ControlMessage{
+		Graft: []*ControlGraft{{TopicID: proto.String(topic)}},
+	})
+	msg := appendRawRPCSubscriptionField(nil, subscription)
+	msg = appendRawRPCControlField(msg, control)
+
+	limit := encodedRawRPCFieldSize(1, subscription) + encodedRawRPCFieldSize(3, control) - 1
+	if err := ValidateRawRPCControlMessageSize(msg, limit); err == nil {
+		t.Fatal("expected cumulative oversized non-exempt field error")
+	}
+}
+
+func TestValidateRawRPCControlMessageSizeCountsFieldFraming(t *testing.T) {
+	var msg []byte
+	for range 3 {
+		msg = appendRawRPCSubscriptionField(msg, nil)
+	}
+
+	if err := ValidateRawRPCControlMessageSize(msg, 5); err == nil {
+		t.Fatal("expected field framing to exceed control size limit")
+	}
+}
+
+func TestValidateRawRPCControlMessageSizeCountsUnknownTopLevelFields(t *testing.T) {
+	msg := protowire.AppendTag(nil, 100, protowire.VarintType)
+	msg = protowire.AppendVarint(msg, 1234)
+	msg = protowire.AppendTag(msg, 101, protowire.BytesType)
+	msg = protowire.AppendBytes(msg, []byte("not a protobuf message"))
+
+	if err := ValidateRawRPCControlMessageSize(msg, len(msg)-1); err == nil {
+		t.Fatal("expected unknown top-level fields to exceed control size limit")
+	}
+}
+
+func TestValidateRawRPCControlMessageSizeAllowsOversizedPublishAndPartialFields(t *testing.T) {
+	topic := strings.Repeat("x", 32)
+
+	msg := marshalTestMessage(t, &RPC{
+		Publish: []*Message{{Topic: proto.String(topic), Data: []byte(strings.Repeat("x", 32))}},
+		Partial: &PartialMessagesExtension{
+			TopicID:        proto.String(topic),
+			PartialMessage: []byte(strings.Repeat("x", 32)),
+		},
+	})
+
+	if err := ValidateRawRPCControlMessageSize(msg, 8); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateRawRPCControlMessageSizeAllowsControlFieldWithinLimit(t *testing.T) {
+	topic := strings.Repeat("x", 32)
+	msg := marshalTestMessage(t, &RPC{
+		Control: &ControlMessage{
+			Graft: []*ControlGraft{{TopicID: proto.String(topic)}},
+		},
+	})
+
+	if err := ValidateRawRPCControlMessageSize(msg, 128); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func marshalTestMessage(t *testing.T, msg proto.Message) []byte {
+	t.Helper()
+
+	raw, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func appendRawRPCControlField(msg []byte, control []byte) []byte {
+	msg = protowire.AppendTag(msg, 3, protowire.BytesType)
+	return protowire.AppendBytes(msg, control)
+}
+
+func appendRawRPCSubscriptionField(msg []byte, subscription []byte) []byte {
+	msg = protowire.AppendTag(msg, 1, protowire.BytesType)
+	return protowire.AppendBytes(msg, subscription)
+}
+
+func encodedRawRPCFieldSize(field protowire.Number, msg []byte) int {
+	return protowire.SizeTag(field) + protowire.SizeBytes(len(msg))
+}

--- a/pb/validator_test.go
+++ b/pb/validator_test.go
@@ -82,8 +82,47 @@ func TestValidateRawRPCControlMessageSizeAllowsOversizedPublishAndPartialFields(
 		},
 	})
 
-	if err := ValidateRawRPCControlMessageSize(msg, 8); err != nil {
+	if err := ValidateRawRPCControlMessageSize(msg, 38); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestValidateRawRPCControlMessageSizeRejectsPublishWithLargeTopicOverhead(t *testing.T) {
+	payload := []byte(strings.Repeat("x", 1024))
+	shortTopicPublish := &Message{Topic: proto.String("x"), Data: payload}
+	largeTopicPublish := &Message{Topic: proto.String(strings.Repeat("x", 64)), Data: payload}
+	limit := encodedRawRPCPublishOverhead(t, shortTopicPublish)
+
+	shortTopicMsg := marshalTestMessage(t, &RPC{Publish: []*Message{shortTopicPublish}})
+	if err := ValidateRawRPCControlMessageSize(shortTopicMsg, limit); err != nil {
+		t.Fatal(err)
+	}
+
+	largeTopicMsg := marshalTestMessage(t, &RPC{Publish: []*Message{largeTopicPublish}})
+	if err := ValidateRawRPCControlMessageSize(largeTopicMsg, limit); err == nil {
+		t.Fatal("expected large publish topic overhead to exceed control size limit")
+	}
+}
+
+func TestValidateRawRPCControlMessageSizeRejectsCumulativePublishOverhead(t *testing.T) {
+	payload := []byte(strings.Repeat("x", 32))
+	publish := &Message{Topic: proto.String("a"), Data: payload}
+	limit := encodedRawRPCPublishOverhead(t, publish)
+
+	singlePublishMsg := marshalTestMessage(t, &RPC{Publish: []*Message{publish}})
+	if err := ValidateRawRPCControlMessageSize(singlePublishMsg, limit); err != nil {
+		t.Fatal(err)
+	}
+
+	multiplePublishMsg := marshalTestMessage(t, &RPC{
+		Publish: []*Message{
+			{Topic: proto.String("a"), Data: payload},
+			{Topic: proto.String("b"), Data: payload},
+			{Topic: proto.String("c"), Data: payload},
+		},
+	})
+	if err := ValidateRawRPCControlMessageSize(multiplePublishMsg, limit); err == nil {
+		t.Fatal("expected cumulative publish overhead to exceed control size limit")
 	}
 }
 
@@ -122,4 +161,15 @@ func appendRawRPCSubscriptionField(msg []byte, subscription []byte) []byte {
 
 func encodedRawRPCFieldSize(field protowire.Number, msg []byte) int {
 	return protowire.SizeTag(field) + protowire.SizeBytes(len(msg))
+}
+
+func encodedRawRPCPublishOverhead(t *testing.T, publish *Message) int {
+	t.Helper()
+
+	rawPublish := marshalTestMessage(t, publish)
+	dataLen := 0
+	if publish.Data != nil {
+		dataLen = protowire.SizeBytes(len(publish.Data))
+	}
+	return encodedRawRPCFieldSize(rpcPublishFieldNumber, rawPublish) - dataLen
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -341,10 +341,12 @@ func (rpc *RPC) LogValue() slog.Value {
 	return slog.GroupValue(fields...)
 }
 
-// split splits the given RPC If a sub RPC is too large and can't be split
-// further (e.g. Message data is bigger than the RPC limit), then it will be
-// returned as an oversized RPC. The caller should filter out oversized RPCs.
-func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
+// split splits the given RPC. If a sub RPC is too large and can't be split
+// further (e.g. Message data is bigger than the RPC limit, or a single
+// non-publish/non-partial message entry is bigger than the control limit), then
+// it will be returned as an oversized RPC. The caller should filter out
+// oversized RPCs.
+func (rpc *RPC) split(limit, controlLimit int) iter.Seq[*RPC] {
 	return func(yield func(*RPC) bool) {
 		nextRPC := &RPC{from: rpc.from}
 
@@ -398,7 +400,7 @@ func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
 			// Restore the original message before returning
 			rpc.Publish = originalPublishSlice
 		}()
-		if s := proto.Size(&rpc.RPC); s < limit {
+		if s := proto.Size(&rpc.RPC); s <= limit && controlRPCSize(rpc) <= controlLimit {
 			if s != 0 {
 				proto.Merge(&nextRPC.RPC, &rpc.RPC)
 				yield(nextRPC)
@@ -410,7 +412,7 @@ func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
 
 		// Merge/Append Subscriptions
 		for _, sub := range rpc.Subscriptions {
-			if nextRPC.Subscriptions = append(nextRPC.Subscriptions, sub); proto.Size(&nextRPC.RPC) > limit {
+			if nextRPC.Subscriptions = append(nextRPC.Subscriptions, sub); nextRPC.exceedsSizeLimits(limit, controlLimit) {
 				nextRPC.Subscriptions = nextRPC.Subscriptions[:len(nextRPC.Subscriptions)-1]
 				if !yield(nextRPC) {
 					return
@@ -425,7 +427,7 @@ func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
 		if ctl := rpc.Control; ctl != nil {
 			if nextRPC.Control == nil {
 				nextRPC.Control = &pb.ControlMessage{}
-				if proto.Size(&nextRPC.RPC) > limit {
+				if nextRPC.exceedsSizeLimits(limit, controlLimit) {
 					nextRPC.Control = nil
 					if !yield(nextRPC) {
 						return
@@ -434,8 +436,21 @@ func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
 				}
 			}
 
+			if extensions := ctl.GetExtensions(); extensions != nil {
+				if nextRPC.Control.Extensions = extensions; nextRPC.exceedsSizeLimits(limit, controlLimit) {
+					nextRPC.Control.Extensions = nil
+					if !yield(nextRPC) {
+						return
+					}
+
+					nextRPC = &RPC{RPC: pb.RPC{Control: &pb.ControlMessage{
+						Extensions: extensions,
+					}}, from: rpc.from}
+				}
+			}
+
 			for _, graft := range ctl.GetGraft() {
-				if nextRPC.Control.Graft = append(nextRPC.Control.Graft, graft); proto.Size(&nextRPC.RPC) > limit {
+				if nextRPC.Control.Graft = append(nextRPC.Control.Graft, graft); nextRPC.exceedsSizeLimits(limit, controlLimit) {
 					nextRPC.Control.Graft = nextRPC.Control.Graft[:len(nextRPC.Control.Graft)-1]
 					if !yield(nextRPC) {
 						return
@@ -446,7 +461,7 @@ func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
 			}
 
 			for _, prune := range ctl.GetPrune() {
-				if nextRPC.Control.Prune = append(nextRPC.Control.Prune, prune); proto.Size(&nextRPC.RPC) > limit {
+				if nextRPC.Control.Prune = append(nextRPC.Control.Prune, prune); nextRPC.exceedsSizeLimits(limit, controlLimit) {
 					nextRPC.Control.Prune = nextRPC.Control.Prune[:len(nextRPC.Control.Prune)-1]
 					if !yield(nextRPC) {
 						return
@@ -462,7 +477,7 @@ func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
 					// For IWANTs we don't need more than a single one,
 					// since there are no topic IDs here.
 					newIWant := &pb.ControlIWant{}
-					if nextRPC.Control.Iwant = append(nextRPC.Control.Iwant, newIWant); proto.Size(&nextRPC.RPC) > limit {
+					if nextRPC.Control.Iwant = append(nextRPC.Control.Iwant, newIWant); nextRPC.exceedsSizeLimits(limit, controlLimit) {
 						nextRPC.Control.Iwant = nextRPC.Control.Iwant[:len(nextRPC.Control.Iwant)-1]
 						if !yield(nextRPC) {
 							return
@@ -473,7 +488,7 @@ func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
 					}
 				}
 				for _, msgID := range iwant.GetMessageIDs() {
-					if nextRPC.Control.Iwant[0].MessageIDs = append(nextRPC.Control.Iwant[0].MessageIDs, msgID); proto.Size(&nextRPC.RPC) > limit {
+					if nextRPC.Control.Iwant[0].MessageIDs = append(nextRPC.Control.Iwant[0].MessageIDs, msgID); nextRPC.exceedsSizeLimits(limit, controlLimit) {
 						nextRPC.Control.Iwant[0].MessageIDs = nextRPC.Control.Iwant[0].MessageIDs[:len(nextRPC.Control.Iwant[0].MessageIDs)-1]
 						if !yield(nextRPC) {
 							return
@@ -485,12 +500,38 @@ func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
 				}
 			}
 
+			for _, idontwant := range ctl.GetIdontwant() {
+				if len(nextRPC.Control.Idontwant) == 0 {
+					newIDontWant := &pb.ControlIDontWant{}
+					if nextRPC.Control.Idontwant = append(nextRPC.Control.Idontwant, newIDontWant); nextRPC.exceedsSizeLimits(limit, controlLimit) {
+						nextRPC.Control.Idontwant = nextRPC.Control.Idontwant[:len(nextRPC.Control.Idontwant)-1]
+						if !yield(nextRPC) {
+							return
+						}
+						nextRPC = &RPC{RPC: pb.RPC{Control: &pb.ControlMessage{
+							Idontwant: []*pb.ControlIDontWant{newIDontWant},
+						}}, from: rpc.from}
+					}
+				}
+				for _, msgID := range idontwant.GetMessageIDs() {
+					if nextRPC.Control.Idontwant[0].MessageIDs = append(nextRPC.Control.Idontwant[0].MessageIDs, msgID); nextRPC.exceedsSizeLimits(limit, controlLimit) {
+						nextRPC.Control.Idontwant[0].MessageIDs = nextRPC.Control.Idontwant[0].MessageIDs[:len(nextRPC.Control.Idontwant[0].MessageIDs)-1]
+						if !yield(nextRPC) {
+							return
+						}
+						nextRPC = &RPC{RPC: pb.RPC{Control: &pb.ControlMessage{
+							Idontwant: []*pb.ControlIDontWant{{MessageIDs: []string{msgID}}},
+						}}, from: rpc.from}
+					}
+				}
+			}
+
 			for _, ihave := range ctl.GetIhave() {
 				if len(nextRPC.Control.Ihave) == 0 ||
 					nextRPC.Control.Ihave[len(nextRPC.Control.Ihave)-1].TopicID != ihave.TopicID {
 					// Start a new IHAVE if we are referencing a new topic ID
 					newIhave := &pb.ControlIHave{TopicID: ihave.TopicID}
-					if nextRPC.Control.Ihave = append(nextRPC.Control.Ihave, newIhave); proto.Size(&nextRPC.RPC) > limit {
+					if nextRPC.Control.Ihave = append(nextRPC.Control.Ihave, newIhave); nextRPC.exceedsSizeLimits(limit, controlLimit) {
 						nextRPC.Control.Ihave = nextRPC.Control.Ihave[:len(nextRPC.Control.Ihave)-1]
 						if !yield(nextRPC) {
 							return
@@ -502,7 +543,7 @@ func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
 				}
 				for _, msgID := range ihave.GetMessageIDs() {
 					lastIHave := nextRPC.Control.Ihave[len(nextRPC.Control.Ihave)-1]
-					if lastIHave.MessageIDs = append(lastIHave.MessageIDs, msgID); proto.Size(&nextRPC.RPC) > limit {
+					if lastIHave.MessageIDs = append(lastIHave.MessageIDs, msgID); nextRPC.exceedsSizeLimits(limit, controlLimit) {
 						lastIHave.MessageIDs = lastIHave.MessageIDs[:len(lastIHave.MessageIDs)-1]
 						if !yield(nextRPC) {
 							return
@@ -521,6 +562,20 @@ func (rpc *RPC) split(limit int) iter.Seq[*RPC] {
 			}
 		}
 	}
+}
+
+func (rpc *RPC) exceedsSizeLimits(limit, controlLimit int) bool {
+	return proto.Size(&rpc.RPC) > limit || controlRPCSize(rpc) > controlLimit
+}
+
+func controlRPCSize(rpc *RPC) int {
+	if rpc == nil {
+		return 0
+	}
+	return proto.Size(&pb.RPC{
+		Subscriptions: rpc.Subscriptions,
+		Control:       rpc.Control,
+	})
 }
 
 // pbFieldNumberLT15Size is the number of bytes required to encode a protobuf

--- a/pubsub.go
+++ b/pubsub.go
@@ -26,8 +26,12 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// DefaultMaximumMessageSize is 1mb.
-const DefaultMaxMessageSize = 1 << 20
+const (
+	// DefaultMaximumMessageSize is 1MiB.
+	DefaultMaxMessageSize = 1 << 20
+	// DefaultMaxControlMessageSize is 512KiB.
+	DefaultMaxControlMessageSize = 512 << 10
+)
 
 var (
 	// TimeCacheDuration specifies how long a message ID will be remembered as seen.
@@ -84,6 +88,9 @@ type PubSub struct {
 	// maxMessageSize is the maximum message size; it applies globally to all
 	// topics.
 	maxMessageSize int
+
+	// maxControlMessageSize is the maximum size for control messages.
+	maxControlMessageSize int
 
 	// size of the outbound message channel that we maintain for each peer
 	peerOutboundQueueSize int
@@ -551,6 +558,7 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		peerFilter:            DefaultPeerFilter,
 		disc:                  &discover{},
 		maxMessageSize:        DefaultMaxMessageSize,
+		maxControlMessageSize: DefaultMaxControlMessageSize,
 		peerOutboundQueueSize: 32,
 		signID:                h.ID(),
 		signKey:               nil,
@@ -828,6 +836,15 @@ func WithRPCLogger(logger *slog.Logger) Option {
 func WithMaxMessageSize(maxMessageSize int) Option {
 	return func(ps *PubSub) error {
 		ps.maxMessageSize = maxMessageSize
+		return nil
+	}
+}
+
+// WithMaxControlMessageSize sets the maximum size for pubsub control messages.
+// The default value is 512KiB (DefaultMaxControlMessageSize).
+func WithMaxControlMessageSize(maxControlMessageSize int) Option {
+	return func(ps *PubSub) error {
+		ps.maxControlMessageSize = maxControlMessageSize
 		return nil
 	}
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -387,13 +387,11 @@ func (rpc *RPC) split(limit, controlLimit int) iter.Seq[*RPC] {
 				if !yield(nextRPC) {
 					return
 				}
-				nextRPC = &RPC{from: rpc.from}
 			}
 		}
 
 		// Fast path check. It's possible the original RPC is now small enough
 		// without the messages to publish
-		nextRPC = &RPC{from: rpc.from}
 		originalPublishSlice := rpc.Publish
 		rpc.Publish = nil
 		defer func() {
@@ -402,6 +400,7 @@ func (rpc *RPC) split(limit, controlLimit int) iter.Seq[*RPC] {
 		}()
 		if s := proto.Size(&rpc.RPC); s <= limit && controlRPCSize(rpc) <= controlLimit {
 			if s != 0 {
+				nextRPC = &RPC{from: rpc.from}
 				proto.Merge(&nextRPC.RPC, &rpc.RPC)
 				yield(nextRPC)
 			}
@@ -409,6 +408,7 @@ func (rpc *RPC) split(limit, controlLimit int) iter.Seq[*RPC] {
 		}
 
 		// We have to split the RPC into multiple parts
+		nextRPC = &RPC{from: rpc.from}
 
 		// Merge/Append Subscriptions
 		for _, sub := range rpc.Subscriptions {

--- a/pubsub.go
+++ b/pubsub.go
@@ -572,10 +572,20 @@ func controlRPCSize(rpc *RPC) int {
 	if rpc == nil {
 		return 0
 	}
-	return proto.Size(&pb.RPC{
-		Subscriptions: rpc.Subscriptions,
-		Control:       rpc.Control,
-	})
+	// Compute the encoded size of an RPC containing only the Subscriptions and
+	// Control fields, without allocating a temporary pb.RPC. Calling proto.Size
+	// on the existing sub-message pointers doesn't allocate, whereas building a
+	// throwaway pb.RPC{Subscriptions, Control} escapes to the heap.
+	var size int
+	// Subscriptions are field 1 in pb.RPC (field number < 16).
+	for _, sub := range rpc.Subscriptions {
+		size += pbFieldNumberLT15Size + sizeOfEmbeddedMsg(proto.Size(sub))
+	}
+	// Control is field 3 in pb.RPC (field number < 16).
+	if rpc.Control != nil {
+		size += pbFieldNumberLT15Size + sizeOfEmbeddedMsg(proto.Size(rpc.Control))
+	}
+	return size
 }
 
 // pbFieldNumberLT15Size is the number of bytes required to encode a protobuf

--- a/rpc_size_test.go
+++ b/rpc_size_test.go
@@ -1,0 +1,174 @@
+package pubsub
+
+import (
+	"testing"
+
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"google.golang.org/protobuf/proto"
+)
+
+// controlRPCSizeViaTempStruct is the straightforward implementation that
+// allocates a temporary pb.RPC. It's kept here only as a reference oracle to
+// verify that the allocation-free controlRPCSize produces identical results.
+func controlRPCSizeViaTempStruct(rpc *RPC) int {
+	if rpc == nil {
+		return 0
+	}
+	return proto.Size(&pb.RPC{
+		Subscriptions: rpc.Subscriptions,
+		Control:       rpc.Control,
+	})
+}
+
+func TestControlRPCSize(t *testing.T) {
+	topic := "some-topic"
+	subscribe := true
+	unsubscribe := false
+
+	// Typical gossipsub message IDs are from+seqno (roughly 40 bytes).
+	msgIDs := func(n, size int) []string {
+		ids := make([]string, n)
+		b := make([]byte, size)
+		for i := range ids {
+			b[0] = byte(i)
+			ids[i] = string(b)
+		}
+		return ids
+	}
+
+	typicalMsgIDs := msgIDs(10, 40)
+	publishMsg := &pb.Message{
+		Data:  make([]byte, 256),
+		Topic: &topic,
+	}
+
+	cases := []struct {
+		name string
+		rpc  *RPC
+	}{
+		{
+			name: "empty",
+			rpc:  &RPC{},
+		},
+		{
+			name: "subscription",
+			rpc: &RPC{
+				RPC: pb.RPC{
+					Subscriptions: []*pb.RPC_SubOpts{
+						{Subscribe: &subscribe, Topicid: &topic},
+					},
+				},
+			},
+		},
+		{
+			name: "unsubscribe",
+			rpc: &RPC{
+				RPC: pb.RPC{
+					Subscriptions: []*pb.RPC_SubOpts{
+						{Subscribe: &unsubscribe, Topicid: &topic},
+					},
+				},
+			},
+		},
+		{
+			name: "multipleSubscriptions",
+			rpc: &RPC{
+				RPC: pb.RPC{
+					Subscriptions: []*pb.RPC_SubOpts{
+						{Subscribe: &subscribe, Topicid: &topic},
+						{Subscribe: &subscribe, Topicid: strPtr("other-topic")},
+						{Subscribe: &unsubscribe, Topicid: strPtr("old-topic")},
+					},
+				},
+			},
+		},
+		{
+			name: "graftPrune",
+			rpc: rpcWithControl(nil, nil, nil,
+				[]*pb.ControlGraft{{TopicID: &topic}},
+				[]*pb.ControlPrune{{TopicID: strPtr("other-topic")}},
+				nil,
+			),
+		},
+		{
+			name: "ihaveSmall",
+			rpc: rpcWithControl(nil,
+				[]*pb.ControlIHave{{TopicID: &topic, MessageIDs: typicalMsgIDs[:3]}},
+				nil, nil, nil, nil,
+			),
+		},
+		{
+			name: "ihaveTypical",
+			rpc: rpcWithControl(nil,
+				[]*pb.ControlIHave{{TopicID: &topic, MessageIDs: typicalMsgIDs}},
+				nil, nil, nil, nil,
+			),
+		},
+		{
+			name: "iwantSmall",
+			rpc: rpcWithControl(nil, nil,
+				[]*pb.ControlIWant{{MessageIDs: typicalMsgIDs[:3]}},
+				nil, nil, nil,
+			),
+		},
+		{
+			name: "ihaveIwantResponse",
+			rpc: rpcWithControl(nil,
+				[]*pb.ControlIHave{{TopicID: &topic, MessageIDs: typicalMsgIDs[:5]}},
+				[]*pb.ControlIWant{{MessageIDs: typicalMsgIDs[:2]}},
+				nil, nil, nil,
+			),
+		},
+		{
+			name: "idontwant",
+			rpc: rpcWithControl(nil, nil, nil, nil, nil,
+				[]*pb.ControlIDontWant{{MessageIDs: typicalMsgIDs[:5]}},
+			),
+		},
+		{
+			name: "publishOnly",
+			rpc:  rpcWithMessages(publishMsg),
+		},
+		{
+			name: "publishWithControl",
+			rpc: rpcWithControl(
+				[]*pb.Message{publishMsg},
+				[]*pb.ControlIHave{{TopicID: &topic, MessageIDs: typicalMsgIDs[:3]}},
+				nil, nil, nil, nil,
+			),
+		},
+		{
+			name: "heartbeatControl",
+			rpc: rpcWithControl(nil,
+				[]*pb.ControlIHave{
+					{TopicID: &topic, MessageIDs: typicalMsgIDs},
+					{TopicID: strPtr("other-topic"), MessageIDs: typicalMsgIDs[:5]},
+				},
+				[]*pb.ControlIWant{{MessageIDs: typicalMsgIDs[:3]}},
+				[]*pb.ControlGraft{{TopicID: strPtr("new-topic")}},
+				[]*pb.ControlPrune{{TopicID: strPtr("old-topic")}},
+				nil,
+			),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			size := controlRPCSize(tc.rpc)
+			if want := controlRPCSizeViaTempStruct(tc.rpc); size != want {
+				t.Fatalf("controlRPCSize=%d, want %d (temp-struct oracle)", size, want)
+			}
+			if allocs := testing.AllocsPerRun(100, func() {
+				if got := controlRPCSize(tc.rpc); got != size {
+					t.Fatalf("controlRPCSize changed from %d to %d", size, got)
+				}
+			}); allocs != 0 {
+				t.Errorf("controlRPCSize allocated %v times per run, want 0", allocs)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
This adds a new option to limit to total size of control fields (including subscriptions) when receiving a pb rpc. This fixes an issue where allowing a large message payload should not also allow a large amount of control messages at once. 

This depends on #706 