### PR TITLE
Improve IWANT handling by grace period and RTT adaptive expiry

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -82,7 +82,7 @@ var (
 	GossipSubIDontWantMessageThreshold        = 1024 // 1KB
 	GossipSubIDontWantMessageTTL              = 3    // 3 heartbeats
 
-	GossipSubMaxIWantsPerMessageIDPerHeartbeat = 10
+	GossipSubMaxIWantsPerMessageID = 10
 )
 
 type checksum struct {
@@ -249,10 +249,13 @@ type GossipSubParams struct {
 	// IDONTWANT is cleared when it's older than the TTL.
 	IDontWantMessageTTL int
 
-	// MaxIWantsPerMessageIDPerHeartbeat is the maximum number of pending IWANT
-	// requests allowed per message ID per heartbeat. This helps limit the
-	// number of duplicates we'll receive from peers.
-	MaxIWantsPerMessageIDPerHeartbeat int
+	// MaxIWantsPerMessageID is the maximum number of IWANT requests allowed
+	// per message ID while requests are outstanding. This helps limit the
+	// number of duplicates we'll receive from peers. The budget for a message
+	// ID refills IWantFollowupTime after its last request, so a request that
+	// went unanswered can be retried without waiting for a heartbeat boundary
+	// and a request in flight is not re-issued at one.
+	MaxIWantsPerMessageID int
 }
 
 func (params *GossipSubParams) validate() error {
@@ -321,10 +324,9 @@ func DefaultGossipSubRouter(h host.Host) *GossipSubRouter {
 		tagTracer:       newTagTracer(h.ConnManager()),
 		params:          params,
 		reducePXRecords: defaultPXRecordReducer,
-		// number of allowed IWANTs per message ID. If the message ID is
-		// missing, it must be initialized to
-		// `MaxIWantsPerMessageIDPerHeartbeat`
-		allowedIWantCount: make(map[string]int),
+		// remaining IWANT budget per message ID. A missing or expired entry
+		// stands for a full budget of `MaxIWantsPerMessageID`.
+		allowedIWantCount: make(map[string]iwantBudget),
 	}
 
 	rt.extensions = newExtensionsState(PeerExtensions{}, func(p peer.ID) {
@@ -373,7 +375,7 @@ func DefaultGossipSubParams() GossipSubParams {
 		IDontWantMessageTTL:       GossipSubIDontWantMessageTTL,
 		SlowHeartbeatWarning:      0.1,
 
-		MaxIWantsPerMessageIDPerHeartbeat: GossipSubMaxIWantsPerMessageIDPerHeartbeat,
+		MaxIWantsPerMessageID: GossipSubMaxIWantsPerMessageID,
 	}
 }
 
@@ -620,9 +622,9 @@ type GossipSubRouter struct {
 	connect      chan connectInfo                 // px connection requests
 	cab          peerstore.AddrBook
 
-	// allowed number of IWANTs per message ID. Must be initialized to
-	// `MaxIWantsPerMessageIDPerHeartbeat` if message id is missing.
-	allowedIWantCount map[string]int
+	// remaining IWANT budget per message ID. A missing or expired entry
+	// stands for a full budget of `MaxIWantsPerMessageID`.
+	allowedIWantCount map[string]iwantBudget
 
 	protos  []protocol.ID
 	feature GossipSubFeatureTest
@@ -997,19 +999,22 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 				continue
 			}
 
-			allowedIWants, ok := gs.allowedIWantCount[mid]
-			if !ok {
-				allowedIWants = gs.params.MaxIWantsPerMessageIDPerHeartbeat
+			now := time.Now()
+			budget, ok := gs.allowedIWantCount[mid]
+			if !ok || now.After(budget.renewAt) {
+				budget = iwantBudget{remaining: gs.params.MaxIWantsPerMessageID}
 			}
 
 			// Check if we've exceeded the maximum number of pending IWANTs for this message
-			if allowedIWants <= 0 {
+			if budget.remaining <= 0 {
 				gs.logger.Debug("IHAVE: ignoring IHAVE; too many inflight IWANTs", "message", mid, "peer", p)
 				continue
 			}
 
 			iwant[mid] = struct{}{}
-			gs.allowedIWantCount[mid] = allowedIWants - 1
+			budget.remaining--
+			budget.renewAt = now.Add(gs.params.IWantFollowupTime)
+			gs.allowedIWantCount[mid] = budget
 		}
 	}
 
@@ -1694,8 +1699,9 @@ func (gs *GossipSubRouter) heartbeat() {
 	toprune := make(map[peer.ID][]string)
 	noPX := make(map[peer.ID]bool)
 
-	// reset number of allowed IWANT requests
-	gs.resetAllowedIWants()
+	// drop expired IWANT budgets; refill happens per entry, IWantFollowupTime
+	// after the last request, not at the heartbeat
+	gs.pruneAllowedIWants()
 
 	// clean up expired backoffs
 	gs.clearBackoff()
@@ -1948,10 +1954,22 @@ func (gs *GossipSubRouter) heartbeat() {
 	gs.extensions.Heartbeat()
 }
 
-func (gs *GossipSubRouter) resetAllowedIWants() {
-	if len(gs.allowedIWantCount) > 0 {
-		// throw away the old map and make a new one
-		gs.allowedIWantCount = make(map[string]int)
+// iwantBudget tracks how many more IWANTs may be sent for a message ID and
+// when the budget refills. Refilling per entry rather than resetting all
+// entries at the heartbeat avoids re-requesting a message whose IWANT is
+// still in flight when a heartbeat fires, and lets an unanswered request be
+// retried without waiting for the next heartbeat boundary.
+type iwantBudget struct {
+	remaining int
+	renewAt   time.Time
+}
+
+func (gs *GossipSubRouter) pruneAllowedIWants() {
+	now := time.Now()
+	for mid, budget := range gs.allowedIWantCount {
+		if now.After(budget.renewAt) {
+			delete(gs.allowedIWantCount, mid)
+		}
 	}
 }
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -249,12 +249,12 @@ type GossipSubParams struct {
 	// IDONTWANT is cleared when it's older than the TTL.
 	IDontWantMessageTTL int
 
-	// MaxIWantsPerMessageID is the maximum number of IWANT requests allowed
-	// per message ID while requests are outstanding. This helps limit the
-	// number of duplicates we'll receive from peers. The budget for a message
-	// ID refills IWantFollowupTime after its last request, so a request that
-	// went unanswered can be retried without waiting for a heartbeat boundary
-	// and a request in flight is not re-issued at one.
+	// MaxIWantsPerMessageID is the maximum number of IWANT requests kept
+	// outstanding per message ID at once, spread across distinct peers. It
+	// bounds how many logically-live requests a single message can have, and so
+	// how many duplicate deliveries it tends to draw. An outstanding request
+	// expires IWantFollowupTime after it was sent, which frees a slot and lets
+	// the message be requested again without waiting for a heartbeat boundary.
 	MaxIWantsPerMessageID int
 }
 
@@ -265,6 +265,14 @@ func (params *GossipSubParams) validate() error {
 
 	if !(params.Dscore <= params.Dhi) {
 		return fmt.Errorf("param Dscore=%d must be lower than or equal to  Dhi=%d", params.Dscore, params.Dhi)
+	}
+
+	if params.MaxIWantsPerMessageID <= 0 {
+		return fmt.Errorf("param MaxIWantsPerMessageID=%d must be positive", params.MaxIWantsPerMessageID)
+	}
+
+	if params.IWantFollowupTime <= 0 {
+		return fmt.Errorf("param IWantFollowupTime=%s must be positive", params.IWantFollowupTime)
 	}
 
 	// Bootstrappers set D=D_lo=D_hi=D_out=0
@@ -324,9 +332,8 @@ func DefaultGossipSubRouter(h host.Host) *GossipSubRouter {
 		tagTracer:       newTagTracer(h.ConnManager()),
 		params:          params,
 		reducePXRecords: defaultPXRecordReducer,
-		// remaining IWANT budget per message ID. A missing or expired entry
-		// stands for a full budget of `MaxIWantsPerMessageID`.
-		allowedIWantCount: make(map[string]iwantBudget),
+		// outstanding IWANTs per message ID, by peer and send time.
+		outstandingIWants: make(map[string]iwantLedger),
 	}
 
 	rt.extensions = newExtensionsState(PeerExtensions{}, func(p peer.ID) {
@@ -622,9 +629,9 @@ type GossipSubRouter struct {
 	connect      chan connectInfo                 // px connection requests
 	cab          peerstore.AddrBook
 
-	// remaining IWANT budget per message ID. A missing or expired entry
-	// stands for a full budget of `MaxIWantsPerMessageID`.
-	allowedIWantCount map[string]iwantBudget
+	// outstanding IWANTs per message ID, by peer and send time. Bounds how
+	// many distinct peers we ask for a given message at once.
+	outstandingIWants map[string]iwantLedger
 
 	protos  []protocol.ID
 	feature GossipSubFeatureTest
@@ -896,7 +903,6 @@ func (gs *GossipSubRouter) Preprocess(from peer.ID, msgs []*Message) {
 	tmids := make(map[string][]string)
 	for _, msg := range msgs {
 		mid := gs.p.idGen.ID(msg)
-		delete(gs.allowedIWantCount, mid)
 		if len(msg.GetData()) < gs.params.IDontWantMessageThreshold {
 			continue
 		}
@@ -975,6 +981,7 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 		return nil
 	}
 
+	now := time.Now()
 	iwant := make(map[string]struct{})
 	for _, ihave := range ctl.GetIhave() {
 		topic := ihave.GetTopicID()
@@ -999,22 +1006,12 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 				continue
 			}
 
-			now := time.Now()
-			budget, ok := gs.allowedIWantCount[mid]
-			if !ok || now.After(budget.renewAt) {
-				budget = iwantBudget{remaining: gs.params.MaxIWantsPerMessageID}
-			}
-
-			// Check if we've exceeded the maximum number of pending IWANTs for this message
-			if budget.remaining <= 0 {
-				gs.logger.Debug("IHAVE: ignoring IHAVE; too many inflight IWANTs", "message", mid, "peer", p)
+			if !gs.canRequestIWant(mid, p, now) {
+				gs.logger.Debug("IHAVE: ignoring IHAVE; too many inflight IWANTs or peer already asked", "message", mid, "peer", p)
 				continue
 			}
 
 			iwant[mid] = struct{}{}
-			budget.remaining--
-			budget.renewAt = now.Add(gs.params.IWantFollowupTime)
-			gs.allowedIWantCount[mid] = budget
 		}
 	}
 
@@ -1040,6 +1037,12 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 	// truncate to the messages we are actually asking for and update the iasked counter
 	iwantlst = iwantlst[:iask]
 	gs.iasked[p] += iask
+
+	// record the asks only for the messages we are actually sending, so a
+	// request dropped by truncation leaves no phantom entry in the ledger
+	for _, mid := range iwantlst {
+		gs.recordIWant(mid, p, now)
+	}
 
 	gs.gossipTracer.AddPromise(p, iwantlst)
 
@@ -1369,6 +1372,7 @@ func (gs *GossipSubRouter) connector() {
 func (gs *GossipSubRouter) PublishBatch(messages []*Message, opts *BatchPublishOptions) {
 	strategy := opts.Strategy
 	for _, msg := range messages {
+		gs.fulfillIWant(msg)
 		msgID := gs.p.idGen.ID(msg)
 		for p, rpc := range gs.rpcs(msg) {
 			strategy.AddRPC(p, msgID, rpc)
@@ -1381,6 +1385,7 @@ func (gs *GossipSubRouter) PublishBatch(messages []*Message, opts *BatchPublishO
 }
 
 func (gs *GossipSubRouter) Publish(msg *Message) {
+	gs.fulfillIWant(msg)
 	for p, rpc := range gs.rpcs(msg) {
 		gs.sendRPC(p, rpc, false)
 	}
@@ -1699,9 +1704,8 @@ func (gs *GossipSubRouter) heartbeat() {
 	toprune := make(map[peer.ID][]string)
 	noPX := make(map[peer.ID]bool)
 
-	// drop expired IWANT budgets; refill happens per entry, IWantFollowupTime
-	// after the last request, not at the heartbeat
-	gs.pruneAllowedIWants()
+	// drop expired outstanding IWANTs so their slots free up
+	gs.pruneOutstandingIWants()
 
 	// clean up expired backoffs
 	gs.clearBackoff()
@@ -1954,21 +1958,58 @@ func (gs *GossipSubRouter) heartbeat() {
 	gs.extensions.Heartbeat()
 }
 
-// iwantBudget tracks how many more IWANTs may be sent for a message ID and
-// when the budget refills. Refilling per entry rather than resetting all
-// entries at the heartbeat avoids re-requesting a message whose IWANT is
-// still in flight when a heartbeat fires, and lets an unanswered request be
-// retried without waiting for the next heartbeat boundary.
-type iwantBudget struct {
-	remaining int
-	renewAt   time.Time
+// iwantLedger records, per peer, when we sent that peer an IWANT for a message
+// ID. An entry older than IWantFollowupTime has expired: it no longer counts
+// against MaxIWantsPerMessageID and the peer may be asked again.
+type iwantLedger map[peer.ID]time.Time
+
+// expireAsks drops asks whose follow-up time has passed, freeing their slots.
+func (gs *GossipSubRouter) expireAsks(ledger iwantLedger, now time.Time) {
+	for ap, at := range ledger {
+		if now.Sub(at) >= gs.params.IWantFollowupTime {
+			delete(ledger, ap)
+		}
+	}
 }
 
-func (gs *GossipSubRouter) pruneAllowedIWants() {
+// canRequestIWant reports whether an IWANT for mid may be sent to p, expiring
+// stale asks first. It does not record the request; recordIWant does that once
+// the message survives per-peer truncation, so a request dropped by truncation
+// leaves no phantom entry in the ledger.
+func (gs *GossipSubRouter) canRequestIWant(mid string, p peer.ID, now time.Time) bool {
+	ledger := gs.outstandingIWants[mid]
+	if ledger == nil {
+		return true
+	}
+	gs.expireAsks(ledger, now)
+	if _, asked := ledger[p]; asked {
+		return false
+	}
+	return len(ledger) < gs.params.MaxIWantsPerMessageID
+}
+
+// recordIWant notes that an IWANT for mid was sent to p at now.
+func (gs *GossipSubRouter) recordIWant(mid string, p peer.ID, now time.Time) {
+	ledger := gs.outstandingIWants[mid]
+	if ledger == nil {
+		ledger = make(iwantLedger)
+		gs.outstandingIWants[mid] = ledger
+	}
+	ledger[p] = now
+}
+
+// fulfillIWant clears any outstanding IWANTs for a message once it has been
+// received and validated.
+func (gs *GossipSubRouter) fulfillIWant(msg *Message) {
+	delete(gs.outstandingIWants, gs.p.idGen.ID(msg))
+}
+
+func (gs *GossipSubRouter) pruneOutstandingIWants() {
 	now := time.Now()
-	for mid, budget := range gs.allowedIWantCount {
-		if now.After(budget.renewAt) {
-			delete(gs.allowedIWantCount, mid)
+	for mid, ledger := range gs.outstandingIWants {
+		gs.expireAsks(ledger, now)
+		if len(ledger) == 0 {
+			delete(gs.outstandingIWants, mid)
 		}
 	}
 }

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -256,6 +256,13 @@ type GossipSubParams struct {
 	// expires IWantFollowupTime after it was sent, which frees a slot and lets
 	// the message be requested again without waiting for a heartbeat boundary.
 	MaxIWantsPerMessageID int
+
+	// IWantDispatchGrace delays the first IWANT for a message by this much after
+	// its first IHAVE, giving an in-flight push a chance to arrive before we
+	// pull. The deferred pull is driven by the next IHAVE after the grace
+	// elapses rather than a timer, so it can lag the grace by up to a heartbeat.
+	// Zero (the default) dispatches immediately.
+	IWantDispatchGrace time.Duration
 }
 
 func (params *GossipSubParams) validate() error {
@@ -273,6 +280,10 @@ func (params *GossipSubParams) validate() error {
 
 	if params.IWantFollowupTime <= 0 {
 		return fmt.Errorf("param IWantFollowupTime=%s must be positive", params.IWantFollowupTime)
+	}
+
+	if params.IWantDispatchGrace < 0 {
+		return fmt.Errorf("param IWantDispatchGrace=%s must not be negative", params.IWantDispatchGrace)
 	}
 
 	// Bootstrappers set D=D_lo=D_hi=D_out=0
@@ -333,7 +344,7 @@ func DefaultGossipSubRouter(h host.Host) *GossipSubRouter {
 		params:          params,
 		reducePXRecords: defaultPXRecordReducer,
 		// outstanding IWANTs per message ID, by peer and send time.
-		outstandingIWants: make(map[string]iwantLedger),
+		outstandingIWants: make(map[string]*iwantState),
 	}
 
 	rt.extensions = newExtensionsState(PeerExtensions{}, func(p peer.ID) {
@@ -631,7 +642,7 @@ type GossipSubRouter struct {
 
 	// outstanding IWANTs per message ID, by peer and send time. Bounds how
 	// many distinct peers we ask for a given message at once.
-	outstandingIWants map[string]iwantLedger
+	outstandingIWants map[string]*iwantState
 
 	protos  []protocol.ID
 	feature GossipSubFeatureTest
@@ -1963,6 +1974,12 @@ func (gs *GossipSubRouter) heartbeat() {
 // against MaxIWantsPerMessageID and the peer may be asked again.
 type iwantLedger map[peer.ID]time.Time
 
+// iwantState is the outstanding-request state for a single message ID.
+type iwantState struct {
+	firstIHaveAt time.Time   // when the first IHAVE for this message arrived
+	askedAt      iwantLedger // peers with an outstanding IWANT, and when it was sent
+}
+
 // expireAsks drops asks whose follow-up time has passed, freeing their slots.
 func (gs *GossipSubRouter) expireAsks(ledger iwantLedger, now time.Time) {
 	for ap, at := range ledger {
@@ -1976,26 +1993,38 @@ func (gs *GossipSubRouter) expireAsks(ledger iwantLedger, now time.Time) {
 // stale asks first. It does not record the request; recordIWant does that once
 // the message survives per-peer truncation, so a request dropped by truncation
 // leaves no phantom entry in the ledger.
+//
+// On the first IHAVE for a message it starts the grace clock. If a dispatch
+// grace is configured the first request is held, so an in-flight push can
+// arrive before we pull; the deferred pull happens on the next IHAVE once the
+// grace has elapsed (IHAVEs re-gossip each heartbeat), not from a timer.
 func (gs *GossipSubRouter) canRequestIWant(mid string, p peer.ID, now time.Time) bool {
-	ledger := gs.outstandingIWants[mid]
-	if ledger == nil {
-		return true
+	st := gs.outstandingIWants[mid]
+	if st == nil {
+		gs.outstandingIWants[mid] = &iwantState{firstIHaveAt: now}
+		return gs.params.IWantDispatchGrace <= 0
 	}
-	gs.expireAsks(ledger, now)
-	if _, asked := ledger[p]; asked {
+	if now.Sub(st.firstIHaveAt) < gs.params.IWantDispatchGrace {
 		return false
 	}
-	return len(ledger) < gs.params.MaxIWantsPerMessageID
+	gs.expireAsks(st.askedAt, now)
+	if _, asked := st.askedAt[p]; asked {
+		return false
+	}
+	return len(st.askedAt) < gs.params.MaxIWantsPerMessageID
 }
 
 // recordIWant notes that an IWANT for mid was sent to p at now.
 func (gs *GossipSubRouter) recordIWant(mid string, p peer.ID, now time.Time) {
-	ledger := gs.outstandingIWants[mid]
-	if ledger == nil {
-		ledger = make(iwantLedger)
-		gs.outstandingIWants[mid] = ledger
+	st := gs.outstandingIWants[mid]
+	if st == nil {
+		st = &iwantState{firstIHaveAt: now}
+		gs.outstandingIWants[mid] = st
 	}
-	ledger[p] = now
+	if st.askedAt == nil {
+		st.askedAt = make(iwantLedger)
+	}
+	st.askedAt[p] = now
 }
 
 // fulfillIWant clears any outstanding IWANTs for a message once it has been
@@ -2006,9 +2035,15 @@ func (gs *GossipSubRouter) fulfillIWant(msg *Message) {
 
 func (gs *GossipSubRouter) pruneOutstandingIWants() {
 	now := time.Now()
-	for mid, ledger := range gs.outstandingIWants {
-		gs.expireAsks(ledger, now)
-		if len(ledger) == 0 {
+	// Keep state through the grace-and-follow-up window even with no live ask,
+	// so grace does not restart each heartbeat before the deferred pull fires.
+	staleAfter := gs.params.IWantFollowupTime
+	if gs.params.IWantDispatchGrace > staleAfter {
+		staleAfter = gs.params.IWantDispatchGrace
+	}
+	for mid, st := range gs.outstandingIWants {
+		gs.expireAsks(st.askedAt, now)
+		if len(st.askedAt) == 0 && now.Sub(st.firstIHaveAt) >= staleAfter {
 			delete(gs.outstandingIWants, mid)
 		}
 	}

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -263,6 +263,21 @@ type GossipSubParams struct {
 	// elapses rather than a timer, so it can lag the grace by up to a heartbeat.
 	// Zero (the default) dispatches immediately.
 	IWantDispatchGrace time.Duration
+
+	// IWantAdaptiveHorizon makes an outstanding IWANT expire after a tracked
+	// estimate of the asked peer's response time rather than the fixed
+	// IWantFollowupTime, so a typically-fast peer frees its slot sooner and a
+	// slow one is given longer. Off by default.
+	IWantAdaptiveHorizon bool
+
+	// IWantHorizonQuantile is the quantile of a peer's response-time
+	// distribution tracked as its horizon when IWantAdaptiveHorizon is set.
+	IWantHorizonQuantile float64
+
+	// IWantHorizonFloor and IWantHorizonCeil clamp the adaptive horizon. Ceil
+	// also bounds how long a silent peer holds a slot.
+	IWantHorizonFloor time.Duration
+	IWantHorizonCeil  time.Duration
 }
 
 func (params *GossipSubParams) validate() error {
@@ -284,6 +299,18 @@ func (params *GossipSubParams) validate() error {
 
 	if params.IWantDispatchGrace < 0 {
 		return fmt.Errorf("param IWantDispatchGrace=%s must not be negative", params.IWantDispatchGrace)
+	}
+
+	if params.IWantAdaptiveHorizon {
+		if !(params.IWantHorizonQuantile > 0 && params.IWantHorizonQuantile < 1) {
+			return fmt.Errorf("param IWantHorizonQuantile=%f must be in (0,1)", params.IWantHorizonQuantile)
+		}
+		if params.IWantHorizonFloor <= 0 || params.IWantHorizonCeil <= 0 {
+			return fmt.Errorf("params IWantHorizonFloor=%s and IWantHorizonCeil=%s must be positive", params.IWantHorizonFloor, params.IWantHorizonCeil)
+		}
+		if params.IWantHorizonFloor > params.IWantHorizonCeil {
+			return fmt.Errorf("param IWantHorizonFloor=%s must not exceed IWantHorizonCeil=%s", params.IWantHorizonFloor, params.IWantHorizonCeil)
+		}
 	}
 
 	// Bootstrappers set D=D_lo=D_hi=D_out=0
@@ -394,6 +421,10 @@ func DefaultGossipSubParams() GossipSubParams {
 		SlowHeartbeatWarning:      0.1,
 
 		MaxIWantsPerMessageID: GossipSubMaxIWantsPerMessageID,
+
+		IWantHorizonQuantile: 0.8,
+		IWantHorizonFloor:    200 * time.Millisecond,
+		IWantHorizonCeil:     GossipSubIWantFollowupTime,
 	}
 }
 
@@ -644,6 +675,11 @@ type GossipSubRouter struct {
 	// many distinct peers we ask for a given message at once.
 	outstandingIWants map[string]*iwantState
 
+	// per-peer and global IWANT response-time trackers for the adaptive
+	// horizon. Nil until the first sample when the horizon is enabled.
+	rttPeer   map[peer.ID]*responseQuantile
+	rttGlobal *responseQuantile
+
 	protos  []protocol.ID
 	feature GossipSubFeatureTest
 
@@ -849,6 +885,7 @@ func (gs *GossipSubRouter) OnClosedOutboundStream(p peer.ID) {
 	delete(gs.control, p)
 	delete(gs.outbound, p)
 	delete(gs.unwanted, p)
+	delete(gs.rttPeer, p)
 }
 
 func (gs *GossipSubRouter) EnoughPeers(topic string, suggested int) bool {
@@ -1969,21 +2006,29 @@ func (gs *GossipSubRouter) heartbeat() {
 	gs.extensions.Heartbeat()
 }
 
-// iwantLedger records, per peer, when we sent that peer an IWANT for a message
-// ID. An entry older than IWantFollowupTime has expired: it no longer counts
-// against MaxIWantsPerMessageID and the peer may be asked again.
-type iwantLedger map[peer.ID]time.Time
+// iwantLedger records, per peer, the outstanding IWANT we sent that peer for a
+// message ID. An expired entry no longer counts against MaxIWantsPerMessageID
+// and the peer may be asked again.
+type iwantLedger map[peer.ID]iwantAsk
+
+// iwantAsk is one outstanding IWANT: when it was sent and when it expires. The
+// expiry is snapshotted at send time so a later change to a peer's estimate
+// does not move the deadline of a request already in flight.
+type iwantAsk struct {
+	sentAt    time.Time
+	expiresAt time.Time
+}
 
 // iwantState is the outstanding-request state for a single message ID.
 type iwantState struct {
 	firstIHaveAt time.Time   // when the first IHAVE for this message arrived
-	askedAt      iwantLedger // peers with an outstanding IWANT, and when it was sent
+	askedAt      iwantLedger // peers with an outstanding IWANT
 }
 
-// expireAsks drops asks whose follow-up time has passed, freeing their slots.
+// expireAsks drops asks whose horizon has passed, freeing their slots.
 func (gs *GossipSubRouter) expireAsks(ledger iwantLedger, now time.Time) {
-	for ap, at := range ledger {
-		if now.Sub(at) >= gs.params.IWantFollowupTime {
+	for ap, ask := range ledger {
+		if !now.Before(ask.expiresAt) {
 			delete(ledger, ap)
 		}
 	}
@@ -2014,7 +2059,8 @@ func (gs *GossipSubRouter) canRequestIWant(mid string, p peer.ID, now time.Time)
 	return len(st.askedAt) < gs.params.MaxIWantsPerMessageID
 }
 
-// recordIWant notes that an IWANT for mid was sent to p at now.
+// recordIWant notes that an IWANT for mid was sent to p at now, snapshotting
+// the peer's request horizon as the ask's expiry.
 func (gs *GossipSubRouter) recordIWant(mid string, p peer.ID, now time.Time) {
 	st := gs.outstandingIWants[mid]
 	if st == nil {
@@ -2024,13 +2070,24 @@ func (gs *GossipSubRouter) recordIWant(mid string, p peer.ID, now time.Time) {
 	if st.askedAt == nil {
 		st.askedAt = make(iwantLedger)
 	}
-	st.askedAt[p] = now
+	st.askedAt[p] = iwantAsk{sentAt: now, expiresAt: now.Add(gs.iwantHorizon(p))}
 }
 
 // fulfillIWant clears any outstanding IWANTs for a message once it has been
-// received and validated.
+// received and validated, and feeds the delivering peer's response time into
+// the adaptive-horizon estimate when that is enabled.
 func (gs *GossipSubRouter) fulfillIWant(msg *Message) {
-	delete(gs.outstandingIWants, gs.p.idGen.ID(msg))
+	mid := gs.p.idGen.ID(msg)
+	st := gs.outstandingIWants[mid]
+	if st == nil {
+		return
+	}
+	if gs.params.IWantAdaptiveHorizon {
+		if ask, ok := st.askedAt[msg.ReceivedFrom]; ok {
+			gs.observeIWantRTT(msg.ReceivedFrom, time.Since(ask.sentAt))
+		}
+	}
+	delete(gs.outstandingIWants, mid)
 }
 
 func (gs *GossipSubRouter) pruneOutstandingIWants() {
@@ -2047,6 +2104,88 @@ func (gs *GossipSubRouter) pruneOutstandingIWants() {
 			delete(gs.outstandingIWants, mid)
 		}
 	}
+}
+
+// iwantMinSamples is how many response-time samples a peer must contribute
+// before its own estimate is trusted over the global one.
+const iwantMinSamples = 8
+
+// responseQuantile is a constant-gain online tracker of a quantile of a peer's
+// IWANT response time. Each observation nudges the estimate by a fixed fraction
+// of its current value toward the target quantile; the gain does not diminish
+// with sample count, so it tracks a drifting distribution rather than
+// converging to a fixed value.
+type responseQuantile struct {
+	est time.Duration
+	n   int
+}
+
+func (rq *responseQuantile) observe(sample time.Duration, q float64) {
+	if rq.n == 0 {
+		rq.est, rq.n = sample, 1
+		return
+	}
+	step := time.Duration(float64(rq.est) * 0.10)
+	if step <= 0 {
+		step = time.Millisecond
+	}
+	if sample <= rq.est {
+		rq.est -= time.Duration(float64(step) * (1 - q))
+	} else {
+		rq.est += time.Duration(float64(step) * q)
+	}
+	if rq.est < 0 {
+		rq.est = 0
+	}
+	rq.n++
+}
+
+// observeIWantRTT feeds one IWANT-to-delivery sample into the per-peer and
+// global response-time trackers.
+func (gs *GossipSubRouter) observeIWantRTT(p peer.ID, sample time.Duration) {
+	if sample <= 0 {
+		return
+	}
+	if gs.rttGlobal == nil {
+		gs.rttGlobal = &responseQuantile{est: gs.params.IWantFollowupTime, n: 1}
+	}
+	if gs.rttPeer == nil {
+		gs.rttPeer = make(map[peer.ID]*responseQuantile)
+	}
+	rq := gs.rttPeer[p]
+	if rq == nil {
+		rq = &responseQuantile{}
+		gs.rttPeer[p] = rq
+	}
+	rq.observe(sample, gs.params.IWantHorizonQuantile)
+	gs.rttGlobal.observe(sample, gs.params.IWantHorizonQuantile)
+}
+
+// iwantHorizon is how long an outstanding IWANT to p counts before it expires
+// and frees a slot. With the adaptive horizon off it is the fixed follow-up
+// time. With it on it is the tracked response-time quantile for p (its own once
+// it has enough samples, otherwise the global tracker, otherwise the follow-up
+// time), clamped to [floor, ceil]. A peer that is typically fast therefore gets
+// a shorter horizon — we give up and ask elsewhere sooner — and a slow peer a
+// longer one; ceil bounds how long a silent peer holds a slot.
+func (gs *GossipSubRouter) iwantHorizon(p peer.ID) time.Duration {
+	if !gs.params.IWantAdaptiveHorizon {
+		return gs.params.IWantFollowupTime
+	}
+	est := gs.params.IWantFollowupTime
+	if gs.rttGlobal != nil {
+		est = gs.rttGlobal.est
+	}
+	if rq, ok := gs.rttPeer[p]; ok && rq.n >= iwantMinSamples {
+		est = rq.est
+	}
+	if est < gs.params.IWantHorizonFloor {
+		est = gs.params.IWantHorizonFloor
+	}
+	if est > gs.params.IWantHorizonCeil {
+		est = gs.params.IWantHorizonCeil
+	}
+	return est
 }
 
 func (gs *GossipSubRouter) clearIHaveCounters() {

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -81,6 +81,8 @@ var (
 	GossipSubIWantFollowupTime                = 3 * time.Second
 	GossipSubIDontWantMessageThreshold        = 1024 // 1KB
 	GossipSubIDontWantMessageTTL              = 3    // 3 heartbeats
+
+	GossipSubMaxIWantsPerMessageIDPerHeartbeat = 10
 )
 
 type checksum struct {
@@ -246,6 +248,11 @@ type GossipSubParams struct {
 
 	// IDONTWANT is cleared when it's older than the TTL.
 	IDontWantMessageTTL int
+
+	// MaxIWantsPerMessageIDPerHeartbeat is the maximum number of pending IWANT
+	// requests allowed per message ID per heartbeat. This helps limit the
+	// number of duplicates we'll receive from peers.
+	MaxIWantsPerMessageIDPerHeartbeat int
 }
 
 func (params *GossipSubParams) validate() error {
@@ -314,6 +321,10 @@ func DefaultGossipSubRouter(h host.Host) *GossipSubRouter {
 		tagTracer:       newTagTracer(h.ConnManager()),
 		params:          params,
 		reducePXRecords: defaultPXRecordReducer,
+		// number of allowed IWANTs per message ID. If the message ID is
+		// missing, it must be initialized to
+		// `MaxIWantsPerMessageIDPerHeartbeat`
+		allowedIWantCount: make(map[string]int),
 	}
 
 	rt.extensions = newExtensionsState(PeerExtensions{}, func(p peer.ID) {
@@ -361,6 +372,8 @@ func DefaultGossipSubParams() GossipSubParams {
 		IDontWantMessageThreshold: GossipSubIDontWantMessageThreshold,
 		IDontWantMessageTTL:       GossipSubIDontWantMessageTTL,
 		SlowHeartbeatWarning:      0.1,
+
+		MaxIWantsPerMessageIDPerHeartbeat: GossipSubMaxIWantsPerMessageIDPerHeartbeat,
 	}
 }
 
@@ -606,6 +619,10 @@ type GossipSubRouter struct {
 	backoff      map[string]map[peer.ID]time.Time // prune backoff
 	connect      chan connectInfo                 // px connection requests
 	cab          peerstore.AddrBook
+
+	// allowed number of IWANTs per message ID. Must be initialized to
+	// `MaxIWantsPerMessageIDPerHeartbeat` if message id is missing.
+	allowedIWantCount map[string]int
 
 	protos  []protocol.ID
 	feature GossipSubFeatureTest
@@ -876,11 +893,13 @@ func (gs *GossipSubRouter) AcceptFrom(p peer.ID) AcceptStatus {
 func (gs *GossipSubRouter) Preprocess(from peer.ID, msgs []*Message) {
 	tmids := make(map[string][]string)
 	for _, msg := range msgs {
+		mid := gs.p.idGen.ID(msg)
+		delete(gs.allowedIWantCount, mid)
 		if len(msg.GetData()) < gs.params.IDontWantMessageThreshold {
 			continue
 		}
 		topic := msg.GetTopic()
-		tmids[topic] = append(tmids[topic], gs.p.idGen.ID(msg))
+		tmids[topic] = append(tmids[topic], mid)
 	}
 	for topic, mids := range tmids {
 		if len(mids) == 0 {
@@ -977,7 +996,20 @@ func (gs *GossipSubRouter) handleIHave(p peer.ID, ctl *pb.ControlMessage) []*pb.
 			if gs.p.seenMessage(mid) {
 				continue
 			}
+
+			allowedIWants, ok := gs.allowedIWantCount[mid]
+			if !ok {
+				allowedIWants = gs.params.MaxIWantsPerMessageIDPerHeartbeat
+			}
+
+			// Check if we've exceeded the maximum number of pending IWANTs for this message
+			if allowedIWants <= 0 {
+				gs.logger.Debug("IHAVE: ignoring IHAVE; too many inflight IWANTs", "message", mid, "peer", p)
+				continue
+			}
+
 			iwant[mid] = struct{}{}
+			gs.allowedIWantCount[mid] = allowedIWants - 1
 		}
 	}
 
@@ -1662,6 +1694,9 @@ func (gs *GossipSubRouter) heartbeat() {
 	toprune := make(map[peer.ID][]string)
 	noPX := make(map[peer.ID]bool)
 
+	// reset number of allowed IWANT requests
+	gs.resetAllowedIWants()
+
 	// clean up expired backoffs
 	gs.clearBackoff()
 
@@ -1911,6 +1946,13 @@ func (gs *GossipSubRouter) heartbeat() {
 	gs.mcache.Shift()
 
 	gs.extensions.Heartbeat()
+}
+
+func (gs *GossipSubRouter) resetAllowedIWants() {
+	if len(gs.allowedIWantCount) > 0 {
+		// throw away the old map and make a new one
+		gs.allowedIWantCount = make(map[string]int)
+	}
 }
 
 func (gs *GossipSubRouter) clearIHaveCounters() {

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -6291,3 +6291,85 @@ func TestIWantDispatchGrace(t *testing.T) {
 		t.Fatal("with zero grace the first IHAVE should dispatch immediately")
 	}
 }
+
+func TestResponseQuantileTracks(t *testing.T) {
+	// Constant-gain tracker: it should settle near a regime and then follow a
+	// drift upward, not converge to a fixed point.
+	rq := &responseQuantile{}
+	for i := 0; i < 400; i++ {
+		rq.observe(50*time.Millisecond, 0.8)
+	}
+	low := rq.est
+	if low < 30*time.Millisecond || low > 80*time.Millisecond {
+		t.Fatalf("estimate did not settle near the low regime: %v", low)
+	}
+	for i := 0; i < 400; i++ {
+		rq.observe(500*time.Millisecond, 0.8)
+	}
+	if rq.est <= low*3 {
+		t.Fatalf("estimate did not track the upward drift: %v (was %v)", rq.est, low)
+	}
+}
+
+func TestIWantHorizonFallback(t *testing.T) {
+	gs := &GossipSubRouter{params: DefaultGossipSubParams()}
+
+	// Off: always the fixed follow-up time.
+	if got := gs.iwantHorizon(peer.ID("a")); got != gs.params.IWantFollowupTime {
+		t.Fatalf("horizon with adaptive off = %v, want %v", got, gs.params.IWantFollowupTime)
+	}
+
+	gs.params.IWantAdaptiveHorizon = true
+	gs.params.IWantHorizonFloor = 200 * time.Millisecond
+	gs.params.IWantHorizonCeil = 2 * time.Second
+
+	// Cold: no global, no peer -> follow-up time clamped to the ceiling.
+	if got := gs.iwantHorizon(peer.ID("cold")); got != gs.params.IWantHorizonCeil {
+		t.Fatalf("cold horizon = %v, want ceil %v", got, gs.params.IWantHorizonCeil)
+	}
+
+	// Global warm; a peer below the sample threshold uses the global estimate.
+	gs.rttGlobal = &responseQuantile{est: 800 * time.Millisecond, n: 50}
+	gs.rttPeer = map[peer.ID]*responseQuantile{
+		"few": {est: 1500 * time.Millisecond, n: iwantMinSamples - 1},
+	}
+	if got := gs.iwantHorizon("few"); got != 800*time.Millisecond {
+		t.Fatalf("below-threshold peer horizon = %v, want global 800ms", got)
+	}
+	// At the threshold the peer's own estimate wins.
+	gs.rttPeer["enough"] = &responseQuantile{est: 1500 * time.Millisecond, n: iwantMinSamples}
+	if got := gs.iwantHorizon("enough"); got != 1500*time.Millisecond {
+		t.Fatalf("at-threshold peer horizon = %v, want its own 1500ms", got)
+	}
+	// Clamp: a very fast peer is floored.
+	gs.rttPeer["fast"] = &responseQuantile{est: 10 * time.Millisecond, n: iwantMinSamples}
+	if got := gs.iwantHorizon("fast"); got != gs.params.IWantHorizonFloor {
+		t.Fatalf("fast peer horizon = %v, want floor %v", got, gs.params.IWantHorizonFloor)
+	}
+}
+
+func TestIWantHorizonSnapshot(t *testing.T) {
+	gs := &GossipSubRouter{
+		params:            DefaultGossipSubParams(),
+		outstandingIWants: make(map[string]*iwantState),
+	}
+	gs.params.IWantAdaptiveHorizon = true
+	gs.params.IWantHorizonFloor = 100 * time.Millisecond
+	gs.params.IWantHorizonCeil = 5 * time.Second
+	gs.rttGlobal = &responseQuantile{est: time.Second, n: 50}
+
+	now := time.Now()
+	mid, p := "m", peer.ID("a")
+	gs.recordIWant(mid, p, now)
+	want := gs.outstandingIWants[mid].askedAt[p].expiresAt
+
+	// Snapshotted from the horizon at record time (~1s from now).
+	if d := want.Sub(now); d < 900*time.Millisecond || d > 1100*time.Millisecond {
+		t.Fatalf("snapshot horizon = %v, want ~1s", d)
+	}
+	// Changing the estimate afterwards must not move an ask already in flight.
+	gs.rttGlobal.est = 5 * time.Second
+	if got := gs.outstandingIWants[mid].askedAt[p].expiresAt; !got.Equal(want) {
+		t.Fatalf("recorded ask expiry moved: got %v want %v", got, want)
+	}
+}

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -6169,3 +6169,75 @@ func TestGossipsubLimitIWANT(t *testing.T) {
 		t.Fatal("Expected exactly 1 IWANT due to limits")
 	}
 }
+
+func TestIWantPerPeerLimit(t *testing.T) {
+	gs := &GossipSubRouter{
+		params:            DefaultGossipSubParams(),
+		outstandingIWants: make(map[string]iwantLedger),
+	}
+	gs.params.MaxIWantsPerMessageID = 2
+	gs.params.IWantFollowupTime = time.Second
+
+	base := time.Now()
+	mid := "m"
+	p1, p2, p3 := peer.ID("a"), peer.ID("b"), peer.ID("c")
+
+	// Two distinct peers admitted and recorded, at different times.
+	if !gs.canRequestIWant(mid, p1, base) {
+		t.Fatal("p1 should be admitted")
+	}
+	gs.recordIWant(mid, p1, base)
+	half := base.Add(500 * time.Millisecond)
+	if !gs.canRequestIWant(mid, p2, half) {
+		t.Fatal("p2 should be admitted")
+	}
+	gs.recordIWant(mid, p2, half)
+
+	// A third distinct peer is over the limit.
+	if gs.canRequestIWant(mid, p3, half) {
+		t.Fatal("p3 should be refused at the limit")
+	}
+	// A peer with a live ask is not asked again.
+	if gs.canRequestIWant(mid, p1, half) {
+		t.Fatal("p1 should not be re-asked while its ask is live")
+	}
+
+	// At base+followup, p1's ask has expired but p2's (sent later) has not, so
+	// exactly one slot frees: p3 is admitted, and re-asking p1 is now allowed
+	// but p2 is still blocked as live.
+	after := base.Add(gs.params.IWantFollowupTime + time.Millisecond)
+	if !gs.canRequestIWant(mid, p3, after) {
+		t.Fatal("p3 should be admitted once p1's expired ask frees a slot")
+	}
+	gs.recordIWant(mid, p3, after)
+	if _, ok := gs.outstandingIWants[mid][p2]; !ok {
+		t.Fatal("p2's later ask should still be live, not expired")
+	}
+	if gs.canRequestIWant(mid, p2, after) {
+		t.Fatal("p2 should still be blocked as live while p3 holds the other slot")
+	}
+}
+
+func TestIWantNoPhantomOnTruncation(t *testing.T) {
+	// canRequestIWant must not record; only recordIWant does. A candidate that
+	// passes the check but is dropped by truncation must leave no ledger entry.
+	gs := &GossipSubRouter{
+		params:            DefaultGossipSubParams(),
+		outstandingIWants: make(map[string]iwantLedger),
+	}
+	gs.params.MaxIWantsPerMessageID = 1
+	now := time.Now()
+	mid, p := "m", peer.ID("a")
+
+	if !gs.canRequestIWant(mid, p, now) {
+		t.Fatal("first check should pass")
+	}
+	// Not selected (truncated away): no recordIWant call.
+	if _, ok := gs.outstandingIWants[mid]; ok {
+		t.Fatal("a checked-but-unsent request must not appear in the ledger")
+	}
+	// A different peer can still be asked, since nothing was recorded.
+	if !gs.canRequestIWant(mid, peer.ID("b"), now) {
+		t.Fatal("another peer should still be admissible after an unrecorded check")
+	}
+}

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -6085,10 +6085,12 @@ func TestGossipsubLimitIWANT(t *testing.T) {
 	psubs := make([]*PubSub, 3)
 
 	defaultParams := DefaultGossipSubParams()
-	defaultParams.MaxIWantsPerMessageIDPerHeartbeat = 1
-	// Delay the heartbeat so we don't reset our count of allowed IWANTS for the
-	// first part of the test.
-	defaultParams.HeartbeatInitialDelay = 4 * time.Second
+	defaultParams.MaxIWantsPerMessageID = 1
+	// The budget refills IWantFollowupTime after the last request.
+	defaultParams.IWantFollowupTime = 2 * time.Second
+	// Push the heartbeat far out to show the refill is window-driven, not
+	// heartbeat-driven.
+	defaultParams.HeartbeatInitialDelay = 10 * time.Second
 	defaultParams.HeartbeatInterval = time.Second
 
 	psubs[0] = getGossipsub(ctx, hosts[0], WithGossipSubParams(defaultParams))
@@ -6156,7 +6158,8 @@ func TestGossipsubLimitIWANT(t *testing.T) {
 		t.Fatal("Expected exactly 1 IWANT due to limits")
 	}
 
-	// Wait for heartbeat to reset limit
+	// Wait for the follow-up window to expire and refill the budget; no
+	// heartbeat fires within this test.
 	time.Sleep(2 * time.Second)
 
 	publishIWant()

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -6173,7 +6173,7 @@ func TestGossipsubLimitIWANT(t *testing.T) {
 func TestIWantPerPeerLimit(t *testing.T) {
 	gs := &GossipSubRouter{
 		params:            DefaultGossipSubParams(),
-		outstandingIWants: make(map[string]iwantLedger),
+		outstandingIWants: make(map[string]*iwantState),
 	}
 	gs.params.MaxIWantsPerMessageID = 2
 	gs.params.IWantFollowupTime = time.Second
@@ -6210,7 +6210,7 @@ func TestIWantPerPeerLimit(t *testing.T) {
 		t.Fatal("p3 should be admitted once p1's expired ask frees a slot")
 	}
 	gs.recordIWant(mid, p3, after)
-	if _, ok := gs.outstandingIWants[mid][p2]; !ok {
+	if _, ok := gs.outstandingIWants[mid].askedAt[p2]; !ok {
 		t.Fatal("p2's later ask should still be live, not expired")
 	}
 	if gs.canRequestIWant(mid, p2, after) {
@@ -6219,11 +6219,12 @@ func TestIWantPerPeerLimit(t *testing.T) {
 }
 
 func TestIWantNoPhantomOnTruncation(t *testing.T) {
-	// canRequestIWant must not record; only recordIWant does. A candidate that
-	// passes the check but is dropped by truncation must leave no ledger entry.
+	// canRequestIWant must not record an ask; only recordIWant does. A candidate
+	// that passes the check but is dropped by truncation must leave no phantom
+	// ask (it may leave grace-tracking state, but with no recorded peer).
 	gs := &GossipSubRouter{
 		params:            DefaultGossipSubParams(),
-		outstandingIWants: make(map[string]iwantLedger),
+		outstandingIWants: make(map[string]*iwantState),
 	}
 	gs.params.MaxIWantsPerMessageID = 1
 	now := time.Now()
@@ -6232,12 +6233,61 @@ func TestIWantNoPhantomOnTruncation(t *testing.T) {
 	if !gs.canRequestIWant(mid, p, now) {
 		t.Fatal("first check should pass")
 	}
-	// Not selected (truncated away): no recordIWant call.
-	if _, ok := gs.outstandingIWants[mid]; ok {
-		t.Fatal("a checked-but-unsent request must not appear in the ledger")
+	// Not selected (truncated away): no recordIWant call, so no ask recorded.
+	if st := gs.outstandingIWants[mid]; st != nil && len(st.askedAt) != 0 {
+		t.Fatal("a checked-but-unsent request must not record a phantom ask")
 	}
 	// A different peer can still be asked, since nothing was recorded.
 	if !gs.canRequestIWant(mid, peer.ID("b"), now) {
 		t.Fatal("another peer should still be admissible after an unrecorded check")
+	}
+}
+
+func TestIWantDispatchGrace(t *testing.T) {
+	newRouter := func(grace time.Duration) *GossipSubRouter {
+		gs := &GossipSubRouter{
+			params:            DefaultGossipSubParams(),
+			outstandingIWants: make(map[string]*iwantState),
+		}
+		gs.params.IWantDispatchGrace = grace
+		gs.params.IWantFollowupTime = time.Second
+		return gs
+	}
+	mid, p := "m", peer.ID("a")
+
+	// The first IHAVE within the grace window is held; a later one dispatches.
+	gs := newRouter(100 * time.Millisecond)
+	base := time.Now()
+	if gs.canRequestIWant(mid, p, base) {
+		t.Fatal("first IHAVE within grace should be held")
+	}
+	if gs.canRequestIWant(mid, p, base.Add(50*time.Millisecond)) {
+		t.Fatal("still within grace, should be held")
+	}
+	if !gs.canRequestIWant(mid, p, base.Add(150*time.Millisecond)) {
+		t.Fatal("after grace the deferred request should dispatch")
+	}
+
+	// Pruning must not drop or reset a freshly-graced, un-asked state, else
+	// grace would restart every heartbeat and never complete.
+	gs = newRouter(100 * time.Millisecond)
+	gs.canRequestIWant(mid, p, time.Now())
+	first := gs.outstandingIWants[mid].firstIHaveAt
+	gs.pruneOutstandingIWants()
+	st, ok := gs.outstandingIWants[mid]
+	if !ok || !st.firstIHaveAt.Equal(first) {
+		t.Fatal("prune must not drop or reset a state still within its window")
+	}
+	// Once stale (older than the follow-up time) with no live ask, prune drops it.
+	st.firstIHaveAt = time.Now().Add(-2 * time.Second)
+	gs.pruneOutstandingIWants()
+	if _, ok := gs.outstandingIWants[mid]; ok {
+		t.Fatal("prune should drop a stale, un-asked state")
+	}
+
+	// With zero grace the first IHAVE dispatches immediately.
+	gs = newRouter(0)
+	if !gs.canRequestIWant(mid, p, time.Now()) {
+		t.Fatal("with zero grace the first IHAVE should dispatch immediately")
 	}
 }

--- a/gossipsub_test.go
+++ b/gossipsub_test.go
@@ -6075,3 +6075,94 @@ func TestGossipsubDuplicatePublishDeliveredOnce(t *testing.T) {
 		}
 	})
 }
+
+func TestGossipsubLimitIWANT(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hosts := getDefaultHosts(t, 3)
+	denseConnect(t, hosts)
+
+	psubs := make([]*PubSub, 3)
+
+	defaultParams := DefaultGossipSubParams()
+	defaultParams.MaxIWantsPerMessageIDPerHeartbeat = 1
+	// Delay the heartbeat so we don't reset our count of allowed IWANTS for the
+	// first part of the test.
+	defaultParams.HeartbeatInitialDelay = 4 * time.Second
+	defaultParams.HeartbeatInterval = time.Second
+
+	psubs[0] = getGossipsub(ctx, hosts[0], WithGossipSubParams(defaultParams))
+
+	var iwantsRecvd atomic.Int32
+
+	copy(psubs[1:], getGossipsubs(ctx, hosts[1:], WithRawTracer(&mockRawTracer{
+		onRecvRPC: func(rpc *RPC) {
+			if len(rpc.GetControl().GetIwant()) > 0 {
+				iwantsRecvd.Add(1)
+			}
+		},
+	})))
+
+	topicString := "foobar"
+	for _, ps := range psubs {
+		topic, err := ps.Join(topicString)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = topic.Subscribe()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(2 * time.Second)
+
+	publishIWant := func() {
+		psubs[1].eval <- func() {
+			psubs[1].rt.(*GossipSubRouter).sendRPC(hosts[0].ID(), &RPC{
+				RPC: pb.RPC{
+					Control: &pb.ControlMessage{
+						Ihave: []*pb.ControlIHave{
+							{
+								TopicID:    &topicString,
+								MessageIDs: []string{"1"},
+							},
+						},
+					},
+				},
+			}, false)
+		}
+
+		psubs[2].eval <- func() {
+			psubs[2].rt.(*GossipSubRouter).sendRPC(hosts[0].ID(), &RPC{
+				RPC: pb.RPC{
+					Control: &pb.ControlMessage{
+						Ihave: []*pb.ControlIHave{
+							{
+								TopicID:    &topicString,
+								MessageIDs: []string{"1"},
+							},
+						},
+					},
+				},
+			}, false)
+		}
+	}
+
+	publishIWant()
+	time.Sleep(time.Second)
+
+	if iwantsRecvd.Swap(0) != 1 {
+		t.Fatal("Expected exactly 1 IWANT due to limits")
+	}
+
+	// Wait for heartbeat to reset limit
+	time.Sleep(2 * time.Second)
+
+	publishIWant()
+	time.Sleep(time.Second)
+
+	if iwantsRecvd.Swap(0) != 1 {
+		t.Fatal("Expected exactly 1 IWANT due to limits")
+	}
+}


### PR DESCRIPTION
This PR improves IWANT handling, building on top of #625 and #730
It introduces a few novelties, making the policy more configurable and improving performance.
- a grace period is introduced after the reception of the first IHAVE. This could be useful depending on push-vs-announce configuration and use-case(low-latency vs. bandwidth optimized. Defaults to 0, making this a NOP if not configured. 
- adds a time estimate for the wait to comletion of the IWANT instead of the fixed wait before new attempts.

The implementation is still in draft, waiting to be validated. Sharing here for information while working on the final form.