### PR TITLE
Fix memory leak due to retention of empty topic maps

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -1036,6 +1036,9 @@ func (p *PubSub) clearPeerFromTopicsState(pid peer.ID) {
 	for t, tmap := range p.topics {
 		if _, ok := tmap[pid]; ok {
 			delete(tmap, pid)
+			if len(tmap) == 0 {
+				delete(p.topics, t)
+			}
 			p.notifyLeave(t, pid)
 		}
 	}

--- a/pubsub.go
+++ b/pubsub.go
@@ -1440,6 +1440,9 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 
 			if _, ok := tmap[rpc.from]; ok {
 				delete(tmap, rpc.from)
+				if len(tmap) == 0 {
+					delete(p.topics, t)
+				}
 				p.notifyLeave(t, rpc.from)
 			}
 		}

--- a/topic_test.go
+++ b/topic_test.go
@@ -1318,7 +1318,7 @@ func TestSelfMessageFilter(t *testing.T) {
 
 // Checking if topic is removed from topics map
 // https://github.com/libp2p/go-libp2p-pubsub/issues/705
-func TestTopicDeleteEmptyTopicList(t *testing.T) {
+func TestTopicDeleteEmptyTopicMap(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/topic_test.go
+++ b/topic_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -1312,5 +1313,87 @@ func TestSelfMessageFilter(t *testing.T) {
 	}
 	if !bytes.Equal(m.Data, remoteMsg) {
 		t.Fatal("expected to receive remote message on filtered subscription")
+	}
+}
+
+// Host 1 connects to both topics and Host 2 connects to one of them.
+// Later Host 1 disconnects from both.
+func TestTopicDeleteEmptyTopicList(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const numHosts = 2
+	topicIDs := [2]string{"foobarA", "foobarB"}
+	hosts := getDefaultHosts(t, numHosts)
+
+	ps := getPubsubs(ctx, hosts)
+
+	topicAHost0, err := ps[0].Join(topicIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	topicBHost0, err := ps[0].Join(topicIDs[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	topicAHost1, err := ps[1].Join(topicIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	topicBHost1, err := ps[1].Join(topicIDs[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	connectAll(t, hosts)
+	time.Sleep(time.Millisecond * 100)
+
+	subAHost0, err := topicAHost0.Subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := topicBHost0.Subscribe(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := topicAHost1.Subscribe(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := topicBHost1.Subscribe(); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Millisecond * 100)
+
+	verifyTopicPeers := func(actual map[peer.ID]peerTopicState, expected []string) {
+		list := make([]string, 0, len(actual))
+
+		for k := range actual {
+			list = append(list, k.String())
+		}
+
+		slices.Sort(list)
+		slices.Sort(expected)
+
+		if !slices.Equal(list, expected) {
+			t.Fatalf("Expected %v Actual %v", expected, list)
+		}
+	}
+
+	verifyTopicPeers(ps[0].topics[topicIDs[0]], []string{hosts[1].ID().String()})
+	verifyTopicPeers(ps[0].topics[topicIDs[1]], []string{hosts[1].ID().String()})
+
+	verifyTopicPeers(ps[1].topics[topicIDs[0]], []string{hosts[0].ID().String()})
+	verifyTopicPeers(ps[1].topics[topicIDs[1]], []string{hosts[0].ID().String()})
+
+	subAHost0.Cancel()
+	if err := topicAHost0.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Millisecond * 100)
+
+	verifyTopicPeers(ps[1].topics[topicIDs[1]], []string{hosts[0].ID().String()})
+	if _, ok := ps[1].topics[topicIDs[0]]; ok {
+		t.Fatalf("Topic %s still present and length: %d\n", topicIDs[0], len(ps[1].topics[topicIDs[0]]))
 	}
 }

--- a/topic_test.go
+++ b/topic_test.go
@@ -1316,32 +1316,18 @@ func TestSelfMessageFilter(t *testing.T) {
 	}
 }
 
-// Host 1 connects to both topics and Host 2 connects to one of them.
-// Later Host 1 disconnects from both.
+// Checking if topic is removed from topics map
+// https://github.com/libp2p/go-libp2p-pubsub/issues/705
 func TestTopicDeleteEmptyTopicList(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	const numHosts = 2
-	topicIDs := [2]string{"foobarA", "foobarB"}
+	topicName := "foobar"
 	hosts := getDefaultHosts(t, numHosts)
-
 	ps := getPubsubs(ctx, hosts)
 
-	topicAHost0, err := ps[0].Join(topicIDs[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	topicBHost0, err := ps[0].Join(topicIDs[1])
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	topicAHost1, err := ps[1].Join(topicIDs[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	topicBHost1, err := ps[1].Join(topicIDs[1])
+	topicAHost0, err := ps[0].Join(topicName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1353,15 +1339,7 @@ func TestTopicDeleteEmptyTopicList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := topicBHost0.Subscribe(); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := topicAHost1.Subscribe(); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := topicBHost1.Subscribe(); err != nil {
-		t.Fatal(err)
-	}
+
 	time.Sleep(time.Millisecond * 100)
 
 	verifyTopicPeers := func(actual map[peer.ID]peerTopicState, expected []string) {
@@ -1379,21 +1357,13 @@ func TestTopicDeleteEmptyTopicList(t *testing.T) {
 		}
 	}
 
-	verifyTopicPeers(ps[0].topics[topicIDs[0]], []string{hosts[1].ID().String()})
-	verifyTopicPeers(ps[0].topics[topicIDs[1]], []string{hosts[1].ID().String()})
-
-	verifyTopicPeers(ps[1].topics[topicIDs[0]], []string{hosts[0].ID().String()})
-	verifyTopicPeers(ps[1].topics[topicIDs[1]], []string{hosts[0].ID().String()})
+	verifyTopicPeers(ps[1].topics[topicName], []string{hosts[0].ID().String()})
 
 	subAHost0.Cancel()
-	if err := topicAHost0.Close(); err != nil {
-		t.Fatal(err)
-	}
 
 	time.Sleep(time.Millisecond * 100)
 
-	verifyTopicPeers(ps[1].topics[topicIDs[1]], []string{hosts[0].ID().String()})
-	if _, ok := ps[1].topics[topicIDs[0]]; ok {
-		t.Fatalf("Topic %s still present and length: %d\n", topicIDs[0], len(ps[1].topics[topicIDs[0]]))
+	if _, ok := ps[1].topics[topicName]; ok {
+		t.Fatalf("Topic %s still present and length: %d\n", topicName, len(ps[1].topics[topicName]))
 	}
 }


### PR DESCRIPTION
This PR aims to fix the issue #705 which was discovered and reported by @tonghuaroot and @lidel with verification by @seetadev

`clearPeerFromTopicsState` and `handleIncomingRPC` functions have been updated to check if the map of peers for a topic is empty after removal of a peer and then delete that entry.

In addition to the fix, testcase for the same has been added as `TestTopicDeleteEmptyTopicMap` to ensure future changes adhere to this requirment.
I have also created a [simple pubsub application](https://github.com/bismuth01/pubsub-mem-leak) with mDNS discovery to connect nodes a common topic to optionally application test if the changes have affected anything else.