### PR TITLE
rerun validation if node publishes a previously seen message

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -922,16 +922,16 @@ func (gs *GossipSubRouter) HandleRPC(rpc *RPC) {
 	}
 
 	iwant := gs.handleIHave(rpc.from, ctl)
-	ihave := gs.handleIWant(rpc.from, ctl)
+	msgs := gs.handleIWant(rpc.from, ctl)
 	prune := gs.handleGraft(rpc.from, ctl)
 	gs.handlePrune(rpc.from, ctl)
 	gs.handleIDontWant(rpc.from, ctl)
 
-	if len(iwant) == 0 && len(ihave) == 0 && len(prune) == 0 {
+	if len(iwant) == 0 && len(msgs) == 0 && len(prune) == 0 {
 		return
 	}
 
-	out := rpcWithControl(ihave, nil, iwant, nil, prune, nil)
+	out := rpcWithControl(msgs, nil, iwant, nil, prune, nil)
 	gs.sendRPC(rpc.from, out, false)
 }
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -922,16 +922,16 @@ func (gs *GossipSubRouter) HandleRPC(rpc *RPC) {
 	}
 
 	iwant := gs.handleIHave(rpc.from, ctl)
-	msgs := gs.handleIWant(rpc.from, ctl)
+	iWantResponses := gs.handleIWant(rpc.from, ctl)
 	prune := gs.handleGraft(rpc.from, ctl)
 	gs.handlePrune(rpc.from, ctl)
 	gs.handleIDontWant(rpc.from, ctl)
 
-	if len(iwant) == 0 && len(msgs) == 0 && len(prune) == 0 {
+	if len(iwant) == 0 && len(iWantResponses) == 0 && len(prune) == 0 {
 		return
 	}
 
-	out := rpcWithControl(msgs, nil, iwant, nil, prune, nil)
+	out := rpcWithControl(iWantResponses, nil, iwant, nil, prune, nil)
 	gs.sendRPC(rpc.from, out, false)
 }
 

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	crand "crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -5817,6 +5818,167 @@ func TestGossipsubFanoutOnlyRelay(t *testing.T) {
 		_, err = topic.Relay()
 		if !errors.Is(err, ErrFanoutOnlyTopic) {
 			t.Fatalf("expected ErrFanoutOnlyTopic, got: %v", err)
+		}
+	})
+}
+
+func TestGossipsubDuplicatePublishError(t *testing.T) {
+	// republishing a rejected message must rerun validation and return the
+	// rejection error again, not report success as a duplicate
+	synctestTest(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		hosts := getDefaultHosts(t, 1)
+		psubs := getGossipsubs(ctx, hosts)
+
+		allReject := func(ctx context.Context, p peer.ID, msg *Message) ValidationResult {
+			return ValidationReject
+		}
+		err := psubs[0].RegisterTopicValidator("test", allReject)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		topic, err := psubs[0].Join("test", WithTopicMessageIdFn(func(pmsg *pb.Message) string {
+			return "message-1"
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := topic.Publish(ctx, []byte("hello")); err == nil {
+			t.Fatal("expected rejection error on publish")
+		}
+
+		if err := topic.Publish(ctx, []byte("hello")); err == nil {
+			t.Fatal("expected rejection error on republish")
+		}
+	})
+}
+
+func TestGossipsubForwardAfterIgnore(t *testing.T) {
+	// uses a linear chain 0-1-2-3-4 where node k=2 ignores relayed messages, so the
+	// message stops at k until k republishes it locally and it reaches the rest
+	synctestTest(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		const N = 5
+		hosts := getDefaultHosts(t, N)
+		psubs := getGossipsubs(ctx, hosts)
+		for i := range N - 1 {
+			connect(t, hosts[i], hosts[i+1])
+		}
+		var topics []*Topic
+		for i := range N {
+			topic, err := psubs[i].Join("test", WithTopicMessageIdFn(func(pmsg *pb.Message) string {
+				hash := sha256.Sum256(pmsg.Data)
+				return string(hash[:])
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			topics = append(topics, topic)
+		}
+
+		var subs []*Subscription
+		for i := range N {
+			sub, err := topics[i].Subscribe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			subs = append(subs, sub)
+		}
+
+		time.Sleep(2 * time.Second)
+
+		// node k ignores the message and republishes it later
+		const k = 2
+		ignoreAllNonLocal := func(ctx context.Context, p peer.ID, msg *Message) ValidationResult {
+			// only accept locally published messages
+			if p == hosts[k].ID() {
+				return ValidationAccept
+			}
+			return ValidationIgnore
+		}
+		err := psubs[k].RegisterTopicValidator("test", ignoreAllNonLocal)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		publishedMessage := []byte("hello")
+		if err := topics[0].Publish(ctx, publishedMessage); err != nil {
+			t.Fatal(err)
+		}
+
+		for i := range k {
+			assertReceive(t, subs[i], publishedMessage)
+		}
+		for i := k; i < N; i++ {
+			assertNeverReceives(t, subs[i], time.Second)
+		}
+
+		if err := topics[k].Publish(ctx, publishedMessage); err != nil {
+			t.Fatal(err)
+		}
+
+		for i := k; i < N; i++ {
+			assertReceive(t, subs[i], publishedMessage)
+		}
+		// nodes before k must not receive the republished message again
+		for i := range k {
+			assertNeverReceives(t, subs[i], time.Second)
+		}
+	})
+}
+
+func TestGossipsubDuplicatePublishDeliveredOnce(t *testing.T) {
+	// republishing an already-delivered message must not deliver it to local
+	// subscribers or the network a second time
+	synctestTest(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		hosts := getDefaultHosts(t, 2)
+		psubs := getGossipsubs(ctx, hosts)
+		connect(t, hosts[0], hosts[1])
+
+		var topics []*Topic
+		var subs []*Subscription
+		for i := range 2 {
+			topic, err := psubs[i].Join("test", WithTopicMessageIdFn(func(pmsg *pb.Message) string {
+				hash := sha256.Sum256(pmsg.Data)
+				return string(hash[:])
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			topics = append(topics, topic)
+
+			sub, err := topic.Subscribe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			subs = append(subs, sub)
+		}
+
+		time.Sleep(2 * time.Second)
+
+		publishedMessage := []byte("hello")
+		if err := topics[0].Publish(ctx, publishedMessage); err != nil {
+			t.Fatal(err)
+		}
+		for i := range 2 {
+			assertReceive(t, subs[i], publishedMessage)
+		}
+
+		// republishing a delivered message is a no-op reported as success
+		if err := topics[0].Publish(ctx, publishedMessage); err != nil {
+			t.Fatal(err)
+		}
+		for i := range 2 {
+			assertNeverReceives(t, subs[i], time.Second)
 		}
 	})
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -1612,7 +1612,7 @@ func (p *PubSub) publishMessage(msg *Message) {
 }
 
 func (p *PubSub) publishMessageBatch(batchAndOpts messageBatchAndPublishOptions) {
-	msgs := make([]*Message, 0, len(batchAndOpts.messages))
+	msgs := batchAndOpts.messages[:0]
 	for _, msg := range batchAndOpts.messages {
 		if !p.markDelivered(p.idGen.ID(msg)) {
 			continue
@@ -1620,6 +1620,7 @@ func (p *PubSub) publishMessageBatch(batchAndOpts messageBatchAndPublishOptions)
 		p.notifySubs(msg)
 		msgs = append(msgs, msg)
 	}
+
 	// We type checked when pushing the batch to the channel
 	p.rt.(BatchPublisher).PublishBatch(msgs, batchAndOpts.opts)
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -175,6 +175,11 @@ type PubSub struct {
 	seenMsgTTL      time.Duration
 	seenMsgStrategy timecache.Strategy
 
+	// deliveredMessages tracks messages delivered to subscribers and routed to peers.
+	// It deduplicates publishes of already-delivered messages, while still allowing
+	// republishes of messages that were only seen (e.g. ValidationIgnore).
+	deliveredMessages timecache.TimeCache
+
 	// generator used to compute the ID for a message
 	idGen *msgIDGenerator
 
@@ -612,6 +617,7 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 	}
 
 	ps.seenMessages = timecache.NewTimeCacheWithStrategy(ps.seenMsgStrategy, ps.seenMsgTTL)
+	ps.deliveredMessages = timecache.NewTimeCacheWithStrategy(ps.seenMsgStrategy, ps.seenMsgTTL)
 
 	if err := ps.disc.Start(ps); err != nil {
 		return nil, err
@@ -880,6 +886,7 @@ func (p *PubSub) processLoop(ctx context.Context) {
 		p.peers = nil
 		p.topics = nil
 		p.seenMessages.Done()
+		p.deliveredMessages.Done()
 	}()
 
 	for {
@@ -1336,6 +1343,8 @@ func (p *PubSub) doAnnounceRetry(pid peer.ID, topic string, sub bool) {
 // notifySubs sends a given message to all corresponding subscribers.
 // Only called from processLoop.
 func (p *PubSub) notifySubs(msg *Message) {
+	p.tracer.DeliverMessage(msg)
+
 	topic := msg.GetTopic()
 	subs := p.mySubs[topic]
 	for f := range subs {
@@ -1360,6 +1369,12 @@ func (p *PubSub) seenMessage(id string) bool {
 // returns true if the message was freshly marked
 func (p *PubSub) markSeen(id string) bool {
 	return p.seenMessages.Add(id)
+}
+
+// markDelivered marks a message as delivered to subscribers and routed to peers.
+// returns true if the message was freshly marked
+func (p *PubSub) markDelivered(id string) bool {
+	return p.deliveredMessages.Add(id)
 }
 
 // subscribedToMessage returns whether we are subscribed to one of the topics
@@ -1587,7 +1602,9 @@ func (p *PubSub) checkSigningPolicy(msg *Message) error {
 }
 
 func (p *PubSub) publishMessage(msg *Message) {
-	p.tracer.DeliverMessage(msg)
+	if !p.markDelivered(p.idGen.ID(msg)) {
+		return
+	}
 	p.notifySubs(msg)
 	if !msg.Local {
 		p.rt.Publish(msg)
@@ -1595,12 +1612,16 @@ func (p *PubSub) publishMessage(msg *Message) {
 }
 
 func (p *PubSub) publishMessageBatch(batchAndOpts messageBatchAndPublishOptions) {
+	msgs := make([]*Message, 0, len(batchAndOpts.messages))
 	for _, msg := range batchAndOpts.messages {
-		p.tracer.DeliverMessage(msg)
+		if !p.markDelivered(p.idGen.ID(msg)) {
+			continue
+		}
 		p.notifySubs(msg)
+		msgs = append(msgs, msg)
 	}
 	// We type checked when pushing the batch to the channel
-	p.rt.(BatchPublisher).PublishBatch(batchAndOpts.messages, batchAndOpts.opts)
+	p.rt.(BatchPublisher).PublishBatch(msgs, batchAndOpts.opts)
 }
 
 type addTopicReq struct {

--- a/topic.go
+++ b/topic.go
@@ -247,11 +247,6 @@ func setDefaultBatchPublishOptions(opts *BatchPublishOptions) {
 func (t *Topic) Publish(ctx context.Context, data []byte, opts ...PubOpt) error {
 	msg, err := t.validate(ctx, data, opts...)
 	if err != nil {
-		if errors.Is(err, dupeErr{}) {
-			// If it was a duplicate, we return nil to indicate success.
-			// Semantically the message was published by us or someone else.
-			return nil
-		}
 		return err
 	}
 	return t.p.val.sendMsgBlocking(msg)
@@ -260,12 +255,6 @@ func (t *Topic) Publish(ctx context.Context, data []byte, opts ...PubOpt) error 
 func (t *Topic) AddToBatch(ctx context.Context, batch *MessageBatch, data []byte, opts ...PubOpt) error {
 	msg, err := t.validate(ctx, data, opts...)
 	if err != nil {
-		if errors.Is(err, dupeErr{}) {
-			// If it was a duplicate, we return nil to indicate success.
-			// Semantically the message was published by us or someone else.
-			// We won't add it to the batch. Since it's already been published.
-			return nil
-		}
 		return err
 	}
 	batch.add(msg)

--- a/validation.go
+++ b/validation.go
@@ -27,12 +27,6 @@ func (e ValidationError) Error() string {
 	return e.Reason
 }
 
-type dupeErr struct{}
-
-func (dupeErr) Error() string {
-	return "duplicate message"
-}
-
 // Validator is a function that validates a message with a binary decision: accept or reject.
 type Validator func(context.Context, peer.ID, *Message) bool
 
@@ -309,9 +303,13 @@ func (v *validation) sendMsgBlocking(msg *Message) error {
 }
 
 // validate performs validation and only calls onValid if all validators succeed.
-// If synchronous is true, onValid will be called before this function returns
-// if the message is new and accepted.
-func (v *validation) validate(vals []*validatorImpl, src peer.ID, msg *Message, synchronous bool, onValid func(*Message) error) error {
+// If local is true,
+//  1. validation is run even if the message was seen before, and all validators are
+//     run synchronously in the calling goroutine.
+//  2. if the message is accepted, onValid is called before this function returns.
+func (v *validation) validate(
+	vals []*validatorImpl, src peer.ID, msg *Message, local bool, onValid func(*Message) error,
+) error {
 	// If signature verification is enabled, but signing is disabled,
 	// the Signature is required to be nil upon receiving the message in PubSub.pushMsg.
 	if msg.Signature != nil {
@@ -325,16 +323,20 @@ func (v *validation) validate(vals []*validatorImpl, src peer.ID, msg *Message, 
 	// we can mark the message as seen now that we have verified the signature
 	// and avoid invoking user validators more than once
 	id := v.p.idGen.ID(msg)
-	if !v.p.markSeen(id) {
+	// Validate again if it's a local publish that was seen but never delivered
+	// (ValidationIgnore), so the node can still forward it. Publishes of already
+	// delivered messages are a no-op; publishMessage dedups any that race past.
+	if (!v.p.markSeen(id) && !local) || v.p.deliveredMessages.Has(id) {
 		v.tracer.DuplicateMessage(msg)
-		return dupeErr{}
+		return nil
 	} else {
 		v.tracer.ValidateMessage(msg)
 	}
 
 	var inline, async []*validatorImpl
 	for _, val := range vals {
-		if val.validateInline || synchronous {
+		// run validation synchronously if it's a local publish.
+		if val.validateInline || local {
 			inline = append(inline, val)
 		} else {
 			async = append(async, val)


### PR DESCRIPTION
This allows the node to publish messages that were previously ignored/rejected for whatever reason. Forwarding only happens once. 

This is a problem in ethereum when a node sees a block very early and attests immediately. If the node pushed the attestation as fanout, it'd mean that the fanout peers if they've not seen the block with park the message for later processing(ValidationIgnore). But now when they later do see the block and process the attestation, they won't forward the attestation to the mesh again. See test `TestGossipsubForwardAfterIgnore`

This will always rerun validation on locally published messages which don't pass validation. I think this is okay as it's strictly for locally published messages and not network received messages. 

@Wondertan does this change break anything for you? 