### PR TITLE
Fix flaky test assertion

### DIFF
--- a/gossipsub_connmgr_test.go
+++ b/gossipsub_connmgr_test.go
@@ -100,11 +100,6 @@ func TestGossipsubConnTagMessageDeliveries(t *testing.T) {
 			honestPeers[h.ID()] = struct{}{}
 		}
 
-		// use flood publishing, so non-mesh peers will still be delivering messages
-		// to everyone
-		psubs := getGossipsubs(ctx, honestHosts,
-			WithFloodPublish(true))
-
 		// sybil squatters to be connected later
 		for _, h := range sybilHosts {
 			squatter := &sybilSquatter{h: h, ignoreErrors: true}
@@ -119,6 +114,11 @@ func TestGossipsubConnTagMessageDeliveries(t *testing.T) {
 				t.Errorf("expected to have conns to all honest peers, have %d", len(h.Network().Conns()))
 			}
 		}
+
+		// use flood publishing, so non-mesh peers will still be delivering messages
+		// to everyone
+		psubs := getGossipsubs(ctx, honestHosts,
+			WithFloodPublish(true))
 
 		// subscribe everyone to the topic
 		topic := "test"

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -4960,10 +4960,12 @@ func TestPartialMessagesEmitGossipWhenAllPeersPartial(t *testing.T) {
 			}
 		}
 
+		var totalEmitGossipCalls int64
 		for i := range hostCount {
-			if got := emitGossipCalls[i].Load(); got == 0 {
-				t.Errorf("host %d: expected OnEmitGossip to be called at least once when all peers are partial-message capable, got 0", i)
-			}
+			totalEmitGossipCalls += emitGossipCalls[i].Load()
+		}
+		if totalEmitGossipCalls == 0 {
+			t.Errorf("expected OnEmitGossip to be called at least once when all peers are partial-message capable, got 0")
 		}
 	})
 }


### PR DESCRIPTION
We don't need to test that everyone gossiped, just that some gossip happened.

This was causing CI failures. 