### PR TITLE
refactor: apply go fix modernizers

### DIFF
--- a/backoff_test.go
+++ b/backoff_test.go
@@ -41,11 +41,8 @@ func TestBackoff_Update(t *testing.T) {
 				t.Fatalf("unexpected error post update: %s", err)
 			}
 
-			expected := time.Duration(math.Pow(BackoffMultiplier, float64(i)) *
-				float64(MinBackoffDelay+MaxBackoffJitterCoff*time.Millisecond))
-			if expected > MaxBackoffDelay {
-				expected = MaxBackoffDelay
-			}
+			expected := min(time.Duration(math.Pow(BackoffMultiplier, float64(i))*
+				float64(MinBackoffDelay+MaxBackoffJitterCoff*time.Millisecond)), MaxBackoffDelay)
 
 			if expected < got { // considering jitter, expected backoff must always be greater than or equal to actual.
 				t.Fatalf("invalid backoff result, expected: %v, got: %v", expected, got)
@@ -94,7 +91,7 @@ func TestBackoff_Clean(t *testing.T) {
 		maxBackoffAttempts := 100 // setting attempts to a high number hence testing cleanup logic.
 		b := newBackoff(ctx, size, cleanupInterval, maxBackoffAttempts)
 
-		for i := 0; i < size; i++ {
+		for i := range size {
 			id := peer.ID(fmt.Sprintf("peer-%d", i))
 			_, err := b.updateAndGet(id)
 			if err != nil {

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -54,10 +54,7 @@ func (s *mockDiscoveryServer) FindPeers(ns string, limit int) (<-chan peer.AddrI
 		return emptyCh, nil
 	}
 
-	count := len(peers)
-	if count > limit {
-		count = limit
-	}
+	count := min(len(peers), limit)
 	ch := make(chan peer.AddrInfo, count)
 	numSent := 0
 	for _, reg := range peers {
@@ -201,8 +198,8 @@ func TestSimpleDiscovery(t *testing.T) {
 		}
 
 		// Try random peers sending messages and make sure they are received
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d the flooooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d the flooooooood %d", i, i)
 
 			owner := rand.Intn(len(psubs))
 
@@ -269,7 +266,7 @@ func TestGossipSubDiscoveryAfterBootstrap(t *testing.T) {
 			waitUntilGossipsubMeshCount(ps, topic, partitionSize-1)
 		}
 
-		for i := 0; i < partitionSize; i++ {
+		for i := range partitionSize {
 			if _, err := server1.Advertise("floodsub:"+topic, *host.InfoFromHost(hosts[i+partitionSize]), ttl); err != nil {
 				t.Fatal(err)
 			}
@@ -279,8 +276,8 @@ func TestGossipSubDiscoveryAfterBootstrap(t *testing.T) {
 		time.Sleep(5 * time.Second)
 
 		// test the mesh
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := rand.Intn(numHosts)
 

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -160,8 +160,8 @@ func TestBasicFloodsub(t *testing.T) {
 
 		time.Sleep(time.Millisecond * 100)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d the flooooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d the flooooooood %d", i, i)
 
 			owner := mrand.Intn(len(psubs))
 
@@ -1002,9 +1002,9 @@ func TestMessageSender(t *testing.T) {
 
 		time.Sleep(time.Millisecond * 100)
 
-		for i := 0; i < 3; i++ {
-			for j := 0; j < 100; j++ {
-				msg := []byte(fmt.Sprintf("%d sent %d", i, j))
+		for i := range 3 {
+			for j := range 100 {
+				msg := fmt.Appendf(nil, "%d sent %d", i, j)
 
 				psubs[i].Publish(topic, msg)
 
@@ -1183,8 +1183,8 @@ func TestPubsubWithAssortedOptions(t *testing.T) {
 
 		time.Sleep(time.Second)
 
-		for i := 0; i < 2; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 2 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i].Publish("test", msg)
 
 			for _, sub := range subs {

--- a/fuzz_helpers_test.go
+++ b/fuzz_helpers_test.go
@@ -47,12 +47,12 @@ func generateControl(data []byte, limit int) *pb.ControlMessage {
 	ctl := &pb.ControlMessage{}
 
 	ctl.Iwant = make([]*pb.ControlIWant, 0, numIWANTMsgs)
-	for i := 0; i < numIWANTMsgs; i++ {
+	for i := range numIWANTMsgs {
 		msgSize := int(generateU16(&data)) % limit
 		msgCount := int(generateU16(&data)) % limit
 		ctl.Iwant = append(ctl.Iwant, &pb.ControlIWant{})
 		ctl.Iwant[i].MessageIDs = make([]string, 0, msgCount)
-		for j := 0; j < msgCount; j++ {
+		for range msgCount {
 			ctl.Iwant[i].MessageIDs = append(ctl.Iwant[i].MessageIDs, string(make([]byte, msgSize)))
 		}
 	}
@@ -61,7 +61,7 @@ func generateControl(data []byte, limit int) *pb.ControlMessage {
 	}
 
 	ctl.Ihave = make([]*pb.ControlIHave, 0, numIHAVEMsgs)
-	for i := 0; i < numIHAVEMsgs; i++ {
+	for i := range numIHAVEMsgs {
 		msgSize := int(generateU16(&data)) % limit
 		msgCount := int(generateU16(&data)) % limit
 		topicSize := int(generateU16(&data)) % limit
@@ -69,7 +69,7 @@ func generateControl(data []byte, limit int) *pb.ControlMessage {
 		ctl.Ihave = append(ctl.Ihave, &pb.ControlIHave{TopicID: &topic})
 
 		ctl.Ihave[i].MessageIDs = make([]string, 0, msgCount)
-		for j := 0; j < msgCount; j++ {
+		for range msgCount {
 			ctl.Ihave[i].MessageIDs = append(ctl.Ihave[i].MessageIDs, string(make([]byte, msgSize)))
 		}
 	}
@@ -79,7 +79,7 @@ func generateControl(data []byte, limit int) *pb.ControlMessage {
 
 	numGraft := int(generateU16(&data)) % limit
 	ctl.Graft = make([]*pb.ControlGraft, 0, numGraft)
-	for i := 0; i < numGraft; i++ {
+	for range numGraft {
 		topicSize := int(generateU16(&data)) % limit
 		topic := string(make([]byte, topicSize))
 		ctl.Graft = append(ctl.Graft, &pb.ControlGraft{TopicID: &topic})
@@ -90,7 +90,7 @@ func generateControl(data []byte, limit int) *pb.ControlMessage {
 
 	numPrune := int(generateU16(&data)) % limit
 	ctl.Prune = make([]*pb.ControlPrune, 0, numPrune)
-	for i := 0; i < numPrune; i++ {
+	for range numPrune {
 		topicSize := int(generateU16(&data)) % limit
 		topic := string(make([]byte, topicSize))
 		ctl.Prune = append(ctl.Prune, &pb.ControlPrune{TopicID: &topic})
@@ -108,7 +108,7 @@ func generateRPC(data []byte, limit int) *RPC {
 
 	msgCount := int(generateU16(&data)) % (limit / 2)
 	rpc.Publish = make([]*pb.Message, 0, msgCount)
-	for i := 0; i < msgCount; i++ {
+	for range msgCount {
 		msg := generateMessage(data, limit)
 
 		sizeTester.Publish = []*pb.Message{msg}
@@ -123,7 +123,7 @@ func generateRPC(data []byte, limit int) *RPC {
 
 	subCount := int(generateU16(&data)) % (limit / 2)
 	rpc.Subscriptions = make([]*pb.RPC_SubOpts, 0, subCount)
-	for i := 0; i < subCount; i++ {
+	for range subCount {
 		sub := generateSub(data, limit)
 
 		sizeTester.Subscriptions = []*pb.RPC_SubOpts{sub}

--- a/gossip_tracer_test.go
+++ b/gossip_tracer_test.go
@@ -21,7 +21,7 @@ func TestBrokenPromises(t *testing.T) {
 		peerC := peer.ID("C")
 
 		var mids []string
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			m := makeTestMessage(i)
 			m.From = []byte(peerA)
 			mid := DefaultMsgIdFn(m)
@@ -78,7 +78,7 @@ func TestNoBrokenPromises(t *testing.T) {
 
 		var msgs []*pb.Message
 		var mids []string
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			m := makeTestMessage(i)
 			m.From = []byte(peerA)
 			msgs = append(msgs, m)

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -705,7 +705,7 @@ func (gs *GossipSubRouter) Attach(p *PubSub) {
 }
 
 func (gs *GossipSubRouter) manageAddrBook() {
-	sub, err := gs.p.host.EventBus().Subscribe([]interface{}{
+	sub, err := gs.p.host.EventBus().Subscribe([]any{
 		&event.EvtPeerIdentificationCompleted{},
 		&event.EvtPeerConnectednessChanged{},
 	})

--- a/gossipsub_connmgr_test.go
+++ b/gossipsub_connmgr_test.go
@@ -50,7 +50,7 @@ func TestGossipsubConnTagMessageDeliveries(t *testing.T) {
 		connLimit := 10
 
 		connmgrs := make([]*connmgr.BasicConnMgr, nHonest)
-		for i := 0; i < nHonest; i++ {
+		for i := range nHonest {
 			var err error
 			connmgrs[i], err = connmgr.NewConnManager(nHonest, connLimit,
 				connmgr.WithGracePeriod(0),
@@ -135,7 +135,7 @@ func TestGossipsubConnTagMessageDeliveries(t *testing.T) {
 		// have all the hosts publish enough messages to ensure that they get some delivery credit
 		nMessages := GossipSubConnTagMessageDeliveryCap * 2
 		for _, ps := range psubs {
-			for i := 0; i < nMessages; i++ {
+			for range nMessages {
 				ps.Publish(topic, []byte("hello"))
 			}
 		}

--- a/gossipsub_feat_test.go
+++ b/gossipsub_feat_test.go
@@ -142,8 +142,8 @@ func TestGossipSubCustomProtocols(t *testing.T) {
 		}
 
 		// send some messages
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not quite a floooooood %d", i, i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "%d it's not quite a floooooood %d", i, i)
 
 			owner := rand.Intn(len(psubs))
 

--- a/gossipsub_spam_test.go
+++ b/gossipsub_spam_test.go
@@ -725,7 +725,7 @@ func TestGossipsubAttackInvalidMessageSpam(t *testing.T) {
 
 						// Send a bunch of messages with no signature (these will
 						// fail validation and reduce the attacker's score)
-						for i := 0; i < 100; i++ {
+						for i := range 100 {
 							msg := &pb.Message{
 								Data:  []byte("some data" + strconv.Itoa(i)),
 								Topic: &mytopic,
@@ -935,7 +935,7 @@ func TestGossipsubHandleIDontwantSpam(t *testing.T) {
 		}
 		exceededIDWLength := GossipSubMaxIDontWantLength + 1
 		var idwIds []string
-		for i := 0; i < exceededIDWLength; i++ {
+		for i := range exceededIDWLength {
 			idwIds = append(idwIds, fmt.Sprintf("idontwant-%d", i))
 		}
 		rPid := hosts[1].ID()

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -148,8 +148,8 @@ func TestSparseGossipsub(t *testing.T) {
 		// wait for heartbeats to build mesh
 		time.Sleep(time.Second * 2)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := mrand.Intn(len(psubs))
 
@@ -191,8 +191,8 @@ func TestDenseGossipsub(t *testing.T) {
 		// wait for heartbeats to build mesh
 		time.Sleep(time.Second * 2)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := mrand.Intn(len(psubs))
 
@@ -234,8 +234,8 @@ func TestGossipsubFanout(t *testing.T) {
 		// wait for heartbeats to build mesh
 		time.Sleep(time.Second * 2)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := 0
 
@@ -262,8 +262,8 @@ func TestGossipsubFanout(t *testing.T) {
 		// wait for a heartbeat
 		time.Sleep(time.Second * 1)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := 0
 
@@ -305,8 +305,8 @@ func TestGossipsubFanoutMaintenance(t *testing.T) {
 		// wait for heartbeats to build mesh
 		time.Sleep(time.Second * 2)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := 0
 
@@ -344,8 +344,8 @@ func TestGossipsubFanoutMaintenance(t *testing.T) {
 
 		time.Sleep(time.Second * 2)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := 0
 
@@ -392,8 +392,8 @@ func TestGossipsubFanoutExpiry(t *testing.T) {
 		// wait for heartbeats to build mesh
 		time.Sleep(time.Second * 2)
 
-		for i := 0; i < 5; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 5 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := 0
 
@@ -453,8 +453,8 @@ func TestGossipsubGossip(t *testing.T) {
 		// wait for heartbeats to build mesh
 		time.Sleep(time.Second * 2)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := mrand.Intn(len(psubs))
 
@@ -513,8 +513,8 @@ func TestGossipsubGossipPiggyback(t *testing.T) {
 		// wait for heartbeats to build mesh
 		time.Sleep(time.Second * 2)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := mrand.Intn(len(psubs))
 
@@ -576,8 +576,8 @@ func TestGossipsubGossipPropagation(t *testing.T) {
 
 		time.Sleep(time.Second * 1)
 
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := 0
 
@@ -607,7 +607,7 @@ func TestGossipsubGossipPropagation(t *testing.T) {
 		}
 
 		var collect [][]byte
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			for _, sub := range msgs2 {
 				got, err := sub.Next(ctx)
 				if err != nil {
@@ -617,8 +617,8 @@ func TestGossipsubGossipPropagation(t *testing.T) {
 			}
 		}
 
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 			gotit := false
 			for j := 0; j < len(collect); j++ {
 				if bytes.Equal(msg, collect[j]) {
@@ -664,8 +664,8 @@ func TestGossipsubPrune(t *testing.T) {
 		// wait a bit to take effect
 		time.Sleep(time.Millisecond * 100)
 
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := mrand.Intn(len(psubs))
 
@@ -763,8 +763,8 @@ func TestGossipsubPruneBackoffTime(t *testing.T) {
 			t.Errorf("missing too many backoffs: %v", missingBackoffs)
 		}
 
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			// Don't publish from host 0, since everyone should have pruned it.
 			owner := mrand.Intn(len(psubs)-1) + 1
@@ -811,8 +811,8 @@ func TestGossipsubGraft(t *testing.T) {
 
 		time.Sleep(time.Second * 1)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := mrand.Intn(len(psubs))
 
@@ -862,8 +862,8 @@ func TestGossipsubRemovePeer(t *testing.T) {
 		// wait a heartbeat
 		time.Sleep(time.Second * 1)
 
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := 5 + mrand.Intn(len(psubs)-5)
 
@@ -893,7 +893,7 @@ func TestGossipsubGraftPruneRetry(t *testing.T) {
 
 		var topics []string
 		var msgs [][]*Subscription
-		for i := 0; i < 35; i++ {
+		for i := range 35 {
 			topic := fmt.Sprintf("topic%d", i)
 			topics = append(topics, topic)
 
@@ -913,7 +913,7 @@ func TestGossipsubGraftPruneRetry(t *testing.T) {
 		time.Sleep(time.Second * 5)
 
 		for i, topic := range topics {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := mrand.Intn(len(psubs))
 
@@ -962,7 +962,7 @@ func TestGossipsubControlPiggyback(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			owner := mrand.Intn(len(psubs))
-			for i := 0; i < 10000; i++ {
+			for range 10000 {
 				msg := []byte("background flooooood")
 				psubs[owner].Publish("flood", msg)
 			}
@@ -974,7 +974,7 @@ func TestGossipsubControlPiggyback(t *testing.T) {
 		// in the background flood
 		var topics []string
 		var msgs [][]*Subscription
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			topic := fmt.Sprintf("topic%d", i)
 			topics = append(topics, topic)
 
@@ -998,7 +998,7 @@ func TestGossipsubControlPiggyback(t *testing.T) {
 
 		// and test that we have functional overlays
 		for i, topic := range topics {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := mrand.Intn(len(psubs))
 
@@ -1042,8 +1042,8 @@ func TestMixedGossipsub(t *testing.T) {
 		// wait for heartbeats to build mesh
 		time.Sleep(time.Second * 2)
 
-		for i := 0; i < 100; i++ {
-			msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+		for i := range 100 {
+			msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 
 			owner := mrand.Intn(len(psubs))
 
@@ -1230,8 +1230,8 @@ func TestGossipsubStarTopology(t *testing.T) {
 		}
 
 		// send a message from each peer and assert it was propagated
-		for i := 0; i < 20; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 20 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i].Publish("test", msg)
 
 			for _, sub := range subs {
@@ -1328,8 +1328,8 @@ func TestGossipsubStarTopologyWithSignedPeerRecords(t *testing.T) {
 		}
 
 		// send a message from each peer and assert it was propagated
-		for i := 0; i < 20; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 20 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i].Publish("test", msg)
 
 			for _, sub := range subs {
@@ -1373,8 +1373,8 @@ func TestGossipsubDirectPeers(t *testing.T) {
 		time.Sleep(time.Second)
 
 		// publish some messages
-		for i := 0; i < 3; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 3 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i].Publish("test", msg)
 
 			for _, sub := range subs {
@@ -1394,8 +1394,8 @@ func TestGossipsubDirectPeers(t *testing.T) {
 		}
 
 		// publish some messages
-		for i := 0; i < 3; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 3 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i].Publish("test", msg)
 
 			for _, sub := range subs {
@@ -1524,8 +1524,8 @@ func TestGossipsubDirectPeersFanout(t *testing.T) {
 		time.Sleep(time.Second)
 
 		// h2 publishes some messages to build a fanout
-		for i := 0; i < 3; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 3 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[2].Publish("test", msg)
 
 			for _, sub := range subs {
@@ -1612,8 +1612,8 @@ func TestGossipsubFloodPublish(t *testing.T) {
 		time.Sleep(time.Second)
 
 		// send a message from the star and assert it was received
-		for i := 0; i < 20; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 20 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[0].Publish("test", msg)
 
 			for _, sub := range subs {
@@ -1746,8 +1746,8 @@ func TestGossipsubNegativeScore(t *testing.T) {
 
 		time.Sleep(3 * time.Second)
 
-		for i := 0; i < 20; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 20 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i%20].Publish("test", msg)
 			time.Sleep(20 * time.Millisecond)
 		}
@@ -2083,8 +2083,8 @@ func TestGossipsubOpportunisticGrafting(t *testing.T) {
 		}
 
 		// publish a bunch of messages from the real hosts
-		for i := 0; i < 1000; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 1000 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i%10].Publish("test", msg)
 			time.Sleep(20 * time.Millisecond)
 		}
@@ -2345,8 +2345,8 @@ func TestGossipsubPeerScoreInspect(t *testing.T) {
 
 		time.Sleep(time.Second)
 
-		for i := 0; i < 20; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 20 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i%2].Publish("test", msg)
 			time.Sleep(20 * time.Millisecond)
 		}
@@ -2567,7 +2567,7 @@ func TestGossipsubRPCFragmentation(t *testing.T) {
 		// publish a bunch of fairly large messages from the real host
 		nMessages := 1000
 		msgSize := 20000
-		for i := 0; i < nMessages; i++ {
+		for range nMessages {
 			msg := make([]byte, msgSize)
 			crand.Read(msg)
 			ps.Publish("test", msg)
@@ -2752,7 +2752,7 @@ func TestFragmentRPCFunction(t *testing.T) {
 			},
 		}
 		rpc.Publish = make([]*pb.Message, nMessages)
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			rpc.Publish[i] = mkMsg(msgSize)
 		}
 		results, err = fragmentRPC(rpc, limit)
@@ -2821,9 +2821,9 @@ func TestFragmentRPCFunction(t *testing.T) {
 		msgsPerTopic := 100 // enough that a single IHAVE or IWANT will exceed the limit
 		rpc.Control.Ihave = make([]*pb.ControlIHave, nTopics)
 		rpc.Control.Iwant = make([]*pb.ControlIWant, nTopics)
-		for i := 0; i < nTopics; i++ {
+		for i := range nTopics {
 			messageIds := make([]string, msgsPerTopic)
-			for m := 0; m < msgsPerTopic; m++ {
+			for m := range msgsPerTopic {
 				mid := make([]byte, messageIdSize)
 				crand.Read(mid)
 				messageIds[m] = string(mid)
@@ -2967,10 +2967,7 @@ func FuzzRPCSplit(f *testing.F) {
 	minMaxMsgSize := 100
 	maxMaxMsgSize := 2048
 	f.Fuzz(func(t *testing.T, data []byte) {
-		maxSize := int(generateU16(&data)) % maxMaxMsgSize
-		if maxSize < minMaxMsgSize {
-			maxSize = minMaxMsgSize
-		}
+		maxSize := max(int(generateU16(&data))%maxMaxMsgSize, minMaxMsgSize)
 		rpc := generateRPC(data, maxSize)
 
 		originalControl := compressedRPC{ihave: make(map[string][]string)}
@@ -3214,7 +3211,7 @@ func TestGossipsubIdontwantSend(t *testing.T) {
 						time.Sleep(100 * time.Millisecond)
 
 						// Publish messages from the first peer
-						for i := 0; i < 10; i++ {
+						for range 10 {
 							publishMsg()
 						}
 					}()
@@ -3545,7 +3542,7 @@ func TestGossipsubIdontwantNonMesh(t *testing.T) {
 						time.Sleep(100 * time.Millisecond)
 
 						// Publish messages from the first peer
-						for i := 0; i < 10; i++ {
+						for range 10 {
 							publishMsg()
 						}
 					}()
@@ -3635,7 +3632,7 @@ func TestGossipsubIdontwantIncompat(t *testing.T) {
 						time.Sleep(100 * time.Millisecond)
 
 						// Publish messages from the first peer
-						for i := 0; i < 10; i++ {
+						for range 10 {
 							publishMsg()
 						}
 					}()
@@ -3725,7 +3722,7 @@ func TestGossipsubIdontwantSmallMessage(t *testing.T) {
 						time.Sleep(100 * time.Millisecond)
 
 						// Publish messages from the first peer
-						for i := 0; i < 10; i++ {
+						for range 10 {
 							publishMsg()
 						}
 					}()
@@ -3965,7 +3962,7 @@ func TestGossipsubPruneMeshCorrectly(t *testing.T) {
 		params.Dhi = 8
 
 		psubs := make([]*PubSub, 9)
-		for i := 0; i < 9; i++ {
+		for i := range 9 {
 			psubs[i] = getGossipsub(ctx, hosts[i],
 				WithGossipSubParams(params),
 				WithMessageIdFn(msgID))
@@ -4037,7 +4034,7 @@ func TestRoundRobinMessageIDScheduler(t *testing.T) {
 						RPC: pb.RPC{
 							Publish: []*pb.Message{
 								{
-									Data: []byte(fmt.Sprintf("msg%d", i)),
+									Data: fmt.Appendf(nil, "msg%d", i),
 								},
 							},
 						},
@@ -4173,18 +4170,16 @@ func TestMessageBatchPublish(t *testing.T) {
 
 				var batch MessageBatch
 				var wg sync.WaitGroup
-				for i := 0; i < numMessages; i++ {
-					msg := []byte(fmt.Sprintf("%d it's not a floooooood %d", i, i))
+				for i := range numMessages {
+					msg := fmt.Appendf(nil, "%d it's not a floooooood %d", i, i)
 					if concurrentAdd {
-						wg.Add(1)
-						go func() {
-							defer wg.Done()
+						wg.Go(func() {
 							err := topics[0].AddToBatch(ctx, &batch, msg)
 							if err != nil {
 								t.Log(err)
 								t.Fail()
 							}
-						}()
+						})
 					} else {
 						err := topics[0].AddToBatch(ctx, &batch, msg)
 						if err != nil {
@@ -4205,7 +4200,7 @@ func TestMessageBatchPublish(t *testing.T) {
 							t.Fatal(err)
 						}
 						id := msgIDFn(got.Message)
-						expected := []byte(fmt.Sprintf("%s it's not a floooooood %s", id, id))
+						expected := fmt.Appendf(nil, "%s it's not a floooooood %s", id, id)
 						if !bytes.Equal(expected, got.Data) {
 							t.Fatal("got wrong message!")
 						}
@@ -4283,7 +4278,7 @@ func BenchmarkSplitRPCLargeMessages(b *testing.B) {
 		const numRPCs = 30
 		const msgSize = 50 * 1024
 		rpc := &RPC{}
-		for i := 0; i < numRPCs; i++ {
+		for range numRPCs {
 			addToRPC(rpc, 20, msgSize+r.Intn(100))
 		}
 
@@ -4299,7 +4294,7 @@ func BenchmarkSplitRPCLargeMessages(b *testing.B) {
 		const numRPCs = 2
 		const msgSize = DefaultMaxMessageSize - 100
 		rpc := &RPC{}
-		for i := 0; i < numRPCs; i++ {
+		for range numRPCs {
 			addToRPC(rpc, 1, msgSize)
 		}
 

--- a/internal/gologshim/gologshim.go
+++ b/internal/gologshim/gologshim.go
@@ -124,7 +124,7 @@ func parseIPFSGoLogEnv(loggingLevelEnvStr string) (slog.Level, map[string]slog.L
 	fallbackLvl := slog.LevelError
 	var systemToLevel map[string]slog.Level
 	if loggingLevelEnvStr != "" {
-		for _, kvs := range strings.Split(loggingLevelEnvStr, ",") {
+		for kvs := range strings.SplitSeq(loggingLevelEnvStr, ",") {
 			kv := strings.SplitN(kvs, "=", 2)
 			var lvl slog.Level
 			err := lvl.UnmarshalText([]byte(kv[len(kv)-1]))

--- a/mcache_test.go
+++ b/mcache_test.go
@@ -17,11 +17,11 @@ func TestMessageCache(t *testing.T) {
 		msgs[i] = makeTestMessage(i)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mcache.Put(&Message{Message: msgs[i]})
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mid := msgID(msgs[i])
 		m, ok := mcache.Get(mid)
 		if !ok {
@@ -38,7 +38,7 @@ func TestMessageCache(t *testing.T) {
 		t.Fatalf("Expected 10 gossip IDs; got %d", len(gids))
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mid := msgID(msgs[i])
 		if mid != gids[i] {
 			t.Fatalf("GossipID mismatch for message %d", i)
@@ -50,7 +50,7 @@ func TestMessageCache(t *testing.T) {
 		mcache.Put(&Message{Message: msgs[i]})
 	}
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		mid := msgID(msgs[i])
 		m, ok := mcache.Get(mid)
 		if !ok {
@@ -67,7 +67,7 @@ func TestMessageCache(t *testing.T) {
 		t.Fatalf("Expected 20 gossip IDs; got %d", len(gids))
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mid := msgID(msgs[i])
 		if mid != gids[10+i] {
 			t.Fatalf("GossipID mismatch for message %d", i)
@@ -105,7 +105,7 @@ func TestMessageCache(t *testing.T) {
 		t.Fatalf("Expected 50 messages in the cache; got %d", len(mcache.msgs))
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mid := msgID(msgs[i])
 		_, ok := mcache.Get(mid)
 		if ok {
@@ -130,7 +130,7 @@ func TestMessageCache(t *testing.T) {
 		t.Fatalf("Expected 30 gossip IDs; got %d", len(gids))
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		mid := msgID(msgs[50+i])
 		if mid != gids[i] {
 			t.Fatalf("GossipID mismatch for message %d", i)
@@ -156,7 +156,7 @@ func TestMessageCache(t *testing.T) {
 func makeTestMessage(n int) *pb.Message {
 	seqno := make([]byte, 8)
 	binary.BigEndian.PutUint64(seqno, uint64(n))
-	data := []byte(fmt.Sprintf("%d", n))
+	data := fmt.Appendf(nil, "%d", n)
 	topic := "test"
 	return &pb.Message{
 		Data:  data,

--- a/peer_gater_test.go
+++ b/peer_gater_test.go
@@ -60,7 +60,7 @@ func TestPeerGater(t *testing.T) {
 			t.Fatal("expected AcceptAll")
 		}
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			pg.RejectMessage(msg, RejectValidationIgnored)
 			pg.RejectMessage(msg, RejectValidationFailed)
 		}
@@ -76,7 +76,7 @@ func TestPeerGater(t *testing.T) {
 			t.Fatal("expected AcceptControl")
 		}
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			pg.DeliverMessage(msg)
 		}
 
@@ -91,7 +91,7 @@ func TestPeerGater(t *testing.T) {
 			t.Fatal("expected to accept at least once")
 		}
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			pg.decayStats()
 		}
 

--- a/peer_notify.go
+++ b/peer_notify.go
@@ -2,6 +2,7 @@ package pubsub
 
 import (
 	"context"
+	"slices"
 
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -12,7 +13,7 @@ import (
 func (ps *PubSub) watchForNewPeers(ctx context.Context) {
 	// We don't bother subscribing to "connectivity" events because we always run identify after
 	// every new connection.
-	sub, err := ps.host.EventBus().Subscribe([]interface{}{
+	sub, err := ps.host.EventBus().Subscribe([]any{
 		&event.EvtPeerIdentificationCompleted{},
 		&event.EvtPeerProtocolsUpdated{},
 	})
@@ -88,11 +89,8 @@ func (ps *PubSub) watchForNewPeers(ctx context.Context) {
 		// We don't bother checking connectivity (connected and non-"limited") here because
 		// we'll check when actually handling the new peer.
 
-		for _, p := range protos {
-			if supportsProtocol(p) {
-				ps.notifyNewPeer(peer)
-				break
-			}
+		if slices.ContainsFunc(protos, supportsProtocol) {
+			ps.notifyNewPeer(peer)
 		}
 	}
 

--- a/pubsub.go
+++ b/pubsub.go
@@ -268,7 +268,7 @@ type Message struct {
 	*pb.Message
 	ID            string
 	ReceivedFrom  peer.ID
-	ValidatorData interface{}
+	ValidatorData any
 	Local         bool
 }
 
@@ -1984,7 +1984,7 @@ func (p *PubSub) BlacklistPeer(pid peer.ID) {
 // By default validators are asynchronous, which means they will run in a separate goroutine.
 // The number of active goroutines is controlled by global and per topic validator
 // throttles; if it exceeds the throttle threshold, messages will be dropped.
-func (p *PubSub) RegisterTopicValidator(topic string, val interface{}, opts ...ValidatorOpt) error {
+func (p *PubSub) RegisterTopicValidator(topic string, val any, opts ...ValidatorOpt) error {
 	addVal := &addValReq{
 		topic:    topic,
 		validate: val,

--- a/randomsub_test.go
+++ b/randomsub_test.go
@@ -58,8 +58,8 @@ func TestRandomsubSmall(t *testing.T) {
 		time.Sleep(time.Second)
 
 		count := 0
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i].Publish("test", msg)
 
 			for _, sub := range subs {
@@ -97,8 +97,8 @@ func TestRandomsubBig(t *testing.T) {
 		time.Sleep(time.Second)
 
 		count := 0
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i].Publish("test", msg)
 
 			for _, sub := range subs {
@@ -138,8 +138,8 @@ func TestRandomsubMixed(t *testing.T) {
 		time.Sleep(time.Second)
 
 		count := 0
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i].Publish("test", msg)
 
 			for _, sub := range subs {

--- a/score.go
+++ b/score.go
@@ -154,7 +154,7 @@ type TopicScoreSnapshot struct {
 //     components for debugging peer scoring.
 //
 // This option must be passed _after_ the WithPeerScore option.
-func WithPeerScoreInspect(inspect interface{}, period time.Duration) Option {
+func WithPeerScoreInspect(inspect any, period time.Duration) Option {
 	return func(ps *PubSub) error {
 		gs, ok := ps.rt.(*GossipSubRouter)
 		if !ok {

--- a/score_test.go
+++ b/score_test.go
@@ -116,7 +116,7 @@ func TestScoreFirstMessageDeliveries(t *testing.T) {
 
 		// deliver a bunch of messages from peer A
 		nMessages := 100
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			pbMsg := makeTestMessage(i)
 			pbMsg.Topic = &mytopic
 			msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -159,7 +159,7 @@ func TestScoreFirstMessageDeliveriesCap(t *testing.T) {
 
 		// deliver a bunch of messages from peer A
 		nMessages := 100
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			pbMsg := makeTestMessage(i)
 			pbMsg.Topic = &mytopic
 			msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -202,7 +202,7 @@ func TestScoreFirstMessageDeliveriesDecay(t *testing.T) {
 
 		// deliver a bunch of messages from peer A
 		nMessages := 100
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			pbMsg := makeTestMessage(i)
 			pbMsg.Topic = &mytopic
 			msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -219,7 +219,7 @@ func TestScoreFirstMessageDeliveriesDecay(t *testing.T) {
 
 		// refreshing the scores applies the decay param
 		decayIntervals := 10
-		for i := 0; i < decayIntervals; i++ {
+		for range decayIntervals {
 			ps.refreshScores()
 			expected *= topicScoreParams.FirstMessageDeliveriesDecay
 		}
@@ -285,7 +285,7 @@ func TestScoreMeshMessageDeliveries(t *testing.T) {
 		// and duplicates outside the window from peer C.
 		nMessages := 100
 		wg := sync.WaitGroup{}
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			pbMsg := makeTestMessage(i)
 			pbMsg.Topic = &mytopic
 			msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -358,7 +358,7 @@ func TestScoreMeshMessageDeliveriesDecay(t *testing.T) {
 
 		// deliver messages from peer A
 		nMessages := 40
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			pbMsg := makeTestMessage(i)
 			pbMsg.Topic = &mytopic
 			msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -378,7 +378,7 @@ func TestScoreMeshMessageDeliveriesDecay(t *testing.T) {
 
 		// we need to refresh enough times for the decay to bring us below the threshold
 		decayedDeliveryCount := float64(nMessages) * topicScoreParams.MeshMessageDeliveriesDecay
-		for i := 0; i < 20; i++ {
+		for range 20 {
 			ps.refreshScores()
 			decayedDeliveryCount *= topicScoreParams.MeshMessageDeliveriesDecay
 		}
@@ -438,7 +438,7 @@ func TestScoreMeshFailurePenalty(t *testing.T) {
 
 		// deliver messages from peer A. peer B does nothing
 		nMessages := 100
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			pbMsg := makeTestMessage(i)
 			pbMsg.Topic = &mytopic
 			msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -504,7 +504,7 @@ func TestScoreInvalidMessageDeliveries(t *testing.T) {
 		ps.Graft(peerA, mytopic)
 
 		nMessages := 100
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			pbMsg := makeTestMessage(i)
 			pbMsg.Topic = &mytopic
 			msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -544,7 +544,7 @@ func TestScoreInvalidMessageDeliveriesDecay(t *testing.T) {
 		ps.Graft(peerA, mytopic)
 
 		nMessages := 100
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			pbMsg := makeTestMessage(i)
 			pbMsg.Topic = &mytopic
 			msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -559,7 +559,7 @@ func TestScoreInvalidMessageDeliveriesDecay(t *testing.T) {
 		}
 
 		// refresh scores a few times to apply decay
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			ps.refreshScores()
 			expected *= math.Pow(topicScoreParams.InvalidMessageDeliveriesDecay, 2)
 		}
@@ -1001,7 +1001,7 @@ func TestScoreRecapTopicParams(t *testing.T) {
 
 		// deliver a bunch of messages from peer A, with duplicates within the window from peer B,
 		nMessages := 100
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			pbMsg := makeTestMessage(i)
 			pbMsg.Topic = &mytopic
 			msg := Message{ReceivedFrom: peerA, Message: pbMsg}
@@ -1086,7 +1086,7 @@ func TestScoreResetTopicParams(t *testing.T) {
 
 		// reject a bunch of messages
 		nMessages := 100
-		for i := 0; i < nMessages; i++ {
+		for i := range nMessages {
 			pbMsg := makeTestMessage(i)
 			pbMsg.Topic = &mytopic
 			msg := Message{ReceivedFrom: peerA, Message: pbMsg}

--- a/tag_tracer_test.go
+++ b/tag_tracer_test.go
@@ -100,7 +100,7 @@ func TestTagTracerDeliveryTags(t *testing.T) {
 		tt.Join(topic1)
 		tt.Join(topic2)
 
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			// deliver only 5 messages to topic 2 (less than the cap)
 			topic := &topic1
 			if i < 5 {
@@ -191,9 +191,9 @@ func TestTagTracerDeliveryTagsNearFirst(t *testing.T) {
 				ReceivedFrom: p,
 				Message: &pb.Message{
 					From:  []byte(p),
-					Data:  []byte(fmt.Sprintf("msg-%d", i)),
+					Data:  fmt.Appendf(nil, "msg-%d", i),
 					Topic: &topic,
-					Seqno: []byte(fmt.Sprintf("%d", i)),
+					Seqno: fmt.Appendf(nil, "%d", i),
 				},
 			}
 

--- a/timecache/first_seen_cache_test.go
+++ b/timecache/first_seen_cache_test.go
@@ -37,13 +37,13 @@ func TestFirstSeenCacheExpire(t *testing.T) {
 		tc := newFirstSeenCacheWithSweepInterval(time.Second, time.Second)
 		defer tc.Done()
 
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			tc.Add(fmt.Sprint(i))
 			time.Sleep(time.Millisecond * 100)
 		}
 
 		time.Sleep(2 * time.Second)
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			if tc.Has(fmt.Sprint(i)) {
 				t.Fatalf("should have dropped this key: %s from the cache already", fmt.Sprint(i))
 			}

--- a/timecache/last_seen_cache_test.go
+++ b/timecache/last_seen_cache_test.go
@@ -24,13 +24,13 @@ func TestLastSeenCacheExpire(t *testing.T) {
 		tc := newLastSeenCacheWithSweepInterval(time.Second, time.Second)
 		defer tc.Done()
 
-		for i := 0; i < 11; i++ {
+		for i := range 11 {
 			tc.Add(fmt.Sprint(i))
 			time.Sleep(time.Millisecond * 100)
 		}
 
 		time.Sleep(2 * time.Second)
-		for i := 0; i < 11; i++ {
+		for i := range 11 {
 			if tc.Has(fmt.Sprint(i)) {
 				t.Fatalf("should have dropped this key: %s from the cache already", fmt.Sprint(i))
 			}

--- a/topic_test.go
+++ b/topic_test.go
@@ -310,7 +310,7 @@ func TestSubscriptionJoinNotification(t *testing.T) {
 		}
 
 		wg := sync.WaitGroup{}
-		for i := 0; i < numHosts; i++ {
+		for i := range numHosts {
 			peersFound := make(map[peer.ID]struct{})
 			topicPeersFound[i] = peersFound
 			evt := evts[i]
@@ -367,7 +367,7 @@ func TestSubscriptionLeaveNotification(t *testing.T) {
 		time.Sleep(time.Millisecond * 100)
 
 		wg := sync.WaitGroup{}
-		for i := 0; i < numHosts; i++ {
+		for i := range numHosts {
 			peersFound := make(map[peer.ID]struct{})
 			topicPeersFound[i] = peersFound
 			evt := evts[i]
@@ -591,7 +591,7 @@ func TestTopicRelay(t *testing.T) {
 
 		time.Sleep(time.Millisecond * 100)
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			msg := []byte("message")
 
 			owner := rand.Intn(len(topics))
@@ -1050,7 +1050,7 @@ func TestTopicRelayPublishWithKey(t *testing.T) {
 
 		time.Sleep(time.Second)
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			msg := []byte("message")
 
 			owner := rand.Intn(len(topics))

--- a/trace_test.go
+++ b/trace_test.go
@@ -96,11 +96,11 @@ func testWithTracer(t *testing.T, tracer EventTracer) {
 	time.Sleep(5 * time.Second)
 
 	// publish some messages
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		if i%7 == 0 {
 			psubs[i].Publish("test", []byte("invalid!"))
 		} else {
-			msg := []byte(fmt.Sprintf("message %d", i))
+			msg := fmt.Appendf(nil, "message %d", i)
 			psubs[i].Publish("test", msg)
 		}
 	}

--- a/validation.go
+++ b/validation.go
@@ -112,7 +112,7 @@ type validatorImpl struct {
 // async request to add a topic validators
 type addValReq struct {
 	topic    string
-	validate interface{}
+	validate any
 	timeout  time.Duration
 	throttle int
 	inline   bool
@@ -517,7 +517,7 @@ func (val *validatorImpl) validateMsg(ctx context.Context, src peer.ID, msg *Mes
 // WithDefaultValidator adds a validator that applies to all topics by default; it can be used
 // more than once and add multiple validators. Having a defult validator does not inhibit registering
 // a per topic validator.
-func WithDefaultValidator(val interface{}, opts ...ValidatorOpt) Option {
+func WithDefaultValidator(val any, opts ...ValidatorOpt) Option {
 	return func(ps *PubSub) error {
 		addVal := &addValReq{
 			validate: val,

--- a/validation_builtin_test.go
+++ b/validation_builtin_test.go
@@ -82,8 +82,8 @@ func testBasicSeqnoValidator(t *testing.T, ttl time.Duration) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	for i := 0; i < 100; i++ {
-		msg := []byte(fmt.Sprintf("%d the flooooooood %d", i, i))
+	for i := range 100 {
+		msg := fmt.Appendf(nil, "%d the flooooooood %d", i, i)
 
 		owner := rng.Intn(len(psubs))
 
@@ -131,8 +131,8 @@ func TestBasicSeqnoValidatorReplay(t *testing.T) {
 
 		time.Sleep(time.Millisecond * 100)
 
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("%d the flooooooood %d", i, i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "%d the flooooooood %d", i, i)
 
 			owner := rng.Intn(len(psubs))
 
@@ -274,7 +274,7 @@ func (r *replayActor) send(p peer.ID, rpc *pb.RPC) {
 
 func (r *replayActor) replay(msg *pb.Message) {
 	// replay the message 10 times to a random subset of peers
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		delay := time.Duration(1+rng.Intn(20)) * time.Millisecond
 		time.Sleep(delay)
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -243,8 +243,7 @@ func TestValidateOverload(t *testing.T) {
 				p := psubs[0]
 
 				var wg sync.WaitGroup
-				wg.Add(1)
-				go func() {
+				wg.Go(func() {
 					for _, tmsg := range tc.msgs {
 						select {
 						case msg := <-sub.ch:
@@ -258,8 +257,7 @@ func TestValidateOverload(t *testing.T) {
 							}
 						}
 					}
-					wg.Done()
-				}()
+				})
 
 				for _, tmsg := range tc.msgs {
 					err := p.Publish(topic, tmsg.msg)
@@ -330,8 +328,8 @@ func TestValidateAssortedOptions(t *testing.T) {
 
 		time.Sleep(time.Second)
 
-		for i := 0; i < 10; i++ {
-			msg := []byte(fmt.Sprintf("message %d", i))
+		for i := range 10 {
+			msg := fmt.Appendf(nil, "message %d", i)
 
 			psubs[i].Publish("test1", msg)
 			for _, sub := range subs1 {


### PR DESCRIPTION
This PR applies automated refactoring from go 1.26 (go fix ./...):

- `interface{}` to `any`, `slices.Contains`, `range` loops and other idiomatic updates.