### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -704,7 +704,7 @@ func (gs *GossipSubRouter) Attach(p *PubSub) {
 }
 
 func (gs *GossipSubRouter) manageAddrBook() {
-	sub, err := gs.p.host.EventBus().Subscribe([]interface{}{
+	sub, err := gs.p.host.EventBus().Subscribe([]any{
 		&event.EvtPeerIdentificationCompleted{},
 		&event.EvtPeerConnectednessChanged{},
 	})

--- a/peer_notify.go
+++ b/peer_notify.go
@@ -12,7 +12,7 @@ import (
 func (ps *PubSub) watchForNewPeers(ctx context.Context) {
 	// We don't bother subscribing to "connectivity" events because we always run identify after
 	// every new connection.
-	sub, err := ps.host.EventBus().Subscribe([]interface{}{
+	sub, err := ps.host.EventBus().Subscribe([]any{
 		&event.EvtPeerIdentificationCompleted{},
 		&event.EvtPeerProtocolsUpdated{},
 	})

--- a/pubsub.go
+++ b/pubsub.go
@@ -260,7 +260,7 @@ type Message struct {
 	*pb.Message
 	ID            string
 	ReceivedFrom  peer.ID
-	ValidatorData interface{}
+	ValidatorData any
 	Local         bool
 }
 
@@ -1895,7 +1895,7 @@ func (p *PubSub) BlacklistPeer(pid peer.ID) {
 // By default validators are asynchronous, which means they will run in a separate goroutine.
 // The number of active goroutines is controlled by global and per topic validator
 // throttles; if it exceeds the throttle threshold, messages will be dropped.
-func (p *PubSub) RegisterTopicValidator(topic string, val interface{}, opts ...ValidatorOpt) error {
+func (p *PubSub) RegisterTopicValidator(topic string, val any, opts ...ValidatorOpt) error {
 	addVal := &addValReq{
 		topic:    topic,
 		validate: val,

--- a/score.go
+++ b/score.go
@@ -154,7 +154,7 @@ type TopicScoreSnapshot struct {
 //     components for debugging peer scoring.
 //
 // This option must be passed _after_ the WithPeerScore option.
-func WithPeerScoreInspect(inspect interface{}, period time.Duration) Option {
+func WithPeerScoreInspect(inspect any, period time.Duration) Option {
 	return func(ps *PubSub) error {
 		gs, ok := ps.rt.(*GossipSubRouter)
 		if !ok {

--- a/validation.go
+++ b/validation.go
@@ -112,7 +112,7 @@ type validatorImpl struct {
 // async request to add a topic validators
 type addValReq struct {
 	topic    string
-	validate interface{}
+	validate any
 	timeout  time.Duration
 	throttle int
 	inline   bool
@@ -517,7 +517,7 @@ func (val *validatorImpl) validateMsg(ctx context.Context, src peer.ID, msg *Mes
 // WithDefaultValidator adds a validator that applies to all topics by default; it can be used
 // more than once and add multiple validators. Having a defult validator does not inhibit registering
 // a per topic validator.
-func WithDefaultValidator(val interface{}, opts ...ValidatorOpt) Option {
+func WithDefaultValidator(val any, opts ...ValidatorOpt) Option {
 	return func(ps *PubSub) error {
 		addVal := &addValReq{
 			validate: val,


### PR DESCRIPTION
Replace `interface{}` with `any` across 5 Go files.

- gossipsub.go
- peer_notify.go
- pubsub.go
- score.go
- validation.go

This is a mechanical refactor using Go 1.18+ `any` alias.