### PR TITLE
Track outstanding IWANTs correctly

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -82,7 +82,7 @@ var (
 	GossipSubIDontWantMessageThreshold        = 1024 // 1KB
 	GossipSubIDontWantMessageTTL              = 3    // 3 heartbeats
 
-	GossipSubMaxIWantsPerMessageIDPerHeartbeat = 10
+	GossipSubMaxIWantsPerMessageID = 10
 )
 
 type checksum struct {
@@ -249,10 +249,13 @@ type GossipSubParams struct {
 	// IDONTWANT is cleared when it's older than the TTL.
 	IDontWantMessageTTL int
 
-	// MaxIWantsPerMessageIDPerHeartbeat is the maximum number of pending IWANT
-	// requests allowed per message ID per heartbeat. This helps limit the
-	// number of duplicates we'll receive from peers.
-	MaxIWantsPerMessageIDPerHeartbeat int
+	// MaxIWantsPerMessageID is the maximum number of IWANT requests allowed
+	// per message ID while requests are outstanding. This helps limit the
+	// number of duplicates we'll receive from peers. The budget for a message
+	// ID refills IWantFollowupTime after its last request, so a request that
+	// went unanswered can be retried without waiting for a heartbeat boundary
+	// and a request in flight is not re-issued at one.
+	MaxIWantsPerMessageID int
 }
 
 func (params *GossipSubParams) validate() error {
@@ -321,10 +324,9 @@ func DefaultGossipSubRouter(h host.Host) *GossipSubRouter {
 		tagTracer:       newTagTracer(h.ConnManager()),
 		params:          params,
 		reducePXRecords: defaultPXRecordReducer,
-		// number of allowed IWANTs per message ID. If the message ID is
-		// missing, it must be initialized to
-		// `MaxIWantsPerMessageIDPerHeartbeat`
-		allowedIWantCount: make(map[string]int),
+		// remaining IWANT budget per message ID. A missing or expired entry
+		// stands for a full budget of `MaxIWantsPerMessageID`.
+		allowedIWantCount: make(map[string]iwantBudget),
 	}
 
 	rt.extensions = newExtensionsState(PeerExtensions{}, func(p peer.ID) {
@@ -373,7 +375,7 @@ func DefaultGossipSubParams() GossipSubParams {
 		IDontWantMessageTTL:       GossipSubIDontWantMessageTTL,
 		SlowHeartbeatWarning:      0.1,
 
-		MaxIWantsPerMessageIDPerHeartbeat: GossipSubMaxIWantsPerMessageIDPerHeartbeat,
+		MaxIWantsPerMessageID: GossipSubMaxIWantsPerMessageID,
 	}
 }
 
@@ -620,9 +622,9 @@ type GossipSubRouter struct {
 	connect      chan connectInfo                 // px connection requests
 	cab          peerstore.AddrBook
 
-	// allowed number of IWANTs per message ID. Must be initialized to
-	// `MaxIWantsPerMessageIDPerHeartbeat` if message id is missing.
-	allowedIWantCount map[string]int
+	// remaining IWANT budget per message ID. A missing or expired entry
+	// stands for a full budget of `MaxIWantsPerMessageID`.
+	allowedIWantCount map[string]iwantBudget
 
 	protos  []protocol.ID
 	feature GossipSubFeatureTest
@@ -997,19 +999,22 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 				continue
 			}
 
-			allowedIWants, ok := gs.allowedIWantCount[mid]
-			if !ok {
-				allowedIWants = gs.params.MaxIWantsPerMessageIDPerHeartbeat
+			now := time.Now()
+			budget, ok := gs.allowedIWantCount[mid]
+			if !ok || now.After(budget.renewAt) {
+				budget = iwantBudget{remaining: gs.params.MaxIWantsPerMessageID}
 			}
 
 			// Check if we've exceeded the maximum number of pending IWANTs for this message
-			if allowedIWants <= 0 {
+			if budget.remaining <= 0 {
 				gs.logger.Debug("IHAVE: ignoring IHAVE; too many inflight IWANTs", "message", mid, "peer", p)
 				continue
 			}
 
 			iwant[mid] = struct{}{}
-			gs.allowedIWantCount[mid] = allowedIWants - 1
+			budget.remaining--
+			budget.renewAt = now.Add(gs.params.IWantFollowupTime)
+			gs.allowedIWantCount[mid] = budget
 		}
 	}
 
@@ -1694,8 +1699,9 @@ func (gs *GossipSubRouter) heartbeat() {
 	toprune := make(map[peer.ID][]string)
 	noPX := make(map[peer.ID]bool)
 
-	// reset number of allowed IWANT requests
-	gs.resetAllowedIWants()
+	// drop expired IWANT budgets; refill happens per entry, IWantFollowupTime
+	// after the last request, not at the heartbeat
+	gs.pruneAllowedIWants()
 
 	// clean up expired backoffs
 	gs.clearBackoff()
@@ -1948,10 +1954,22 @@ func (gs *GossipSubRouter) heartbeat() {
 	gs.extensions.Heartbeat()
 }
 
-func (gs *GossipSubRouter) resetAllowedIWants() {
-	if len(gs.allowedIWantCount) > 0 {
-		// throw away the old map and make a new one
-		gs.allowedIWantCount = make(map[string]int)
+// iwantBudget tracks how many more IWANTs may be sent for a message ID and
+// when the budget refills. Refilling per entry rather than resetting all
+// entries at the heartbeat avoids re-requesting a message whose IWANT is
+// still in flight when a heartbeat fires, and lets an unanswered request be
+// retried without waiting for the next heartbeat boundary.
+type iwantBudget struct {
+	remaining int
+	renewAt   time.Time
+}
+
+func (gs *GossipSubRouter) pruneAllowedIWants() {
+	now := time.Now()
+	for mid, budget := range gs.allowedIWantCount {
+		if now.After(budget.renewAt) {
+			delete(gs.allowedIWantCount, mid)
+		}
 	}
 }
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -249,12 +249,12 @@ type GossipSubParams struct {
 	// IDONTWANT is cleared when it's older than the TTL.
 	IDontWantMessageTTL int
 
-	// MaxIWantsPerMessageID is the maximum number of IWANT requests allowed
-	// per message ID while requests are outstanding. This helps limit the
-	// number of duplicates we'll receive from peers. The budget for a message
-	// ID refills IWantFollowupTime after its last request, so a request that
-	// went unanswered can be retried without waiting for a heartbeat boundary
-	// and a request in flight is not re-issued at one.
+	// MaxIWantsPerMessageID is the maximum number of IWANT requests kept
+	// outstanding per message ID at once, spread across distinct peers. It
+	// bounds how many logically-live requests a single message can have, and so
+	// how many duplicate deliveries it tends to draw. An outstanding request
+	// expires IWantFollowupTime after it was sent, which frees a slot and lets
+	// the message be requested again without waiting for a heartbeat boundary.
 	MaxIWantsPerMessageID int
 }
 
@@ -265,6 +265,14 @@ func (params *GossipSubParams) validate() error {
 
 	if !(params.Dscore <= params.Dhi) {
 		return fmt.Errorf("param Dscore=%d must be lower than or equal to  Dhi=%d", params.Dscore, params.Dhi)
+	}
+
+	if params.MaxIWantsPerMessageID <= 0 {
+		return fmt.Errorf("param MaxIWantsPerMessageID=%d must be positive", params.MaxIWantsPerMessageID)
+	}
+
+	if params.IWantFollowupTime <= 0 {
+		return fmt.Errorf("param IWantFollowupTime=%s must be positive", params.IWantFollowupTime)
 	}
 
 	// Bootstrappers set D=D_lo=D_hi=D_out=0
@@ -324,9 +332,8 @@ func DefaultGossipSubRouter(h host.Host) *GossipSubRouter {
 		tagTracer:       newTagTracer(h.ConnManager()),
 		params:          params,
 		reducePXRecords: defaultPXRecordReducer,
-		// remaining IWANT budget per message ID. A missing or expired entry
-		// stands for a full budget of `MaxIWantsPerMessageID`.
-		allowedIWantCount: make(map[string]iwantBudget),
+		// outstanding IWANTs per message ID, by peer and send time.
+		outstandingIWants: make(map[string]iwantLedger),
 	}
 
 	rt.extensions = newExtensionsState(PeerExtensions{}, func(p peer.ID) {
@@ -622,9 +629,9 @@ type GossipSubRouter struct {
 	connect      chan connectInfo                 // px connection requests
 	cab          peerstore.AddrBook
 
-	// remaining IWANT budget per message ID. A missing or expired entry
-	// stands for a full budget of `MaxIWantsPerMessageID`.
-	allowedIWantCount map[string]iwantBudget
+	// outstanding IWANTs per message ID, by peer and send time. Bounds how
+	// many distinct peers we ask for a given message at once.
+	outstandingIWants map[string]iwantLedger
 
 	protos  []protocol.ID
 	feature GossipSubFeatureTest
@@ -896,7 +903,6 @@ func (gs *GossipSubRouter) Preprocess(from peer.ID, msgs []*Message) {
 	tmids := make(map[string][]string)
 	for _, msg := range msgs {
 		mid := gs.p.idGen.ID(msg)
-		delete(gs.allowedIWantCount, mid)
 		if len(msg.GetData()) < gs.params.IDontWantMessageThreshold {
 			continue
 		}
@@ -975,6 +981,7 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 		return nil
 	}
 
+	now := time.Now()
 	iwant := make(map[string]struct{})
 	for _, ihave := range ctl.GetIhave() {
 		topic := ihave.GetTopicID()
@@ -999,22 +1006,12 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 				continue
 			}
 
-			now := time.Now()
-			budget, ok := gs.allowedIWantCount[mid]
-			if !ok || now.After(budget.renewAt) {
-				budget = iwantBudget{remaining: gs.params.MaxIWantsPerMessageID}
-			}
-
-			// Check if we've exceeded the maximum number of pending IWANTs for this message
-			if budget.remaining <= 0 {
-				gs.logger.Debug("IHAVE: ignoring IHAVE; too many inflight IWANTs", "message", mid, "peer", p)
+			if !gs.canRequestIWant(mid, p, now) {
+				gs.logger.Debug("IHAVE: ignoring IHAVE; too many inflight IWANTs or peer already asked", "message", mid, "peer", p)
 				continue
 			}
 
 			iwant[mid] = struct{}{}
-			budget.remaining--
-			budget.renewAt = now.Add(gs.params.IWantFollowupTime)
-			gs.allowedIWantCount[mid] = budget
 		}
 	}
 
@@ -1040,6 +1037,12 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 	// truncate to the messages we are actually asking for and update the iasked counter
 	iwantlst = iwantlst[:iask]
 	gs.iasked[p] += iask
+
+	// record the asks only for the messages we are actually sending, so a
+	// request dropped by truncation leaves no phantom entry in the ledger
+	for _, mid := range iwantlst {
+		gs.recordIWant(mid, p, now)
+	}
 
 	gs.gossipTracer.AddPromise(p, iwantlst)
 
@@ -1369,6 +1372,7 @@ func (gs *GossipSubRouter) connector() {
 func (gs *GossipSubRouter) PublishBatch(messages []*Message, opts *BatchPublishOptions) {
 	strategy := opts.Strategy
 	for _, msg := range messages {
+		gs.fulfillIWant(msg)
 		msgID := gs.p.idGen.ID(msg)
 		for p, rpc := range gs.rpcs(msg) {
 			strategy.AddRPC(p, msgID, rpc)
@@ -1381,6 +1385,7 @@ func (gs *GossipSubRouter) PublishBatch(messages []*Message, opts *BatchPublishO
 }
 
 func (gs *GossipSubRouter) Publish(msg *Message) {
+	gs.fulfillIWant(msg)
 	for p, rpc := range gs.rpcs(msg) {
 		gs.sendRPC(p, rpc, false)
 	}
@@ -1699,9 +1704,8 @@ func (gs *GossipSubRouter) heartbeat() {
 	toprune := make(map[peer.ID][]string)
 	noPX := make(map[peer.ID]bool)
 
-	// drop expired IWANT budgets; refill happens per entry, IWantFollowupTime
-	// after the last request, not at the heartbeat
-	gs.pruneAllowedIWants()
+	// drop expired outstanding IWANTs so their slots free up
+	gs.pruneOutstandingIWants()
 
 	// clean up expired backoffs
 	gs.clearBackoff()
@@ -1954,21 +1958,58 @@ func (gs *GossipSubRouter) heartbeat() {
 	gs.extensions.Heartbeat()
 }
 
-// iwantBudget tracks how many more IWANTs may be sent for a message ID and
-// when the budget refills. Refilling per entry rather than resetting all
-// entries at the heartbeat avoids re-requesting a message whose IWANT is
-// still in flight when a heartbeat fires, and lets an unanswered request be
-// retried without waiting for the next heartbeat boundary.
-type iwantBudget struct {
-	remaining int
-	renewAt   time.Time
+// iwantLedger records, per peer, when we sent that peer an IWANT for a message
+// ID. An entry older than IWantFollowupTime has expired: it no longer counts
+// against MaxIWantsPerMessageID and the peer may be asked again.
+type iwantLedger map[peer.ID]time.Time
+
+// expireAsks drops asks whose follow-up time has passed, freeing their slots.
+func (gs *GossipSubRouter) expireAsks(ledger iwantLedger, now time.Time) {
+	for ap, at := range ledger {
+		if now.Sub(at) >= gs.params.IWantFollowupTime {
+			delete(ledger, ap)
+		}
+	}
 }
 
-func (gs *GossipSubRouter) pruneAllowedIWants() {
+// canRequestIWant reports whether an IWANT for mid may be sent to p, expiring
+// stale asks first. It does not record the request; recordIWant does that once
+// the message survives per-peer truncation, so a request dropped by truncation
+// leaves no phantom entry in the ledger.
+func (gs *GossipSubRouter) canRequestIWant(mid string, p peer.ID, now time.Time) bool {
+	ledger := gs.outstandingIWants[mid]
+	if ledger == nil {
+		return true
+	}
+	gs.expireAsks(ledger, now)
+	if _, asked := ledger[p]; asked {
+		return false
+	}
+	return len(ledger) < gs.params.MaxIWantsPerMessageID
+}
+
+// recordIWant notes that an IWANT for mid was sent to p at now.
+func (gs *GossipSubRouter) recordIWant(mid string, p peer.ID, now time.Time) {
+	ledger := gs.outstandingIWants[mid]
+	if ledger == nil {
+		ledger = make(iwantLedger)
+		gs.outstandingIWants[mid] = ledger
+	}
+	ledger[p] = now
+}
+
+// fulfillIWant clears any outstanding IWANTs for a message once it has been
+// received and validated.
+func (gs *GossipSubRouter) fulfillIWant(msg *Message) {
+	delete(gs.outstandingIWants, gs.p.idGen.ID(msg))
+}
+
+func (gs *GossipSubRouter) pruneOutstandingIWants() {
 	now := time.Now()
-	for mid, budget := range gs.allowedIWantCount {
-		if now.After(budget.renewAt) {
-			delete(gs.allowedIWantCount, mid)
+	for mid, ledger := range gs.outstandingIWants {
+		gs.expireAsks(ledger, now)
+		if len(ledger) == 0 {
+			delete(gs.outstandingIWants, mid)
 		}
 	}
 }

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -81,6 +81,8 @@ var (
 	GossipSubIWantFollowupTime                = 3 * time.Second
 	GossipSubIDontWantMessageThreshold        = 1024 // 1KB
 	GossipSubIDontWantMessageTTL              = 3    // 3 heartbeats
+
+	GossipSubMaxIWantsPerMessageIDPerHeartbeat = 10
 )
 
 type checksum struct {
@@ -246,6 +248,11 @@ type GossipSubParams struct {
 
 	// IDONTWANT is cleared when it's older than the TTL.
 	IDontWantMessageTTL int
+
+	// MaxIWantsPerMessageIDPerHeartbeat is the maximum number of pending IWANT
+	// requests allowed per message ID per heartbeat. This helps limit the
+	// number of duplicates we'll receive from peers.
+	MaxIWantsPerMessageIDPerHeartbeat int
 }
 
 func (params *GossipSubParams) validate() error {
@@ -314,6 +321,10 @@ func DefaultGossipSubRouter(h host.Host) *GossipSubRouter {
 		tagTracer:       newTagTracer(h.ConnManager()),
 		params:          params,
 		reducePXRecords: defaultPXRecordReducer,
+		// number of allowed IWANTs per message ID. If the message ID is
+		// missing, it must be initialized to
+		// `MaxIWantsPerMessageIDPerHeartbeat`
+		allowedIWantCount: make(map[string]int),
 	}
 
 	rt.extensions = newExtensionsState(PeerExtensions{}, func(p peer.ID) {
@@ -361,6 +372,8 @@ func DefaultGossipSubParams() GossipSubParams {
 		IDontWantMessageThreshold: GossipSubIDontWantMessageThreshold,
 		IDontWantMessageTTL:       GossipSubIDontWantMessageTTL,
 		SlowHeartbeatWarning:      0.1,
+
+		MaxIWantsPerMessageIDPerHeartbeat: GossipSubMaxIWantsPerMessageIDPerHeartbeat,
 	}
 }
 
@@ -606,6 +619,10 @@ type GossipSubRouter struct {
 	backoff      map[string]map[peer.ID]time.Time // prune backoff
 	connect      chan connectInfo                 // px connection requests
 	cab          peerstore.AddrBook
+
+	// allowed number of IWANTs per message ID. Must be initialized to
+	// `MaxIWantsPerMessageIDPerHeartbeat` if message id is missing.
+	allowedIWantCount map[string]int
 
 	protos  []protocol.ID
 	feature GossipSubFeatureTest
@@ -876,11 +893,13 @@ func (gs *GossipSubRouter) AcceptFrom(p peer.ID) AcceptStatus {
 func (gs *GossipSubRouter) Preprocess(from peer.ID, msgs []*Message) {
 	tmids := make(map[string][]string)
 	for _, msg := range msgs {
+		mid := gs.p.idGen.ID(msg)
+		delete(gs.allowedIWantCount, mid)
 		if len(msg.GetData()) < gs.params.IDontWantMessageThreshold {
 			continue
 		}
 		topic := msg.GetTopic()
-		tmids[topic] = append(tmids[topic], gs.p.idGen.ID(msg))
+		tmids[topic] = append(tmids[topic], mid)
 	}
 	for topic, mids := range tmids {
 		if len(mids) == 0 {
@@ -977,7 +996,20 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 			if gs.p.seenMessage(mid) {
 				continue
 			}
+
+			allowedIWants, ok := gs.allowedIWantCount[mid]
+			if !ok {
+				allowedIWants = gs.params.MaxIWantsPerMessageIDPerHeartbeat
+			}
+
+			// Check if we've exceeded the maximum number of pending IWANTs for this message
+			if allowedIWants <= 0 {
+				gs.logger.Debug("IHAVE: ignoring IHAVE; too many inflight IWANTs", "message", mid, "peer", p)
+				continue
+			}
+
 			iwant[mid] = struct{}{}
+			gs.allowedIWantCount[mid] = allowedIWants - 1
 		}
 	}
 
@@ -1662,6 +1694,9 @@ func (gs *GossipSubRouter) heartbeat() {
 	toprune := make(map[peer.ID][]string)
 	noPX := make(map[peer.ID]bool)
 
+	// reset number of allowed IWANT requests
+	gs.resetAllowedIWants()
+
 	// clean up expired backoffs
 	gs.clearBackoff()
 
@@ -1911,6 +1946,13 @@ func (gs *GossipSubRouter) heartbeat() {
 	gs.mcache.Shift()
 
 	gs.extensions.Heartbeat()
+}
+
+func (gs *GossipSubRouter) resetAllowedIWants() {
+	if len(gs.allowedIWantCount) > 0 {
+		// throw away the old map and make a new one
+		gs.allowedIWantCount = make(map[string]int)
+	}
 }
 
 func (gs *GossipSubRouter) clearIHaveCounters() {

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -6169,3 +6169,75 @@ func TestGossipsubLimitIWANT(t *testing.T) {
 		t.Fatal("Expected exactly 1 IWANT due to limits")
 	}
 }
+
+func TestIWantPerPeerLimit(t *testing.T) {
+	gs := &GossipSubRouter{
+		params:            DefaultGossipSubParams(),
+		outstandingIWants: make(map[string]iwantLedger),
+	}
+	gs.params.MaxIWantsPerMessageID = 2
+	gs.params.IWantFollowupTime = time.Second
+
+	base := time.Now()
+	mid := "m"
+	p1, p2, p3 := peer.ID("a"), peer.ID("b"), peer.ID("c")
+
+	// Two distinct peers admitted and recorded, at different times.
+	if !gs.canRequestIWant(mid, p1, base) {
+		t.Fatal("p1 should be admitted")
+	}
+	gs.recordIWant(mid, p1, base)
+	half := base.Add(500 * time.Millisecond)
+	if !gs.canRequestIWant(mid, p2, half) {
+		t.Fatal("p2 should be admitted")
+	}
+	gs.recordIWant(mid, p2, half)
+
+	// A third distinct peer is over the limit.
+	if gs.canRequestIWant(mid, p3, half) {
+		t.Fatal("p3 should be refused at the limit")
+	}
+	// A peer with a live ask is not asked again.
+	if gs.canRequestIWant(mid, p1, half) {
+		t.Fatal("p1 should not be re-asked while its ask is live")
+	}
+
+	// At base+followup, p1's ask has expired but p2's (sent later) has not, so
+	// exactly one slot frees: p3 is admitted, and re-asking p1 is now allowed
+	// but p2 is still blocked as live.
+	after := base.Add(gs.params.IWantFollowupTime + time.Millisecond)
+	if !gs.canRequestIWant(mid, p3, after) {
+		t.Fatal("p3 should be admitted once p1's expired ask frees a slot")
+	}
+	gs.recordIWant(mid, p3, after)
+	if _, ok := gs.outstandingIWants[mid][p2]; !ok {
+		t.Fatal("p2's later ask should still be live, not expired")
+	}
+	if gs.canRequestIWant(mid, p2, after) {
+		t.Fatal("p2 should still be blocked as live while p3 holds the other slot")
+	}
+}
+
+func TestIWantNoPhantomOnTruncation(t *testing.T) {
+	// canRequestIWant must not record; only recordIWant does. A candidate that
+	// passes the check but is dropped by truncation must leave no ledger entry.
+	gs := &GossipSubRouter{
+		params:            DefaultGossipSubParams(),
+		outstandingIWants: make(map[string]iwantLedger),
+	}
+	gs.params.MaxIWantsPerMessageID = 1
+	now := time.Now()
+	mid, p := "m", peer.ID("a")
+
+	if !gs.canRequestIWant(mid, p, now) {
+		t.Fatal("first check should pass")
+	}
+	// Not selected (truncated away): no recordIWant call.
+	if _, ok := gs.outstandingIWants[mid]; ok {
+		t.Fatal("a checked-but-unsent request must not appear in the ledger")
+	}
+	// A different peer can still be asked, since nothing was recorded.
+	if !gs.canRequestIWant(mid, peer.ID("b"), now) {
+		t.Fatal("another peer should still be admissible after an unrecorded check")
+	}
+}

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -6085,10 +6085,12 @@ func TestGossipsubLimitIWANT(t *testing.T) {
 	psubs := make([]*PubSub, 3)
 
 	defaultParams := DefaultGossipSubParams()
-	defaultParams.MaxIWantsPerMessageIDPerHeartbeat = 1
-	// Delay the heartbeat so we don't reset our count of allowed IWANTS for the
-	// first part of the test.
-	defaultParams.HeartbeatInitialDelay = 4 * time.Second
+	defaultParams.MaxIWantsPerMessageID = 1
+	// The budget refills IWantFollowupTime after the last request.
+	defaultParams.IWantFollowupTime = 2 * time.Second
+	// Push the heartbeat far out to show the refill is window-driven, not
+	// heartbeat-driven.
+	defaultParams.HeartbeatInitialDelay = 10 * time.Second
 	defaultParams.HeartbeatInterval = time.Second
 
 	psubs[0] = getGossipsub(ctx, hosts[0], WithGossipSubParams(defaultParams))
@@ -6156,7 +6158,8 @@ func TestGossipsubLimitIWANT(t *testing.T) {
 		t.Fatal("Expected exactly 1 IWANT due to limits")
 	}
 
-	// Wait for heartbeat to reset limit
+	// Wait for the follow-up window to expire and refill the budget; no
+	// heartbeat fires within this test.
 	time.Sleep(2 * time.Second)
 
 	publishIWant()

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -6075,3 +6075,94 @@ func TestGossipsubDuplicatePublishDeliveredOnce(t *testing.T) {
 		}
 	})
 }
+
+func TestGossipsubLimitIWANT(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hosts := getDefaultHosts(t, 3)
+	denseConnect(t, hosts)
+
+	psubs := make([]*PubSub, 3)
+
+	defaultParams := DefaultGossipSubParams()
+	defaultParams.MaxIWantsPerMessageIDPerHeartbeat = 1
+	// Delay the heartbeat so we don't reset our count of allowed IWANTS for the
+	// first part of the test.
+	defaultParams.HeartbeatInitialDelay = 4 * time.Second
+	defaultParams.HeartbeatInterval = time.Second
+
+	psubs[0] = getGossipsub(ctx, hosts[0], WithGossipSubParams(defaultParams))
+
+	var iwantsRecvd atomic.Int32
+
+	copy(psubs[1:], getGossipsubs(ctx, hosts[1:], WithRawTracer(&mockRawTracer{
+		onRecvRPC: func(rpc *RPC) {
+			if len(rpc.GetControl().GetIwant()) > 0 {
+				iwantsRecvd.Add(1)
+			}
+		},
+	})))
+
+	topicString := "foobar"
+	for _, ps := range psubs {
+		topic, err := ps.Join(topicString)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = topic.Subscribe()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(2 * time.Second)
+
+	publishIWant := func() {
+		psubs[1].eval <- func() {
+			psubs[1].rt.(*GossipSubRouter).sendRPC(hosts[0].ID(), &RPC{
+				RPC: pb.RPC{
+					Control: &pb.ControlMessage{
+						Ihave: []*pb.ControlIHave{
+							{
+								TopicID:    &topicString,
+								MessageIDs: []string{"1"},
+							},
+						},
+					},
+				},
+			}, false)
+		}
+
+		psubs[2].eval <- func() {
+			psubs[2].rt.(*GossipSubRouter).sendRPC(hosts[0].ID(), &RPC{
+				RPC: pb.RPC{
+					Control: &pb.ControlMessage{
+						Ihave: []*pb.ControlIHave{
+							{
+								TopicID:    &topicString,
+								MessageIDs: []string{"1"},
+							},
+						},
+					},
+				},
+			}, false)
+		}
+	}
+
+	publishIWant()
+	time.Sleep(time.Second)
+
+	if iwantsRecvd.Swap(0) != 1 {
+		t.Fatal("Expected exactly 1 IWANT due to limits")
+	}
+
+	// Wait for heartbeat to reset limit
+	time.Sleep(2 * time.Second)
+
+	publishIWant()
+	time.Sleep(time.Second)
+
+	if iwantsRecvd.Swap(0) != 1 {
+		t.Fatal("Expected exactly 1 IWANT due to limits")
+	}
+}


### PR DESCRIPTION
This PR adds IWANT tracking on top of the previous change, improving
IWANT efficiency and reducing duplicates.
It builds on a rebased version of #625, including the work of @MarcoPolo 

## Details
Replace the per-message-ID request counter with a ledger of which peers
have an outstanding IWANT for each message and when it was sent. The
limit now caps how many distinct peers we ask for a given message at
once, and a peer with a still-live request is not asked again, so one
peer can no longer soak up the whole budget. An ask older than the
follow-up time expires and frees its slot.

Requests are recorded only after the per-peer truncation that decides
what we actually send, so an ID dropped by truncation no longer leaves a
phantom ask that would block the message from being requested elsewhere.

Clear the ledger when a message is received and validated rather than in
the pre-validation Preprocess step, so an unvalidated or rejected message
can no longer cancel a pending request.