### PR TITLE
test: wait for topic membership in TestGossipsubFloodPublish

### DIFF
--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -1609,7 +1609,12 @@ func TestGossipsubFloodPublish(t *testing.T) {
 			subs = append(subs, sub)
 		}
 
-		time.Sleep(time.Second)
+		// Flood publish only sends to peers currently in the topic map. With
+		// simlibp2p latency, a fixed sleep can resume before subscription
+		// RPCs are applied, so wait until the hub sees every leaf.
+		for len(psubs[0].ListPeers("test")) < len(hosts)-1 {
+			time.Sleep(10 * time.Millisecond)
+		}
 
 		// send a message from the star and assert it was received
 		for i := 0; i < 20; i++ {


### PR DESCRIPTION
Fixes a test hang

Flood publish only sends to peers already in the topic map. With simlibp2p latency, a fixed sleep can resume before subscription RPCs are applied, so the hub publishes to an incomplete peer set and assertReceive times out. Poll ListPeers until all leaves are visible.

Assisted-by: Cursor and GPT-5.6-sol