### PR TITLE
feat: allow pubsub over limited (relayed) connections

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -163,7 +163,7 @@ func (p *PubSub) notifyPeerDead(pid peer.ID) {
 }
 
 func (p *PubSub) handleNewPeer(ctx context.Context, pid peer.ID, outgoing *rpcQueue) {
-	s, err := p.host.NewStream(ctx, pid, p.rt.Protocols()...)
+	s, err := p.host.NewStream(network.WithAllowLimitedConn(ctx, "pubsub"), pid, p.rt.Protocols()...)
 	if err != nil {
 		p.logger.Debug("error opening new stream to peer", "err", err, "peer", pid)
 

--- a/peer_notify.go
+++ b/peer_notify.go
@@ -25,7 +25,7 @@ func (ps *PubSub) watchForNewPeers(ctx context.Context) {
 	ps.newPeersPrioLk.RLock()
 	ps.newPeersMx.Lock()
 	for _, pid := range ps.host.Network().Peers() {
-		if ps.host.Network().Connectedness(pid) != network.Connected {
+		if c := ps.host.Network().Connectedness(pid); c != network.Connected && c != network.Limited {
 			continue
 		}
 		ps.newPeersPend[pid] = struct{}{}

--- a/pubsub.go
+++ b/pubsub.go
@@ -1005,7 +1005,7 @@ func (p *PubSub) handlePendingPeers() {
 	for pid := range newPeers {
 		// Make sure we have a non-limited connection. We do this late because we may have
 		// disconnected in the meantime.
-		if p.host.Network().Connectedness(pid) != network.Connected {
+		if c := p.host.Network().Connectedness(pid); c != network.Connected && c != network.Limited {
 			continue
 		}
 


### PR DESCRIPTION
Hello from the LocalAI team :wave: 

I've been trying to trace an issue while running edgevpn (https://github.com/mudler/edgevpn, which is used by https://github.com/mudler/LocalAI ) between two VMs in qemu network configured user-mode (which uses slirp, and makes the networks completely isolated between each VM) where they can connect but quickly via DHT resolution and nat/holepunch, but loose connection right after. This scenario was working  in a very old version of libp2p, but it stopped to work at a certain version (which I can't pinpoint to), but it was really hard to track down so I eventually gave up. 

Lately I've been put Claude into bruteforcing this just for the sake of it, as it was quite of a timesink otherwise, and it managed to break down the issue (after a long session of driving it in the correct place), now, what I don't know if it is actually OK with the overall design, or if it should be tackled from another angle, so I'd be happy to work this out.

This seems part of the solution - I'm still struggling on other parts, but at least make nodes visible to each other.

Here is the result from Claude:

Three places hard-filtered peers whose only connection to the local host was Limited (network.Limited, i.e. relay/circuit-v2 path):

  * pubsub.go:1008 (handlePendingPeers):  main connection-event loop discarded any peer whose Connectedness wasn't strictly Connected.
  * peer_notify.go:28 (watchForNewPeers): initial peer enumeration discarded Limited peers.
  * comm.go:166 (handleNewPeer): opened the gossipsub stream without network.WithAllowLimitedConn, so even if a Limited peer made it past the prior filters the swarm layer would reject the stream with network.ErrLimitedConn.

These checks date back to when relay/circuit was considered too slow or unreliable for pubsub. With AutoRelay+DCUtR now a regular operating mode for NAT'd hosts, NAT-traversed peers routinely live on Limited connections, and they silently lose every pubsub message. The fix is to accept network.Limited everywhere alongside network.Connected and to pass network.WithAllowLimitedConn at the single stream-open call.

Verified with a standalone reproducer that puts two hosts behind a relay with a ConnectionGater that blocks all direct A↔B addresses, and confirms the A↔B connection is Limited before publishing. Prior to this change the message never arrives (60s timeout); with the change applied the message arrives in well under one heartbeat.